### PR TITLE
ruby binding: add method Vector.raw_memcpy

### DIFF
--- a/bindings/ruby/ext/specialized_types.cc
+++ b/bindings/ruby/ext/specialized_types.cc
@@ -617,6 +617,16 @@ static VALUE vector_contained_memory_id(VALUE self)
 static VALUE vector_raw_memcpy(VALUE self,VALUE _source,VALUE _size)
 {
     Value container_v = rb2cxx::object<Value>(self);
+    bool is_memcpy = false;
+    try
+    {
+        MemoryLayout ops = Typelib::layout_of(container_v.getType());
+        is_memcpy = (ops.size() == 2 && ops[0] == MemLayout::FLAG_MEMCPY);
+    }
+    catch(std::runtime_error) {/* No layout for this type.*/}
+    if(!is_memcpy)
+        rb_raise(rb_eTypeError, "memcpy is not supported for this type");
+
     std::vector<uint8_t> *vector = reinterpret_cast<std::vector<uint8_t>*>(container_v.getData());
     size_t size = NUM2UINT(_size);
     const void *source = reinterpret_cast<const void*>(NUM2ULL(_source));


### PR DESCRIPTION
This method allows to set vector values from ruby via FFI
pt = FFI::Pointer.new
vector.raw_memcpy(pt.address,size)

Example in the context of rock-robotics:
conversion from cv::Mat to frame::Frame
frame.image.raw_memcpy(mat.data.address,mat.total*self.pixel_size)
