### PR TITLE
clang-format-3.5 -style={BasedOnStyle: llvm, IndentWidth: 4, Standard: Cpp03}

### DIFF
--- a/Makefile.clang-format
+++ b/Makefile.clang-format
@@ -1,0 +1,10 @@
+
+FILES=$(shell git ls-files "*.hpp" "*.cpp" "*.cxx" "*.hxx" "*.cc" "*.hh" "*.c" "*.h")
+
+STYLE="{BasedOnStyle: llvm, IndentWidth: 4, Standard: Cpp03}"
+
+format-all: $(addsuffix -convert,$(FILES)) $(addsuffix -convert,$(FILES))
+
+%-convert: %
+	clang-format-3.5 -style=$(STYLE) -i $<
+

--- a/bindings/ruby/ext/convert.cc
+++ b/bindings/ruby/ext/convert.cc
@@ -13,120 +13,173 @@ using namespace typelib_ruby;
  * and returns the VALUE object which corresponds to
  * the field, or returns nil
  */
-bool RubyGetter::visit_ (int8_t  & value) { m_value = INT2FIX(value); return false; }
-bool RubyGetter::visit_ (uint8_t & value) { m_value = INT2FIX(value); return false; }
-bool RubyGetter::visit_ (int16_t & value) { m_value = INT2FIX(value); return false; }
-bool RubyGetter::visit_ (uint16_t& value) { m_value = INT2FIX(value); return false; }
-bool RubyGetter::visit_ (int32_t & value) { m_value = INT2NUM(value); return false; }
-bool RubyGetter::visit_ (uint32_t& value) { m_value = INT2NUM(value); return false; }
-bool RubyGetter::visit_ (int64_t & value) { m_value = LL2NUM(value);  return false; }
-bool RubyGetter::visit_ (uint64_t& value) { m_value = ULL2NUM(value); return false; }
-bool RubyGetter::visit_ (float   & value) { m_value = rb_float_new(value); return false; }
-bool RubyGetter::visit_ (double  & value) { m_value = rb_float_new(value); return false; }
+bool RubyGetter::visit_(int8_t &value) {
+    m_value = INT2FIX(value);
+    return false;
+}
+bool RubyGetter::visit_(uint8_t &value) {
+    m_value = INT2FIX(value);
+    return false;
+}
+bool RubyGetter::visit_(int16_t &value) {
+    m_value = INT2FIX(value);
+    return false;
+}
+bool RubyGetter::visit_(uint16_t &value) {
+    m_value = INT2FIX(value);
+    return false;
+}
+bool RubyGetter::visit_(int32_t &value) {
+    m_value = INT2NUM(value);
+    return false;
+}
+bool RubyGetter::visit_(uint32_t &value) {
+    m_value = INT2NUM(value);
+    return false;
+}
+bool RubyGetter::visit_(int64_t &value) {
+    m_value = LL2NUM(value);
+    return false;
+}
+bool RubyGetter::visit_(uint64_t &value) {
+    m_value = ULL2NUM(value);
+    return false;
+}
+bool RubyGetter::visit_(float &value) {
+    m_value = rb_float_new(value);
+    return false;
+}
+bool RubyGetter::visit_(double &value) {
+    m_value = rb_float_new(value);
+    return false;
+}
 
-bool RubyGetter::visit_(Value const& v, Pointer const& p)
-{
-#   ifdef VERBOSE
-    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(pointer)\n", v.getData());
-#   endif
+bool RubyGetter::visit_(Value const &v, Pointer const &p) {
+#ifdef VERBOSE
+    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(pointer)\n",
+            v.getData());
+#endif
     m_value = cxx2rb::value_wrap(v, m_registry, m_parent);
     return false;
 }
-bool RubyGetter::visit_(Value const& v, Array const& a) 
-{
-#   ifdef VERBOSE
-    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(array)\n", v.getData());
-#   endif
+bool RubyGetter::visit_(Value const &v, Array const &a) {
+#ifdef VERBOSE
+    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(array)\n",
+            v.getData());
+#endif
     m_value = cxx2rb::value_wrap(v, m_registry, m_parent);
     return false;
 }
-bool RubyGetter::visit_(Value const& v, Compound const& c)
-{ 
-#   ifdef VERBOSE
-    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(compound)\n", v.getData());
-#   endif
+bool RubyGetter::visit_(Value const &v, Compound const &c) {
+#ifdef VERBOSE
+    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(compound)\n",
+            v.getData());
+#endif
     m_value = cxx2rb::value_wrap(v, m_registry, m_parent);
-    return false; 
+    return false;
 }
-bool RubyGetter::visit_(Value const& v, OpaqueType const& c)
-{ 
-#   ifdef VERBOSE
-    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(opaque)\n", v.getData());
-#   endif
+bool RubyGetter::visit_(Value const &v, OpaqueType const &c) {
+#ifdef VERBOSE
+    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(opaque)\n",
+            v.getData());
+#endif
     m_value = cxx2rb::value_wrap(v, m_registry, m_parent);
-    return false; 
+    return false;
 }
-bool RubyGetter::visit_(Value const& v, Container const& c)
-{ 
-#   ifdef VERBOSE
-    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(container)\n", v.getData());
-#   endif
+bool RubyGetter::visit_(Value const &v, Container const &c) {
+#ifdef VERBOSE
+    fprintf(stderr, "%p: wrapping from RubyGetter::visit_(container)\n",
+            v.getData());
+#endif
     m_value = cxx2rb::value_wrap(v, m_registry, m_parent);
-    return false; 
+    return false;
 }
-bool RubyGetter::visit_(Enum::integral_type& v, Enum const& e)   
-{ 
+bool RubyGetter::visit_(Enum::integral_type &v, Enum const &e) {
     m_value = cxx2rb::enum_symbol(v, e);
     return false;
 }
-    
-RubyGetter::RubyGetter() : ValueVisitor(false) {}
-RubyGetter::~RubyGetter() { m_value = Qnil; m_registry = Qnil; }
 
-VALUE RubyGetter::apply(Typelib::Value value, VALUE registry, VALUE parent)
-{
+RubyGetter::RubyGetter() : ValueVisitor(false) {}
+RubyGetter::~RubyGetter() {
+    m_value = Qnil;
+    m_registry = Qnil;
+}
+
+VALUE RubyGetter::apply(Typelib::Value value, VALUE registry, VALUE parent) {
     m_registry = registry;
-    m_value    = Qnil;
-    m_parent   = parent;
+    m_value = Qnil;
+    m_parent = parent;
 
     ValueVisitor::apply(value);
     return m_value;
 }
 
-bool RubySetter::visit_ (int8_t  & value) { value = NUM2INT(m_value); return false; }
-bool RubySetter::visit_ (uint8_t & value) { value = NUM2INT(m_value); return false; }
-bool RubySetter::visit_ (int16_t & value) { value = NUM2INT(m_value); return false; }
-bool RubySetter::visit_ (uint16_t& value) { value = NUM2UINT(m_value); return false; }
-bool RubySetter::visit_ (int32_t & value) { value = NUM2INT(m_value); return false; }
-bool RubySetter::visit_ (uint32_t& value) { value = NUM2UINT(m_value); return false; }
-bool RubySetter::visit_ (int64_t & value) { value = NUM2LL(m_value);  return false; }
-bool RubySetter::visit_ (uint64_t& value) { value = NUM2LL(m_value); return false; }
-bool RubySetter::visit_ (float   & value) { value = NUM2DBL(m_value); return false; }
-bool RubySetter::visit_ (double  & value) { value = NUM2DBL(m_value); return false; }
+bool RubySetter::visit_(int8_t &value) {
+    value = NUM2INT(m_value);
+    return false;
+}
+bool RubySetter::visit_(uint8_t &value) {
+    value = NUM2INT(m_value);
+    return false;
+}
+bool RubySetter::visit_(int16_t &value) {
+    value = NUM2INT(m_value);
+    return false;
+}
+bool RubySetter::visit_(uint16_t &value) {
+    value = NUM2UINT(m_value);
+    return false;
+}
+bool RubySetter::visit_(int32_t &value) {
+    value = NUM2INT(m_value);
+    return false;
+}
+bool RubySetter::visit_(uint32_t &value) {
+    value = NUM2UINT(m_value);
+    return false;
+}
+bool RubySetter::visit_(int64_t &value) {
+    value = NUM2LL(m_value);
+    return false;
+}
+bool RubySetter::visit_(uint64_t &value) {
+    value = NUM2LL(m_value);
+    return false;
+}
+bool RubySetter::visit_(float &value) {
+    value = NUM2DBL(m_value);
+    return false;
+}
+bool RubySetter::visit_(double &value) {
+    value = NUM2DBL(m_value);
+    return false;
+}
 
-bool RubySetter::visit_(Value const& v, Array const& a)
-{ 
-    if (a.getIndirection().getName() == "/char")
-    {
-        char*  value = StringValuePtr(m_value);
+bool RubySetter::visit_(Value const &v, Array const &a) {
+    if (a.getIndirection().getName() == "/char") {
+        char *value = StringValuePtr(m_value);
         size_t length = strlen(value);
-        if (length < a.getDimension())
-        {
+        if (length < a.getDimension()) {
             memcpy(v.getData(), value, length + 1);
             return false;
         }
-        throw UnsupportedType(v.getType(), "string too long"); 
+        throw UnsupportedType(v.getType(), "string too long");
     }
-    throw UnsupportedType(v.getType(), "not a string"); 
+    throw UnsupportedType(v.getType(), "not a string");
 }
-bool RubySetter::visit_(Value const& v, Pointer const& c)
-{ 
-    throw UnsupportedType(v.getType(), "no conversion to pointers"); 
+bool RubySetter::visit_(Value const &v, Pointer const &c) {
+    throw UnsupportedType(v.getType(), "no conversion to pointers");
 }
-bool RubySetter::visit_(Value const& v, Compound const& c)
-{ 
-    throw UnsupportedType(v.getType(), "no conversion to compound"); 
+bool RubySetter::visit_(Value const &v, Compound const &c) {
+    throw UnsupportedType(v.getType(), "no conversion to compound");
 }
-bool RubySetter::visit_(Value const& v, OpaqueType const& c)
-{ 
-    throw UnsupportedType(v.getType(), "no conversion to opaque types"); 
+bool RubySetter::visit_(Value const &v, OpaqueType const &c) {
+    throw UnsupportedType(v.getType(), "no conversion to opaque types");
 }
-bool RubySetter::visit_(Value const& v, Container const& c)
-{ 
-    throw UnsupportedType(v.getType(), "no conversion to containers"); 
+bool RubySetter::visit_(Value const &v, Container const &c) {
+    throw UnsupportedType(v.getType(), "no conversion to containers");
 }
-bool RubySetter::visit_(Enum::integral_type& v, Enum const& e)
-{ 
+bool RubySetter::visit_(Enum::integral_type &v, Enum const &e) {
     v = rb2cxx::enum_value(m_value, e);
     return false;
 }
@@ -134,10 +187,9 @@ bool RubySetter::visit_(Enum::integral_type& v, Enum const& e)
 RubySetter::RubySetter() : ValueVisitor(false) {}
 RubySetter::~RubySetter() { m_value = Qnil; }
 
-VALUE RubySetter::apply(Value value, VALUE new_value)
-{
+VALUE RubySetter::apply(Value value, VALUE new_value) {
     m_value = new_value;
-    ValueVisitor::apply(value); 
+    ValueVisitor::apply(value);
     return new_value;
 }
 
@@ -146,9 +198,8 @@ VALUE RubySetter::apply(Value value, VALUE new_value)
  */
 
 /* Converts a Typelib::Value to Ruby's VALUE */
-VALUE typelib_to_ruby(Value v, VALUE registry, VALUE parent)
-{ 
-    if (! v.getData())
+VALUE typelib_to_ruby(Value v, VALUE registry, VALUE parent) {
+    if (!v.getData())
         return Qnil;
 
     RubyGetter getter;
@@ -156,27 +207,24 @@ VALUE typelib_to_ruby(Value v, VALUE registry, VALUE parent)
 }
 
 /* Returns the Value object wrapped into +value+ */
-Value typelib_get(VALUE value)
-{
-    void* object = 0;
+Value typelib_get(VALUE value) {
+    void *object = 0;
     Data_Get_Struct(value, void, object);
-    return *reinterpret_cast<Value*>(object);
+    return *reinterpret_cast<Value *>(object);
 }
 
 /* Tries to initialize +value+ to +new_value+ using the type in +value+ */
-VALUE typelib_from_ruby(Value dst, VALUE new_value)
-{
+VALUE typelib_from_ruby(Value dst, VALUE new_value) {
     // Special case: new_value is actually a Typelib wrapper of the right type
-    if (rb_obj_is_kind_of(new_value, cType))
-    {
-        Value& src = rb2cxx::object<Value>(new_value);
-        Type const& dst_t = dst.getType();
-        Type const& src_t = src.getType();
+    if (rb_obj_is_kind_of(new_value, cType)) {
+        Value &src = rb2cxx::object<Value>(new_value);
+        Type const &dst_t = dst.getType();
+        Type const &src_t = src.getType();
         if (dst_t == src_t)
             Typelib::copy(dst, src);
-        else
-        {
-            rb_raise(rb_eArgError, "wrong type in assignment: %s = %s", dst_t.getName().c_str(), src_t.getName().c_str());
+        else {
+            rb_raise(rb_eArgError, "wrong type in assignment: %s = %s",
+                     dst_t.getName().c_str(), src_t.getName().c_str());
         }
         return new_value;
     }
@@ -186,15 +234,15 @@ VALUE typelib_from_ruby(Value dst, VALUE new_value)
     try {
         RubySetter setter;
         return setter.apply(dst, new_value);
-    } catch(UnsupportedType e) { 
-	// Avoid calling rb_raise in exception context
-	type_name = e.type.getName(); 
-	reason    = e.reason;
+    } catch (UnsupportedType e) {
+        // Avoid calling rb_raise in exception context
+        type_name = e.type.getName();
+        reason = e.reason;
     }
 
     if (reason.length() == 0)
-	rb_raise(rb_eTypeError, "cannot convert to '%s'", type_name.c_str());
+        rb_raise(rb_eTypeError, "cannot convert to '%s'", type_name.c_str());
     else
-	rb_raise(rb_eTypeError, "cannot convert to '%s' (%s)", type_name.c_str(), reason.c_str());
+        rb_raise(rb_eTypeError, "cannot convert to '%s' (%s)",
+                 type_name.c_str(), reason.c_str());
 }
-

--- a/bindings/ruby/ext/functions.cc
+++ b/bindings/ruby/ext/functions.cc
@@ -11,12 +11,10 @@ static VALUE cFunction;
 using namespace Typelib;
 using namespace typelib_ruby;
 
-static VALUE
-library_wrap(VALUE self, VALUE name, VALUE auto_unload)
-{
-    void* libhandle = dlLoadLibrary(StringValuePtr(name));
+static VALUE library_wrap(VALUE self, VALUE name, VALUE auto_unload) {
+    void *libhandle = dlLoadLibrary(StringValuePtr(name));
     if (!libhandle)
-	rb_raise(rb_eArgError, "cannot load library %s", StringValuePtr(name));
+        rb_raise(rb_eArgError, "cannot load library %s", StringValuePtr(name));
 
     if (RTEST(auto_unload))
         return Data_Wrap_Struct(cLibrary, 0, dlFreeLibrary, libhandle);
@@ -31,19 +29,16 @@ library_wrap(VALUE self, VALUE name, VALUE auto_unload)
  * the corresponding Function object. If the symbol is not available in
  * the library, raises ArgumentError.
  */
-static VALUE
-library_find(VALUE self, VALUE name)
-{
-    //void* libhandle;
-    DLLib* libhandle; 
+static VALUE library_find(VALUE self, VALUE name) {
+    // void* libhandle;
+    DLLib *libhandle;
     Data_Get_Struct(self, DLLib, libhandle);
 
-    void* symhandle = dlFindSymbol(libhandle, StringValuePtr(name));
-    if (!symhandle)
-    {
-	VALUE libname = rb_iv_get(self, "@name");
-	rb_raise(rb_eArgError, "cannot find symbol '%s' in library '%s'",
-		StringValuePtr(name), StringValuePtr(libname));
+    void *symhandle = dlFindSymbol(libhandle, StringValuePtr(name));
+    if (!symhandle) {
+        VALUE libname = rb_iv_get(self, "@name");
+        rb_raise(rb_eArgError, "cannot find symbol '%s' in library '%s'",
+                 StringValuePtr(name), StringValuePtr(libname));
     }
 
     VALUE function = Data_Wrap_Struct(cFunction, 0, 0, symhandle);
@@ -51,190 +46,187 @@ library_find(VALUE self, VALUE name)
     return function;
 }
 
-class PrepareVM : public TypeVisitor
-{
-    DCCallVM* m_vm;
+class PrepareVM : public TypeVisitor {
+    DCCallVM *m_vm;
     VALUE m_data;
 
-    virtual bool visit_ (Numeric const& type)
-    {
-        if (type.getNumericCategory() == Numeric::Float)
-	{
-	    double value = NUM2DBL(m_data);
-            switch(type.getSize())
-            {
-                case 4: dcArgFloat(m_vm,  static_cast<float>(value)); break;
-                case 8: dcArgDouble(m_vm, static_cast<double>(value)); break;
+    virtual bool visit_(Numeric const &type) {
+        if (type.getNumericCategory() == Numeric::Float) {
+            double value = NUM2DBL(m_data);
+            switch (type.getSize()) {
+            case 4:
+                dcArgFloat(m_vm, static_cast<float>(value));
+                break;
+            case 8:
+                dcArgDouble(m_vm, static_cast<double>(value));
+                break;
             }
-	}
-	else
-        {
-            switch(type.getSize())
-            {
-                case 1: dcArgChar    (m_vm, static_cast<char>(NUM2INT(m_data))); break;
-                case 2: dcArgShort   (m_vm, static_cast<short>(NUM2INT(m_data))); break;
-                case 4: dcArgInt	 (m_vm, NUM2INT(m_data)); break;
-                case 8: dcArgLongLong(m_vm, NUM2LL(m_data)); break;
+        } else {
+            switch (type.getSize()) {
+            case 1:
+                dcArgChar(m_vm, static_cast<char>(NUM2INT(m_data)));
+                break;
+            case 2:
+                dcArgShort(m_vm, static_cast<short>(NUM2INT(m_data)));
+                break;
+            case 4:
+                dcArgInt(m_vm, NUM2INT(m_data));
+                break;
+            case 8:
+                dcArgLongLong(m_vm, NUM2LL(m_data));
+                break;
             }
         }
         return false;
     }
-    virtual bool visit_ (Enum const& type)      
-    { 
-        BOOST_STATIC_ASSERT(( sizeof(Enum::integral_type) == sizeof(int) ));
+    virtual bool visit_(Enum const &type) {
+        BOOST_STATIC_ASSERT((sizeof(Enum::integral_type) == sizeof(int)));
         dcArgInt(m_vm, NUM2INT(m_data));
         return false;
     }
 
-    virtual bool visit_ (Pointer const& type)
-    {
+    virtual bool visit_(Pointer const &type) {
         dcArgPointer(m_vm, memory_cptr(m_data));
         return false;
     }
-    virtual bool visit_ (Array const& type)
-    { 
+    virtual bool visit_(Array const &type) {
         dcArgPointer(m_vm, memory_cptr(m_data));
-	return false;
+        return false;
     }
 
-    virtual bool visit_ (Compound const& type)
-    { throw UnsupportedType(type); }
+    virtual bool visit_(Compound const &type) { throw UnsupportedType(type); }
 
-public:
-    PrepareVM(DCCallVM* vm, VALUE data)
-	: m_vm(vm), m_data(data) {}
+  public:
+    PrepareVM(DCCallVM *vm, VALUE data) : m_vm(vm), m_data(data) {}
 
-    static void append(DCCallVM* vm, Type const& type, VALUE data)
-    {
-	PrepareVM visitor(vm, data);
-	visitor.apply(type);
+    static void append(DCCallVM *vm, Type const &type, VALUE data) {
+        PrepareVM visitor(vm, data);
+        visitor.apply(type);
     }
 };
 
-static VALUE
-function_compile(VALUE self, VALUE filtered_args)
-{
-    DCCallVM* vm = dcNewCallVM(4096);
-    VALUE rb_vm  = Data_Wrap_Struct(cCallVM, 0, dcFree, vm);
+static VALUE function_compile(VALUE self, VALUE filtered_args) {
+    DCCallVM *vm = dcNewCallVM(4096);
+    VALUE rb_vm = Data_Wrap_Struct(cCallVM, 0, dcFree, vm);
     rb_iv_set(rb_vm, "@arguments", filtered_args);
 
     VALUE argument_types = rb_iv_get(self, "@arguments");
     size_t argc = RARRAY_LEN(argument_types);
-    VALUE* argv = RARRAY_PTR(argument_types);
+    VALUE *argv = RARRAY_PTR(argument_types);
 
     for (size_t i = 0; i < argc; ++i)
-	PrepareVM::append(vm, rb2cxx::object<Type>(argv[i]), RARRAY_PTR(filtered_args)[i]);
+        PrepareVM::append(vm, rb2cxx::object<Type>(argv[i]),
+                          RARRAY_PTR(filtered_args)[i]);
 
     return rb_vm;
 }
 
-class VMCall : public TypeVisitor
-{
-    DCCallVM* m_vm;
-    void*     m_handle;
-    VALUE     m_return_type;
-    VALUE     m_return;
+class VMCall : public TypeVisitor {
+    DCCallVM *m_vm;
+    void *m_handle;
+    VALUE m_return_type;
+    VALUE m_return;
 
-    virtual bool visit_ (NullType const& type)
-    {
-	dcCallVoid(m_vm, m_handle);
-	return true;
+    virtual bool visit_(NullType const &type) {
+        dcCallVoid(m_vm, m_handle);
+        return true;
     }
 
-    virtual bool visit_ (Numeric const& type)
-    {
-        if (type.getNumericCategory() == Numeric::Float)
-	{
-            switch(type.getSize())
-            {
-                case 4: m_return = rb_float_new(dcCallFloat(m_vm,  m_handle)); break;
-                case 8: m_return = rb_float_new(dcCallDouble(m_vm, m_handle)); break;
+    virtual bool visit_(Numeric const &type) {
+        if (type.getNumericCategory() == Numeric::Float) {
+            switch (type.getSize()) {
+            case 4:
+                m_return = rb_float_new(dcCallFloat(m_vm, m_handle));
+                break;
+            case 8:
+                m_return = rb_float_new(dcCallDouble(m_vm, m_handle));
+                break;
             }
-	}
-	else
-        {
-            switch(type.getSize())
-            {
-                case 1: m_return = INT2NUM (dcCallChar    (m_vm, m_handle)); break;
-                case 2: m_return = INT2NUM (dcCallShort   (m_vm, m_handle)); break;
-                case 4: m_return = INT2NUM (dcCallInt	  (m_vm, m_handle)); break;
-                case 8: m_return = LL2NUM  (dcCallLongLong(m_vm, m_handle)); break;
+        } else {
+            switch (type.getSize()) {
+            case 1:
+                m_return = INT2NUM(dcCallChar(m_vm, m_handle));
+                break;
+            case 2:
+                m_return = INT2NUM(dcCallShort(m_vm, m_handle));
+                break;
+            case 4:
+                m_return = INT2NUM(dcCallInt(m_vm, m_handle));
+                break;
+            case 8:
+                m_return = LL2NUM(dcCallLongLong(m_vm, m_handle));
+                break;
             }
         }
         return false;
     }
-    virtual bool visit_ (Enum const& type)      
-    { 
-        BOOST_STATIC_ASSERT(( sizeof(Enum::integral_type) == sizeof(int) ));
+    virtual bool visit_(Enum const &type) {
+        BOOST_STATIC_ASSERT((sizeof(Enum::integral_type) == sizeof(int)));
         m_return = INT2NUM(dcCallInt(m_vm, m_handle));
         return false;
     }
 
-    virtual bool visit_ (Pointer const& type)
-    {
-#ifdef  VERBOSE
-        fprintf(stderr, "wrapping dcCallPointer with type=%s\n", type.getName().c_str());
+    virtual bool visit_(Pointer const &type) {
+#ifdef VERBOSE
+        fprintf(stderr, "wrapping dcCallPointer with type=%s\n",
+                type.getName().c_str());
 #endif
-	m_return = memory_wrap(new void*(dcCallPointer(m_vm, m_handle)), true, 0);
+        m_return =
+            memory_wrap(new void *(dcCallPointer(m_vm, m_handle)), true, 0);
         return false;
     }
-    virtual bool visit_ (Array const& type)
-    { 
-#ifdef  VERBOSE
-        fprintf(stderr, "wrapping dcCallPointer with type=%s\n", type.getName().c_str());
+    virtual bool visit_(Array const &type) {
+#ifdef VERBOSE
+        fprintf(stderr, "wrapping dcCallPointer with type=%s\n",
+                type.getName().c_str());
 #endif
-	m_return = memory_wrap(new void*(dcCallPointer(m_vm, m_handle)), true, 0);
-	return false;
+        m_return =
+            memory_wrap(new void *(dcCallPointer(m_vm, m_handle)), true, 0);
+        return false;
     }
 
-    virtual bool visit_ (Compound const& type)
-    { throw UnsupportedType(type); }
+    virtual bool visit_(Compound const &type) { throw UnsupportedType(type); }
 
-public:
-    VMCall(DCCallVM* vm, void* handle, VALUE return_type)
-	: m_vm(vm), m_handle(handle), m_return_type(return_type), 
-	m_return(Qnil) {}
+  public:
+    VMCall(DCCallVM *vm, void *handle, VALUE return_type)
+        : m_vm(vm), m_handle(handle), m_return_type(return_type),
+          m_return(Qnil) {}
 
     VALUE getReturnedValue() const { return m_return; }
 
-    static VALUE call(DCCallVM* vm, void* handle, VALUE return_type)
-    {
-	if (NIL_P(return_type))
-	{
-	    dcCallVoid(vm, handle);
-	    return Qnil;
-	}
+    static VALUE call(DCCallVM *vm, void *handle, VALUE return_type) {
+        if (NIL_P(return_type)) {
+            dcCallVoid(vm, handle);
+            return Qnil;
+        }
 
-	VMCall visitor(vm, handle, return_type);
-	visitor.apply(rb2cxx::object<Type>(return_type));
-	return visitor.getReturnedValue();
+        VMCall visitor(vm, handle, return_type);
+        visitor.apply(rb2cxx::object<Type>(return_type));
+        return visitor.getReturnedValue();
     }
 };
 
-static VALUE
-vm_call(VALUE self, VALUE function)
-{
-    DCCallVM* vm;
+static VALUE vm_call(VALUE self, VALUE function) {
+    DCCallVM *vm;
     Data_Get_Struct(self, DCCallVM, vm);
 
-    void* symhandle;
+    void *symhandle;
     Data_Get_Struct(function, void, symhandle);
 
     return VMCall::call(vm, symhandle, rb_iv_get(function, "@return_type"));
 }
 
-static
-VALUE filter_numeric_arg(VALUE self, VALUE arg, VALUE rb_expected_type)
-{
-    Type const& expected_type = rb2cxx::object<Type>(rb_expected_type);
+static VALUE filter_numeric_arg(VALUE self, VALUE arg, VALUE rb_expected_type) {
+    Type const &expected_type = rb2cxx::object<Type>(rb_expected_type);
 
     if (expected_type.getCategory() == Type::Enum)
-        return INT2FIX( rb2cxx::enum_value(arg, static_cast<Enum const&>(expected_type)) );
-    else if (expected_type.getCategory() == Type::Pointer)
-    {
-        // Build directly a DL::Ptr object, no need to build a Ruby Value wrapper
-        Pointer const& ptr_type  = static_cast<Pointer const&>(expected_type);
-        Type const& pointed_type = ptr_type.getIndirection();
+        return INT2FIX(
+            rb2cxx::enum_value(arg, static_cast<Enum const &>(expected_type)));
+    else if (expected_type.getCategory() == Type::Pointer) {
+        // Build directly a DL::Ptr object, no need to build a Ruby Value
+        // wrapper
+        Pointer const &ptr_type = static_cast<Pointer const &>(expected_type);
+        Type const &pointed_type = ptr_type.getIndirection();
         VALUE ptr = memory_allocate(pointed_type.getSize());
 
         Value typelib_value(memory_cptr(ptr), pointed_type);
@@ -244,82 +236,81 @@ VALUE filter_numeric_arg(VALUE self, VALUE arg, VALUE rb_expected_type)
     return arg;
 }
 
-static 
-VALUE filter_value_arg(VALUE self, VALUE arg, VALUE rb_expected_type)
-{
-    Type const& expected_type   = rb2cxx::object<Type>(rb_expected_type);
-    Value const& arg_value      = rb2cxx::object<Value>(arg);
-    Type const& arg_type        = arg_value.getType();     
+static VALUE filter_value_arg(VALUE self, VALUE arg, VALUE rb_expected_type) {
+    Type const &expected_type = rb2cxx::object<Type>(rb_expected_type);
+    Value const &arg_value = rb2cxx::object<Value>(arg);
+    Type const &arg_type = arg_value.getType();
 
-    if (arg_type == expected_type)
-    {
-        if (arg_type.getCategory() == Type::Pointer)
-        {
-#ifdef      VERBOSE
-            fprintf(stderr, "wrapping filtered argument with arg_type=%s\n", arg_type.getName().c_str());
+    if (arg_type == expected_type) {
+        if (arg_type.getCategory() == Type::Pointer) {
+#ifdef VERBOSE
+            fprintf(stderr, "wrapping filtered argument with arg_type=%s\n",
+                    arg_type.getName().c_str());
 #endif
-            return memory_wrap(*reinterpret_cast<void**>(arg_value.getData()), false, 0);
-        }
-	else if (arg_type.getCategory() == Type::Array)
-	    return rb_funcall(arg, rb_intern("to_memory_ptr"), 0);
+            return memory_wrap(*reinterpret_cast<void **>(arg_value.getData()),
+                               false, 0);
+        } else if (arg_type.getCategory() == Type::Array)
+            return rb_funcall(arg, rb_intern("to_memory_ptr"), 0);
         else if (arg_type.getCategory() == Type::Numeric)
             return rb_funcall(arg, rb_intern("to_ruby"), 0);
         else
             return Qnil;
     }
 
-    if (expected_type.getCategory() != Type::Pointer && expected_type.getCategory() != Type::Array)
+    if (expected_type.getCategory() != Type::Pointer &&
+        expected_type.getCategory() != Type::Array)
         return Qnil;
 
-    Indirect const& expected_indirect_type   = static_cast<Indirect const&>(expected_type);
-    Type const& expected_pointed_type  = expected_indirect_type.getIndirection();
+    Indirect const &expected_indirect_type =
+        static_cast<Indirect const &>(expected_type);
+    Type const &expected_pointed_type = expected_indirect_type.getIndirection();
 
-    // /void == /nil, so that if expected_type is null, then 
+    // /void == /nil, so that if expected_type is null, then
     // it is because the argument can hold any kind of pointers
     if (expected_pointed_type.isNull() || expected_pointed_type == arg_type)
         return rb_funcall(arg, rb_intern("to_memory_ptr"), 0);
-    
-    // There is only array <-> pointer conversion left to handle
-    Indirect const& arg_indirect = static_cast<Indirect const&>(arg_type);
-    if (arg_indirect.getIndirection() != expected_pointed_type)
-	return Qnil;
 
-    if (expected_type.getCategory() == Type::Pointer)
-    {
-	if (arg_type.getCategory() == Type::Pointer)
-	{
-	    // if it was OK, then arg_type == expected_type which is already handled
-	    return Qnil;
-	}
-	return rb_funcall(arg, rb_intern("to_memory_ptr"), 0);
-    }
-    else
-    {
-	if (arg_type.getCategory() == Type::Pointer)
-            return memory_wrap(*reinterpret_cast<void**>(arg_value.getData()), false, 0);
-	// check sizes
-	Array const& expected_array = static_cast<Array const&>(expected_type);
-	Array const& arg_array = static_cast<Array const&>(arg_type);
-	if (expected_array.getDimension() > arg_array.getDimension())
-	    return Qnil;
-	return rb_funcall(arg, rb_intern("to_memory_ptr"), 0);
+    // There is only array <-> pointer conversion left to handle
+    Indirect const &arg_indirect = static_cast<Indirect const &>(arg_type);
+    if (arg_indirect.getIndirection() != expected_pointed_type)
+        return Qnil;
+
+    if (expected_type.getCategory() == Type::Pointer) {
+        if (arg_type.getCategory() == Type::Pointer) {
+            // if it was OK, then arg_type == expected_type which is already
+            // handled
+            return Qnil;
+        }
+        return rb_funcall(arg, rb_intern("to_memory_ptr"), 0);
+    } else {
+        if (arg_type.getCategory() == Type::Pointer)
+            return memory_wrap(*reinterpret_cast<void **>(arg_value.getData()),
+                               false, 0);
+        // check sizes
+        Array const &expected_array = static_cast<Array const &>(expected_type);
+        Array const &arg_array = static_cast<Array const &>(arg_type);
+        if (expected_array.getDimension() > arg_array.getDimension())
+            return Qnil;
+        return rb_funcall(arg, rb_intern("to_memory_ptr"), 0);
     }
 }
 
-void typelib_ruby::Typelib_init_functions()
-{
-    VALUE mTypelib  = rb_define_module("Typelib");
-    rb_define_singleton_method(mTypelib, "filter_numeric_arg", RUBY_METHOD_FUNC(filter_numeric_arg), 2);
-    rb_define_singleton_method(mTypelib, "filter_value_arg", RUBY_METHOD_FUNC(filter_value_arg), 2);
+void typelib_ruby::Typelib_init_functions() {
+    VALUE mTypelib = rb_define_module("Typelib");
+    rb_define_singleton_method(mTypelib, "filter_numeric_arg",
+                               RUBY_METHOD_FUNC(filter_numeric_arg), 2);
+    rb_define_singleton_method(mTypelib, "filter_value_arg",
+                               RUBY_METHOD_FUNC(filter_value_arg), 2);
 
     cLibrary = rb_define_class_under(mTypelib, "Library", rb_cObject);
-    rb_define_singleton_method(cLibrary, "wrap", RUBY_METHOD_FUNC(library_wrap), 2);
+    rb_define_singleton_method(cLibrary, "wrap", RUBY_METHOD_FUNC(library_wrap),
+                               2);
     rb_define_method(cLibrary, "find", RUBY_METHOD_FUNC(library_find), 1);
 
     cFunction = rb_define_class_under(mTypelib, "Function", rb_cObject);
-    rb_define_private_method(cFunction, "prepare_vm", RUBY_METHOD_FUNC(function_compile), 1);
+    rb_define_private_method(cFunction, "prepare_vm",
+                             RUBY_METHOD_FUNC(function_compile), 1);
 
-    cCallVM  = rb_define_class_under(mTypelib, "CallVM", rb_cObject);
+    cCallVM = rb_define_class_under(mTypelib, "CallVM", rb_cObject);
     rb_define_method(cCallVM, "call", RUBY_METHOD_FUNC(vm_call), 1);
 }
-

--- a/bindings/ruby/ext/memory.cc
+++ b/bindings/ruby/ext/memory.cc
@@ -7,122 +7,100 @@ using namespace std;
 using namespace typelib_ruby;
 
 static VALUE cMemoryZone;
-struct MemoryZone
-{
-    void* ptr;
-    MemoryZone(void* ptr)
-        : ptr(ptr) {}
+struct MemoryZone {
+    void *ptr;
+    MemoryZone(void *ptr) : ptr(ptr) {}
 };
-static st_table* MemoryTable;
+static st_table *MemoryTable;
 
 /* For those who are wondering, st_data_t is always the size of an void*
  * (see the first lines of st.h
  */
-static int memory_table_compare(void* a, void* b)
-{
-    return (a != b);
-}
+static int memory_table_compare(void *a, void *b) { return (a != b); }
 
-static st_index_t memory_table_hash(void* a)
-{
+static st_index_t memory_table_hash(void *a) {
     /* Use the low-order bits as hash value, as they are the most likely to
      * change */
     return (st_index_t)a;
 }
 
 static struct st_hash_type memory_table_type = {
-    (int (*)(...))memory_table_compare,
-    (st_index_t (*)(...))memory_table_hash
-};
+    (int (*)(...))memory_table_compare, (st_index_t (*)(...))memory_table_hash};
 
-struct MemoryTableEntry
-{
+struct MemoryTableEntry {
     int refcount;
     VALUE object;
     bool owned;
-    void* root_ptr;
-    MemoryTableEntry(VALUE object, bool owned, void* root_ptr = 0)
-        : refcount(1), object(object), owned(owned), root_ptr(root_ptr)
-    {
+    void *root_ptr;
+    MemoryTableEntry(VALUE object, bool owned, void *root_ptr = 0)
+        : refcount(1), object(object), owned(owned), root_ptr(root_ptr) {
         if (root_ptr && owned)
-            rb_raise(rb_eArgError, "given both a root pointer and owned=true for object %llu", NUM2ULL(rb_obj_id(object)));
+            rb_raise(rb_eArgError,
+                     "given both a root pointer and owned=true for object %llu",
+                     NUM2ULL(rb_obj_id(object)));
     }
 };
 
-struct RbMemoryLayout
-{
+struct RbMemoryLayout {
     int refcount;
     MemoryLayout layout;
     boost::shared_ptr<Registry> registry;
 
-    RbMemoryLayout()
-        : refcount(0) {}
-    RbMemoryLayout(MemoryLayout const& layout, boost::shared_ptr<Registry> registry)
+    RbMemoryLayout() : refcount(0) {}
+    RbMemoryLayout(MemoryLayout const &layout,
+                   boost::shared_ptr<Registry> registry)
         : refcount(0), layout(layout), registry(registry) {}
 };
 
 // MemoryTypes actually holds the memory layout of each memory zone. We cannot
 // simply use the Type object as, at exit, the Ruby GC do not order finalization
 // and therefore the registry can be deleted before the Type instances.
-typedef std::map< void const*, void const* > MemoryTypes;
-typedef std::map< void const*, RbMemoryLayout > TypeLayouts;
+typedef std::map<void const *, void const *> MemoryTypes;
+typedef std::map<void const *, RbMemoryLayout> TypeLayouts;
 MemoryTypes memory_types;
 TypeLayouts memory_layouts;
 
 #ifdef VERBOSE
-static int
-memory_touch_i(volatile void* ptr, MemoryTableEntry* entry, st_data_t)
-{
-    char value = *((char*)ptr);
+static int memory_touch_i(volatile void *ptr, MemoryTableEntry *entry,
+                          st_data_t) {
+    char value = *((char *)ptr);
     fprintf(stderr, "touching %p (refcount=%i)\n", ptr, entry->refcount);
-    *((char*)ptr) = value;
+    *((char *)ptr) = value;
     return ST_CONTINUE;
 }
 
-static void
-memory_touch_all()
-{
-    st_foreach(MemoryTable, (int(*)(ANYARGS))memory_touch_i, (st_data_t)0);
-
+static void memory_touch_all() {
+    st_foreach(MemoryTable, (int (*)(ANYARGS))memory_touch_i, (st_data_t)0);
 }
 #endif
 
-bool
-typelib_ruby::memory_ref(void *ptr)
-{
-#   ifdef VERBOSE
+bool typelib_ruby::memory_ref(void *ptr) {
+#ifdef VERBOSE
     fprintf(stderr, "%p: ref\n", ptr);
-#   endif
+#endif
 
-    MemoryTableEntry* entry = 0;
-    if (st_lookup(MemoryTable, (st_data_t)ptr, (st_data_t*)&entry))
-    {
+    MemoryTableEntry *entry = 0;
+    if (st_lookup(MemoryTable, (st_data_t)ptr, (st_data_t *)&entry)) {
         ++(entry->refcount);
         return true;
-    }
-    else
-    {
+    } else {
         return false;
     }
 }
 
-static void
-memory_zone_unref(MemoryZone* ptr)
-{
+static void memory_zone_unref(MemoryZone *ptr) {
     // ptr->ptr is NULL if the zone has been invalidated
     if (ptr->ptr)
         memory_unref(ptr->ptr);
 }
 
-void
-typelib_ruby::memory_unref(void *ptr)
-{
-#   ifdef VERBOSE
+void typelib_ruby::memory_unref(void *ptr) {
+#ifdef VERBOSE
     fprintf(stderr, "%p: unref\n", ptr);
-#   endif
+#endif
 
-    MemoryTableEntry* entry = 0;
-    if (!st_lookup(MemoryTable, (st_data_t)ptr, (st_data_t*)&entry))
+    MemoryTableEntry *entry = 0;
+    if (!st_lookup(MemoryTable, (st_data_t)ptr, (st_data_t *)&entry))
         rb_raise(rb_eArgError, "cannot find %p in memory table", ptr);
     --(entry->refcount);
     if (entry->refcount)
@@ -133,234 +111,209 @@ typelib_ruby::memory_unref(void *ptr)
     if (entry->root_ptr)
         memory_unref(entry->root_ptr);
 
-#   ifdef VERBOSE
+#ifdef VERBOSE
     fprintf(stderr, "%p: deregister\n", ptr);
-#   endif
+#endif
     delete entry;
-    st_delete(MemoryTable, (st_data_t*)&ptr, 0);
+    st_delete(MemoryTable, (st_data_t *)&ptr, 0);
 
     MemoryTypes::iterator type_it = memory_types.find(ptr);
-    if (type_it != memory_types.end())
-    {
+    if (type_it != memory_types.end()) {
         TypeLayouts::iterator layout_it = memory_layouts.find(type_it->second);
-        RbMemoryLayout& layout = layout_it->second;
+        RbMemoryLayout &layout = layout_it->second;
         if (0 == --layout.refcount)
             memory_layouts.erase(layout_it);
         memory_types.erase(type_it);
     }
 }
 
-void
-typelib_ruby::memory_delete(void *ptr)
-{
+void typelib_ruby::memory_delete(void *ptr) {
     MemoryTypes::iterator it = memory_types.find(ptr);
-    if (it != memory_types.end())
-    {
+    if (it != memory_types.end()) {
         TypeLayouts::iterator layout_it = memory_layouts.find(it->second);
-        if (layout_it != memory_layouts.end())
-        {
-            RbMemoryLayout& layout = layout_it->second;
-            Typelib::destroy(
-                    static_cast<uint8_t*>(ptr),
-                    layout.layout);
+        if (layout_it != memory_layouts.end()) {
+            RbMemoryLayout &layout = layout_it->second;
+            Typelib::destroy(static_cast<uint8_t *>(ptr), layout.layout);
         }
     }
 
-#   ifdef VERBOSE
+#ifdef VERBOSE
     fprintf(stderr, "%p: deallocated\n", ptr);
-#   endif
+#endif
     ruby_xfree(ptr);
 }
 
-static VALUE
-memory_aref(void *ptr)
-{
-    MemoryTableEntry* entry;
-    if (!st_lookup(MemoryTable, (st_data_t)ptr, (st_data_t*)&entry)) {
-	return Qnil;
+static VALUE memory_aref(void *ptr) {
+    MemoryTableEntry *entry;
+    if (!st_lookup(MemoryTable, (st_data_t)ptr, (st_data_t *)&entry)) {
+        return Qnil;
     }
     if ((VALUE)entry == Qundef)
-	rb_bug("found undef in memory table");
+        rb_bug("found undef in memory table");
 
     return entry->object;
 }
 
-static void
-memory_aset(void *ptr, VALUE obj, bool owned, void* root_ptr)
-{
-    if (! NIL_P(memory_aref(ptr)))
-	rb_raise(rb_eArgError, "there is already a wrapper for %p", ptr);
+static void memory_aset(void *ptr, VALUE obj, bool owned, void *root_ptr) {
+    if (!NIL_P(memory_aref(ptr)))
+        rb_raise(rb_eArgError, "there is already a wrapper for %p", ptr);
 
     if (ptr == root_ptr)
-	rb_raise(rb_eArgError, "pointer and root pointer are equal");
+        rb_raise(rb_eArgError, "pointer and root pointer are equal");
 
-    if (!memory_ref(ptr))
-    {
-        MemoryTableEntry* entry = new MemoryTableEntry(obj, owned, root_ptr);
+    if (!memory_ref(ptr)) {
+        MemoryTableEntry *entry = new MemoryTableEntry(obj, owned, root_ptr);
         st_insert(MemoryTable, (st_data_t)ptr, (st_data_t)entry);
 
-        if (root_ptr)
-        {
-            MemoryTableEntry* root_entry = 0;
-            if (!st_lookup(MemoryTable, (st_data_t)root_ptr, (st_data_t*)&root_entry))
-                rb_raise(rb_eArgError, "%p given as root pointer for %p but is not registered", root_ptr, ptr);
+        if (root_ptr) {
+            MemoryTableEntry *root_entry = 0;
+            if (!st_lookup(MemoryTable, (st_data_t)root_ptr,
+                           (st_data_t *)&root_entry))
+                rb_raise(
+                    rb_eArgError,
+                    "%p given as root pointer for %p but is not registered",
+                    root_ptr, ptr);
             ++(root_entry->refcount);
         }
     }
 }
 
 VALUE
-typelib_ruby::memory_allocate(size_t size)
-{
-#   ifdef VERBOSE
+typelib_ruby::memory_allocate(size_t size) {
+#ifdef VERBOSE
     memory_touch_all();
-#   endif
+#endif
 
-    void* ptr = ruby_xmalloc(size);
-#   ifdef VERBOSE
+    void *ptr = ruby_xmalloc(size);
+#ifdef VERBOSE
     fprintf(stderr, "%p: new allocated zone of size %lu\n", ptr, size);
-#   endif
+#endif
 
     return memory_wrap(ptr, true, 0);
 }
 
-void
-typelib_ruby::memory_init(VALUE ptr, VALUE type)
-{
+void typelib_ruby::memory_init(VALUE ptr, VALUE type) {
     try {
-        void* cptr = memory_cptr(ptr);
+        void *cptr = memory_cptr(ptr);
         MemoryTypes::iterator it = memory_types.find(cptr);
         if (it != memory_types.end())
             rb_raise(rb_eArgError, "memory zone already initialized");
 
         // For deinitialization later, get or register the type's layout
-        Type const& t(rb2cxx::object<Type>(type));
+        Type const &t(rb2cxx::object<Type>(type));
         TypeLayouts::iterator layout_it = memory_layouts.find(&t);
-        if (layout_it == memory_layouts.end())
-        {
-            cxx2rb::RbRegistry& registry = rb2cxx::object<cxx2rb::RbRegistry>(type_get_registry(type));
-            layout_it = memory_layouts.insert(
-                make_pair( &t, RbMemoryLayout(layout_of(t, true), registry.registry) )
-                ).first;
+        if (layout_it == memory_layouts.end()) {
+            cxx2rb::RbRegistry &registry =
+                rb2cxx::object<cxx2rb::RbRegistry>(type_get_registry(type));
+            layout_it =
+                memory_layouts.insert(make_pair(&t, RbMemoryLayout(
+                                                        layout_of(t, true),
+                                                        registry.registry)))
+                    .first;
         }
-        RbMemoryLayout& layout = layout_it->second;
+        RbMemoryLayout &layout = layout_it->second;
         ++layout.refcount;
 
-        memory_types.insert( make_pair(cptr, &t) );
-        Typelib::init(static_cast<uint8_t*>(cptr), layout.layout);
-    } catch(std::exception const& e) {
+        memory_types.insert(make_pair(cptr, &t));
+        Typelib::init(static_cast<uint8_t *>(cptr), layout.layout);
+    } catch (std::exception const &e) {
         rb_raise(rb_eArgError, "internal error: %s", e.what());
     }
 }
 
 VALUE
-typelib_ruby::memory_wrap(void* ptr, bool take_ownership, void* root_ptr)
-{
+typelib_ruby::memory_wrap(void *ptr, bool take_ownership, void *root_ptr) {
     VALUE zone = memory_aref(ptr);
-    if (NIL_P(zone))
-    {
-#	ifdef VERBOSE
-	fprintf(stderr, "%p: wrapping new memory zone\n", ptr);
-#	endif
+    if (NIL_P(zone)) {
+#ifdef VERBOSE
+        fprintf(stderr, "%p: wrapping new memory zone\n", ptr);
+#endif
 
-        zone = Data_Wrap_Struct(cMemoryZone, 0, &memory_zone_unref, new MemoryZone(ptr));
-	memory_aset(ptr, zone, take_ownership, root_ptr);
-    }
-    else
-    {
-#	ifdef VERBOSE
-	fprintf(stderr, "%p: already known memory zone\n", ptr);
-#	endif
+        zone = Data_Wrap_Struct(cMemoryZone, 0, &memory_zone_unref,
+                                new MemoryZone(ptr));
+        memory_aset(ptr, zone, take_ownership, root_ptr);
+    } else {
+#ifdef VERBOSE
+        fprintf(stderr, "%p: already known memory zone\n", ptr);
+#endif
     }
 
     return zone;
 }
 
-void*
-typelib_ruby::memory_cptr(VALUE ptr)
-{
-    MemoryZone* cptr;
+void *typelib_ruby::memory_cptr(VALUE ptr) {
+    MemoryZone *cptr;
     Data_Get_Struct(ptr, MemoryZone, cptr);
     return cptr->ptr;
 }
 
-static MemoryZone*
-memory_zone(VALUE ptr)
-{
-    MemoryZone* cptr;
+static MemoryZone *memory_zone(VALUE ptr) {
+    MemoryZone *cptr;
     Data_Get_Struct(ptr, MemoryZone, cptr);
     return cptr;
 }
 
-
-static VALUE
-memory_zone_address(VALUE self)
-{
-    void* ptr = memory_cptr(self);
+static VALUE memory_zone_address(VALUE self) {
+    void *ptr = memory_cptr(self);
     return ULL2NUM(reinterpret_cast<uint64_t>(ptr));
 }
 
-static VALUE
-memory_zone_to_ptr(VALUE self)
-{
-#   ifdef VERBOSE
+static VALUE memory_zone_to_ptr(VALUE self) {
+#ifdef VERBOSE
     fprintf(stderr, "allocating void* to create a pointer-to-memory\n");
-#   endif
+#endif
 
-    VALUE result = memory_allocate(sizeof(void*));
+    VALUE result = memory_allocate(sizeof(void *));
 
-    void* newptr = memory_cptr(result);
-    void* ptr    = memory_cptr(self);
+    void *newptr = memory_cptr(result);
+    void *ptr = memory_cptr(self);
 
-    *reinterpret_cast<void**>(newptr) = ptr;
+    *reinterpret_cast<void **>(newptr) = ptr;
     rb_iv_set(result, "@pointed_to_memory", self);
     return result;
 }
 
-static VALUE
-memory_zone_invalidate(VALUE self)
-{
-    MemoryZone* cptr = memory_zone(self);
-#   ifdef VERBOSE
+static VALUE memory_zone_invalidate(VALUE self) {
+    MemoryZone *cptr = memory_zone(self);
+#ifdef VERBOSE
     fprintf(stderr, "invalidating memory zone %p", cptr->ptr);
-#   endif
+#endif
     if (cptr->ptr)
         memory_unref(cptr->ptr);
     cptr->ptr = 0;
     return Qnil;
 }
 
-static VALUE
-string_to_memory_ptr(VALUE self)
-{
+static VALUE string_to_memory_ptr(VALUE self) {
     rb_str_modify(self);
-#   ifdef VERBOSE
+#ifdef VERBOSE
     fprintf(stderr, "wrapping string value from Ruby\n");
-#   endif
+#endif
     VALUE ptr = memory_wrap(StringValuePtr(self), false, 0);
     rb_iv_set(ptr, "@buffer_string", self);
     return ptr;
 }
 
-static VALUE
-memory_zone_table_size(VALUE self)
-{
+static VALUE memory_zone_table_size(VALUE self) {
     return INT2NUM(MemoryTable->num_entries);
 }
 
-void typelib_ruby::Typelib_init_memory()
-{
-    VALUE mTypelib  = rb_define_module("Typelib");
-    MemoryTable     = st_init_table(&memory_table_type);
-    VALUE table     = Data_Wrap_Struct(rb_cObject, 0, 0, MemoryTable);
+void typelib_ruby::Typelib_init_memory() {
+    VALUE mTypelib = rb_define_module("Typelib");
+    MemoryTable = st_init_table(&memory_table_type);
+    VALUE table = Data_Wrap_Struct(rb_cObject, 0, 0, MemoryTable);
     rb_iv_set(mTypelib, "@__memory_table__", table);
 
     cMemoryZone = rb_define_class_under(mTypelib, "MemoryZone", rb_cObject);
-    rb_define_method(cMemoryZone, "zone_address", RUBY_METHOD_FUNC(memory_zone_address), 0);
-    rb_define_method(cMemoryZone, "to_ptr", RUBY_METHOD_FUNC(memory_zone_to_ptr), 0);
-    rb_define_method(cMemoryZone, "invalidate", RUBY_METHOD_FUNC(memory_zone_invalidate), 0);
-    rb_define_singleton_method(cMemoryZone, "table_size", RUBY_METHOD_FUNC(memory_zone_table_size), 0);
+    rb_define_method(cMemoryZone, "zone_address",
+                     RUBY_METHOD_FUNC(memory_zone_address), 0);
+    rb_define_method(cMemoryZone, "to_ptr",
+                     RUBY_METHOD_FUNC(memory_zone_to_ptr), 0);
+    rb_define_method(cMemoryZone, "invalidate",
+                     RUBY_METHOD_FUNC(memory_zone_invalidate), 0);
+    rb_define_singleton_method(cMemoryZone, "table_size",
+                               RUBY_METHOD_FUNC(memory_zone_table_size), 0);
 
-    rb_define_method(rb_cString, "to_memory_ptr", RUBY_METHOD_FUNC(string_to_memory_ptr), 0);
+    rb_define_method(rb_cString, "to_memory_ptr",
+                     RUBY_METHOD_FUNC(string_to_memory_ptr), 0);
 }
-

--- a/bindings/ruby/ext/metadata.cc
+++ b/bindings/ruby/ext/metadata.cc
@@ -8,52 +8,48 @@ using namespace Typelib;
 using namespace typelib_ruby;
 
 VALUE typelib_ruby::cMetaData;
-rb_encoding* enc_utf8;
+rb_encoding *enc_utf8;
 
-VALUE cxx2rb::metadata_wrap(MetaData& metadata)
-{
+VALUE cxx2rb::metadata_wrap(MetaData &metadata) {
     return Data_Wrap_Struct(cMetaData, 0, 0, &metadata);
 }
 
-static VALUE metadata_get(VALUE self, VALUE key)
-{
-    MetaData& metadata = rb2cxx::object<MetaData>(self);
+static VALUE metadata_get(VALUE self, VALUE key) {
+    MetaData &metadata = rb2cxx::object<MetaData>(self);
     MetaData::Values v = metadata.get(StringValuePtr(key));
 
     VALUE result = rb_ary_new();
     for (MetaData::Values::const_iterator it = v.begin(); it != v.end(); ++it)
-        rb_ary_push(result, rb_enc_str_new(it->c_str(), it->length(), enc_utf8));
+        rb_ary_push(result,
+                    rb_enc_str_new(it->c_str(), it->length(), enc_utf8));
     return result;
 }
 
-static VALUE metadata_keys(VALUE self)
-{
-    MetaData& metadata = rb2cxx::object<MetaData>(self);
-    MetaData::Map const& map = metadata.get();
+static VALUE metadata_keys(VALUE self) {
+    MetaData &metadata = rb2cxx::object<MetaData>(self);
+    MetaData::Map const &map = metadata.get();
 
     VALUE result = rb_ary_new();
     for (MetaData::Map::const_iterator it = map.begin(); it != map.end(); ++it)
-        rb_ary_push(result, rb_enc_str_new(it->first.c_str(), it->first.length(), enc_utf8));
+        rb_ary_push(result, rb_enc_str_new(it->first.c_str(),
+                                           it->first.length(), enc_utf8));
     return result;
 }
 
-static VALUE metadata_set(VALUE self, VALUE key, VALUE value)
-{
-    MetaData& metadata = rb2cxx::object<MetaData>(self);
+static VALUE metadata_set(VALUE self, VALUE key, VALUE value) {
+    MetaData &metadata = rb2cxx::object<MetaData>(self);
     metadata.set(StringValuePtr(key), StringValuePtr(value));
     return Qnil;
 }
 
-static VALUE metadata_add(VALUE self, VALUE key, VALUE value)
-{
-    MetaData& metadata = rb2cxx::object<MetaData>(self);
+static VALUE metadata_add(VALUE self, VALUE key, VALUE value) {
+    MetaData &metadata = rb2cxx::object<MetaData>(self);
     metadata.add(StringValuePtr(key), StringValuePtr(value));
     return Qnil;
 }
 
-static VALUE metadata_clear(int argc, VALUE* argv, VALUE self)
-{
-    MetaData& metadata = rb2cxx::object<MetaData>(self);
+static VALUE metadata_clear(int argc, VALUE *argv, VALUE self) {
+    MetaData &metadata = rb2cxx::object<MetaData>(self);
     if (argc == 0)
         metadata.clear();
     else if (argc == 1)
@@ -61,21 +57,18 @@ static VALUE metadata_clear(int argc, VALUE* argv, VALUE self)
     return Qnil;
 }
 
-static void metadata_free(void* metadata)
-{
-    delete reinterpret_cast<MetaData*>(metadata);
+static void metadata_free(void *metadata) {
+    delete reinterpret_cast<MetaData *>(metadata);
 }
 
-static VALUE metadata_alloc(VALUE klass)
-{
-    MetaData* metadata = new MetaData;
+static VALUE metadata_alloc(VALUE klass) {
+    MetaData *metadata = new MetaData;
     return Data_Wrap_Struct(cMetaData, 0, metadata_free, metadata);
 }
 
-void typelib_ruby::Typelib_init_metadata()
-{
-    VALUE mTypelib  = rb_define_module("Typelib");
-    cMetaData   = rb_define_class_under(mTypelib, "MetaData", rb_cObject);
+void typelib_ruby::Typelib_init_metadata() {
+    VALUE mTypelib = rb_define_module("Typelib");
+    cMetaData = rb_define_class_under(mTypelib, "MetaData", rb_cObject);
     rb_define_alloc_func(cMetaData, metadata_alloc);
 
     rb_define_method(cMetaData, "get", RUBY_METHOD_FUNC(metadata_get), 1);
@@ -85,4 +78,3 @@ void typelib_ruby::Typelib_init_metadata()
     rb_define_method(cMetaData, "keys", RUBY_METHOD_FUNC(metadata_keys), 0);
     enc_utf8 = rb_enc_find("utf-8");
 }
-

--- a/bindings/ruby/ext/registry.cc
+++ b/bindings/ruby/ext/registry.cc
@@ -14,10 +14,9 @@ using namespace std;
 using namespace typelib_ruby;
 using cxx2rb::RbRegistry;
 
-
 namespace typelib_ruby {
-    VALUE cRegistry = Qnil;
-    VALUE eNotFound = Qnil;
+VALUE cRegistry = Qnil;
+VALUE eNotFound = Qnil;
 }
 
 /***********************************************************************************
@@ -26,15 +25,12 @@ namespace typelib_ruby {
  *
  */
 
-
-static 
-void registry_free(void* ptr)
-{
+static void registry_free(void *ptr) {
     using cxx2rb::WrapperMap;
-    RbRegistry* rbregistry = reinterpret_cast<RbRegistry*>(ptr);
-    WrapperMap& wrappers = rbregistry->wrappers;
-    for (WrapperMap::iterator it = wrappers.begin(); it != wrappers.end(); ++it)
-    {
+    RbRegistry *rbregistry = reinterpret_cast<RbRegistry *>(ptr);
+    WrapperMap &wrappers = rbregistry->wrappers;
+    for (WrapperMap::iterator it = wrappers.begin(); it != wrappers.end();
+         ++it) {
         if (it->second.first)
             delete it->first;
     }
@@ -42,34 +38,28 @@ void registry_free(void* ptr)
     delete rbregistry;
 }
 
-static
-void registry_mark(void* ptr)
-{
+static void registry_mark(void *ptr) {
     using cxx2rb::WrapperMap;
-    WrapperMap const& wrappers = reinterpret_cast<RbRegistry const*>(ptr)->wrappers;
-    for (WrapperMap::const_iterator it = wrappers.begin(); it != wrappers.end(); ++it)
-	rb_gc_mark(it->second.second);
+    WrapperMap const &wrappers =
+        reinterpret_cast<RbRegistry const *>(ptr)->wrappers;
+    for (WrapperMap::const_iterator it = wrappers.begin(); it != wrappers.end();
+         ++it)
+        rb_gc_mark(it->second.second);
 }
 
-static
-VALUE registry_wrap(VALUE klass, Registry* registry)
-{
-    return Data_Wrap_Struct(klass, registry_mark, registry_free, new RbRegistry(registry));
+static VALUE registry_wrap(VALUE klass, Registry *registry) {
+    return Data_Wrap_Struct(klass, registry_mark, registry_free,
+                            new RbRegistry(registry));
 }
 
-static
-VALUE registry_alloc(VALUE klass)
-{
-    Registry* registry = new Registry;
+static VALUE registry_alloc(VALUE klass) {
+    Registry *registry = new Registry;
     return registry_wrap(klass, registry);
 }
 
-
-static
-VALUE registry_includes_p(VALUE self, VALUE name)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
-    Type const* type = registry.get( StringValuePtr(name) );
+static VALUE registry_includes_p(VALUE self, VALUE name) {
+    Registry &registry = rb2cxx::object<Registry>(self);
+    Type const *type = registry.get(StringValuePtr(name));
     return type ? Qtrue : Qfalse;
 }
 
@@ -81,18 +71,15 @@ VALUE registry_includes_p(VALUE self, VALUE name)
  *
  * Returns the set of removed types
  */
-static
-VALUE registry_remove(VALUE self, VALUE rbtype)
-{
-    RbRegistry& rbregistry = rb2cxx::object<RbRegistry>(self);
-    Registry&   registry = *(rbregistry.registry);
-    Type const& type(rb2cxx::object<Type>(rbtype));
-    std::set<Type*> deleted = registry.remove(type);
-    
+static VALUE registry_remove(VALUE self, VALUE rbtype) {
+    RbRegistry &rbregistry = rb2cxx::object<RbRegistry>(self);
+    Registry &registry = *(rbregistry.registry);
+    Type const &type(rb2cxx::object<Type>(rbtype));
+    std::set<Type *> deleted = registry.remove(type);
+
     VALUE result = rb_ary_new();
-    std::set<Type*>::iterator it, end;
-    for (it = deleted.begin(); it != deleted.end(); ++it)
-    {
+    std::set<Type *>::iterator it, end;
+    for (it = deleted.begin(); it != deleted.end(); ++it) {
         rb_ary_push(result, cxx2rb::type_wrap(**it, self));
         cxx2rb::WrapperMap::iterator wrapper_it = rbregistry.wrappers.find(*it);
         wrapper_it->second.first = true;
@@ -106,58 +93,56 @@ VALUE registry_remove(VALUE self, VALUE rbtype)
  *
  * Returns the source ID for the given type, if one is set
  */
-static
-VALUE registry_source_id_of(VALUE self, VALUE rbtype)
-{
-    RbRegistry& rbregistry = rb2cxx::object<RbRegistry>(self);
-    Registry&   registry = *(rbregistry.registry);
-    Type const& type(rb2cxx::object<Type>(rbtype));
+static VALUE registry_source_id_of(VALUE self, VALUE rbtype) {
+    RbRegistry &rbregistry = rb2cxx::object<RbRegistry>(self);
+    Registry &registry = *(rbregistry.registry);
+    Type const &type(rb2cxx::object<Type>(rbtype));
 
     RegistryIterator it = registry.find(type.getName());
     if (it == registry.end())
-        rb_raise(rb_eArgError, "this registry has no type called %s", type.getName().c_str());
+        rb_raise(rb_eArgError, "this registry has no type called %s",
+                 type.getName().c_str());
 
     std::string source = it.getSource();
-    if (source.empty()) return Qnil;
+    if (source.empty())
+        return Qnil;
     return rb_str_new(it.getSource().c_str(), it.getSource().length());
 }
 
 /* @overload registry.reverse_depends(type)
- *   Returns an array of the types that depend on another type, including the type itself
+ *   Returns an array of the types that depend on another type, including the
+ *type itself
  *
- *   @param [Class<Typelib::Type>] type the type whose reverse dependencies we want
+ *   @param [Class<Typelib::Type>] type the type whose reverse dependencies we
+ *want
  *   @return [Array<Class<Typelib::Type>>] the types that depend on the given
  *     type, recursively and including the type itself.
  */
-static
-VALUE registry_reverse_depends(VALUE self, VALUE rbtype)
-{
-    Registry const& registry = rb2cxx::object<Registry>(self);
-    Type const& type(rb2cxx::object<Type>(rbtype));
-    std::set<Type const*> rdeps = registry.reverseDepends(type);
-    
+static VALUE registry_reverse_depends(VALUE self, VALUE rbtype) {
+    Registry const &registry = rb2cxx::object<Registry>(self);
+    Type const &type(rb2cxx::object<Type>(rbtype));
+    std::set<Type const *> rdeps = registry.reverseDepends(type);
+
     VALUE result = rb_ary_new();
-    std::set<Type const*>::iterator it, end;
+    std::set<Type const *>::iterator it, end;
     for (it = rdeps.begin(); it != rdeps.end(); ++it)
         rb_ary_push(result, cxx2rb::type_wrap(**it, self));
 
     return result;
 }
 
-static
-VALUE registry_do_get(VALUE self, VALUE name)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
-    Type const* type = registry.get( StringValuePtr(name) );
+static VALUE registry_do_get(VALUE self, VALUE name) {
+    Registry &registry = rb2cxx::object<Registry>(self);
+    Type const *type = registry.get(StringValuePtr(name));
 
-    if (! type)
-        rb_raise(eNotFound, "there is no type in this registry with the name '%s'", StringValuePtr(name));
+    if (!type)
+        rb_raise(eNotFound,
+                 "there is no type in this registry with the name '%s'",
+                 StringValuePtr(name));
     return cxx2rb::type_wrap(*type, self);
 }
 
-static
-VALUE registry_do_build(int argc, VALUE* argv, VALUE self)
-{
+static VALUE registry_do_build(int argc, VALUE *argv, VALUE self) {
     VALUE name = argv[0];
     int size = 0;
     if (argc == 0 || argc > 2)
@@ -165,73 +150,66 @@ VALUE registry_do_build(int argc, VALUE* argv, VALUE self)
     else if (argc == 2)
         size = NUM2INT(argv[1]);
 
-    Registry& registry = rb2cxx::object<Registry>(self);
+    Registry &registry = rb2cxx::object<Registry>(self);
     try {
-        Type const* type = registry.build( StringValuePtr(name), size );
-        if (! type) 
-            rb_raise(eNotFound, "cannot find %s in registry", StringValuePtr(name));
+        Type const *type = registry.build(StringValuePtr(name), size);
+        if (!type)
+            rb_raise(eNotFound, "cannot find %s in registry",
+                     StringValuePtr(name));
         return cxx2rb::type_wrap(*type, self);
+    } catch (std::exception const &e) {
+        rb_raise(rb_eRuntimeError, "%s", e.what());
     }
-    catch(std::exception const& e) { rb_raise(rb_eRuntimeError, "%s", e.what()); }
 }
-
 
 /* call-seq:
  *  alias(new_name, name)	    => self
  *
  * Make +new_name+ refer to the type named +name+
  */
-static
-VALUE registry_alias(VALUE self, VALUE name, VALUE aliased)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
+static VALUE registry_alias(VALUE self, VALUE name, VALUE aliased) {
+    Registry &registry = rb2cxx::object<Registry>(self);
 
-    try { 
-	registry.alias(StringValuePtr(aliased), StringValuePtr(name)); 
-	return self;
-    } catch(BadName) {
+    try {
+        registry.alias(StringValuePtr(aliased), StringValuePtr(name));
+        return self;
+    } catch (BadName) {
         rb_raise(rb_eArgError, "invalid type name %s", StringValuePtr(name));
-    } catch(Undefined) {
-        rb_raise(eNotFound, "there is not type in this registry with the name '%s'", StringValuePtr(aliased));
+    } catch (Undefined) {
+        rb_raise(eNotFound,
+                 "there is not type in this registry with the name '%s'",
+                 StringValuePtr(aliased));
     }
 }
 
-static
-void setup_configset_from_option_array(config_set& config, VALUE options)
-{
+static void setup_configset_from_option_array(config_set &config,
+                                              VALUE options) {
     int options_length = RARRAY_LEN(options);
-    for (int i = 0; i < options_length; ++i)
-    {
-	VALUE entry = RARRAY_PTR(options)[i];
-	VALUE k = RARRAY_PTR(entry)[0];
-	VALUE v = RARRAY_PTR(entry)[1];
+    for (int i = 0; i < options_length; ++i) {
+        VALUE entry = RARRAY_PTR(options)[i];
+        VALUE k = RARRAY_PTR(entry)[0];
+        VALUE v = RARRAY_PTR(entry)[1];
 
-	if ( rb_obj_is_kind_of(v, rb_cArray) )
-	{
+        if (rb_obj_is_kind_of(v, rb_cArray)) {
             VALUE first_el = rb_ary_entry(v, 0);
-            if (rb_obj_is_kind_of(first_el, rb_cArray))
-            {
+            if (rb_obj_is_kind_of(first_el, rb_cArray)) {
                 // We are building recursive config sets
-                for (int j = 0; j < RARRAY_LEN(v); ++j)
-                {
-                    config_set* child = new config_set;
-                    setup_configset_from_option_array(*child, rb_ary_entry(v, j));
+                for (int j = 0; j < RARRAY_LEN(v); ++j) {
+                    config_set *child = new config_set;
+                    setup_configset_from_option_array(*child,
+                                                      rb_ary_entry(v, j));
                     config.insert(StringValuePtr(k), child);
                 }
-            }
-            else
-            {
-                for (int j = 0; j < RARRAY_LEN(v); ++j)
-                {
+            } else {
+                for (int j = 0; j < RARRAY_LEN(v); ++j) {
                     VALUE value = rb_ary_entry(v, j);
                     config.insert(StringValuePtr(k), StringValuePtr(value));
                 }
             }
-	}
-	else if (TYPE(v) == T_TRUE || TYPE(v) == T_FALSE)
-	    config.set(StringValuePtr(k), RTEST(v) ? "true" : "false");
-	else
-	    config.set(StringValuePtr(k), StringValuePtr(v));
+        } else if (TYPE(v) == T_TRUE || TYPE(v) == T_FALSE)
+            config.set(StringValuePtr(k), RTEST(v) ? "true" : "false");
+        else
+            config.set(StringValuePtr(k), StringValuePtr(v));
     }
 }
 
@@ -239,28 +217,29 @@ void setup_configset_from_option_array(config_set& config, VALUE options)
  * We expect Registry#import to format the arguments before calling
  * do_import
  */
-static
-VALUE registry_import(VALUE self, VALUE file, VALUE kind, VALUE merge, VALUE options)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
+static VALUE registry_import(VALUE self, VALUE file, VALUE kind, VALUE merge,
+                             VALUE options) {
+    Registry &registry = rb2cxx::object<Registry>(self);
 
     config_set config;
     setup_configset_from_option_array(config, options);
-    
+
     std::string error_string;
-    try { 
-	if (RTEST(merge))
-	{
-	    Registry temp;
-	    PluginManager::load(StringValuePtr(kind), StringValuePtr(file), config, temp); 
-	    registry.merge(temp);
-	}
-	else
-	    PluginManager::load(StringValuePtr(kind), StringValuePtr(file), config, registry); 
-	return Qnil;
+    try {
+        if (RTEST(merge)) {
+            Registry temp;
+            PluginManager::load(StringValuePtr(kind), StringValuePtr(file),
+                                config, temp);
+            registry.merge(temp);
+        } else
+            PluginManager::load(StringValuePtr(kind), StringValuePtr(file),
+                                config, registry);
+        return Qnil;
+    } catch (boost::bad_lexical_cast e) {
+        error_string = e.what();
+    } catch (std::exception const &e) {
+        error_string = e.what();
     }
-    catch(boost::bad_lexical_cast e)   { error_string = e.what(); }
-    catch(std::exception const& e) { error_string = e.what(); }
 
     rb_raise(rb_eRuntimeError, "%s", error_string.c_str());
 }
@@ -269,23 +248,22 @@ VALUE registry_import(VALUE self, VALUE file, VALUE kind, VALUE merge, VALUE opt
  * to format the +options+ argument from a Ruby hash into an array suitable
  * for setup_configset_from_option_array
  */
-static
-VALUE registry_export(VALUE self, VALUE kind, VALUE options)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
+static VALUE registry_export(VALUE self, VALUE kind, VALUE options) {
+    Registry &registry = rb2cxx::object<Registry>(self);
 
     config_set config;
     setup_configset_from_option_array(config, options);
-    
+
     string error_message;
     try {
-	std::string exported = PluginManager::save(StringValuePtr(kind), config, registry);
-	return rb_str_new(exported.c_str(), exported.length());
+        std::string exported =
+            PluginManager::save(StringValuePtr(kind), config, registry);
+        return rb_str_new(exported.c_str(), exported.length());
+    } catch (std::exception const &e) {
+        error_message = e.what();
     }
-    catch (std::exception const& e) { error_message = e.what(); }
     rb_raise(rb_eRuntimeError, "%s", error_message.c_str());
 }
-
 
 /*
  * call-seq:
@@ -293,21 +271,19 @@ VALUE registry_export(VALUE self, VALUE kind, VALUE options)
  *
  * Move all types found in +other_registry+ into +self+
  */
-static
-VALUE registry_merge(VALUE self, VALUE rb_merged)
-{
+static VALUE registry_merge(VALUE self, VALUE rb_merged) {
     std::string error_string;
 
-    Registry& registry = rb2cxx::object<Registry>(self);
-    Registry& merged   = rb2cxx::object<Registry>(rb_merged);
-    try { 
-	registry.merge(merged);
-	return self;
+    Registry &registry = rb2cxx::object<Registry>(self);
+    Registry &merged = rb2cxx::object<Registry>(rb_merged);
+    try {
+        registry.merge(merged);
+        return self;
+    } catch (std::exception const &e) {
+        error_string = e.what();
     }
-    catch(std::exception const& e) { error_string = e.what(); }
     rb_raise(rb_eRuntimeError, "%s", error_string.c_str());
 }
-
 
 /*
  * call-seq:
@@ -316,73 +292,58 @@ VALUE registry_merge(VALUE self, VALUE rb_merged)
  * Changes the size of some types, while modifying the types that depend on
  * them to keep the registry consistent.
  */
-static
-VALUE registry_resize(VALUE self, VALUE new_sizes)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
+static VALUE registry_resize(VALUE self, VALUE new_sizes) {
+    Registry &registry = rb2cxx::object<Registry>(self);
 
     std::map<std::string, size_t> sizes;
-    size_t map_size   = RARRAY_LEN(new_sizes);
-    VALUE* map_values = RARRAY_PTR(new_sizes);
-    for (size_t i = 0; i < map_size; ++i)
-    {
-        VALUE* pair = RARRAY_PTR(map_values[i]);
-        sizes.insert(std::make_pair(
-                StringValuePtr(pair[0]),
-                NUM2INT(pair[1])));
+    size_t map_size = RARRAY_LEN(new_sizes);
+    VALUE *map_values = RARRAY_PTR(new_sizes);
+    for (size_t i = 0; i < map_size; ++i) {
+        VALUE *pair = RARRAY_PTR(map_values[i]);
+        sizes.insert(std::make_pair(StringValuePtr(pair[0]), NUM2INT(pair[1])));
     }
-    try { 
-	registry.resize(sizes);
-	return Qnil;
-    }
-    catch(std::exception const& e) {
+    try {
+        registry.resize(sizes);
+        return Qnil;
+    } catch (std::exception const &e) {
         rb_raise(rb_eRuntimeError, "%s", e.what());
     }
 }
 
-static
-VALUE registry_minimal(VALUE self, VALUE rb_auto, VALUE with_aliases)
-{
+static VALUE registry_minimal(VALUE self, VALUE rb_auto, VALUE with_aliases) {
     std::string error_string;
-    Registry& registry   = rb2cxx::object<Registry>(self);
+    Registry &registry = rb2cxx::object<Registry>(self);
 
-    if (rb_obj_is_kind_of(rb_auto, rb_cString))
-    {
-        try { 
-            Registry* result = registry.minimal(StringValuePtr(rb_auto), RTEST(with_aliases));
+    if (rb_obj_is_kind_of(rb_auto, rb_cString)) {
+        try {
+            Registry *result =
+                registry.minimal(StringValuePtr(rb_auto), RTEST(with_aliases));
             return registry_wrap(cRegistry, result);
+        } catch (std::exception const &e) {
+            rb_raise(rb_eRuntimeError, "%s", e.what());
         }
-        catch(std::exception const& e)
-        { rb_raise(rb_eRuntimeError, "%s", e.what()); }
-    }
-    else
-    {
-        Registry& auto_types = rb2cxx::object<Registry>(rb_auto);
-        try { 
-            Registry* result = registry.minimal(auto_types);
+    } else {
+        Registry &auto_types = rb2cxx::object<Registry>(rb_auto);
+        try {
+            Registry *result = registry.minimal(auto_types);
             return registry_wrap(cRegistry, result);
+        } catch (std::exception const &e) {
+            rb_raise(rb_eRuntimeError, "%s", e.what());
         }
-        catch(std::exception const& e)
-        { rb_raise(rb_eRuntimeError, "%s", e.what()); }
     }
 }
 
-
-static void yield_types(VALUE self, bool with_aliases, RegistryIterator it, RegistryIterator end)
-{
-    if (with_aliases)
-    {
-        for (; it != end; ++it)
-        {
-            std::string const& type_name = it.getName();
-            VALUE rb_type_name = rb_str_new(type_name.c_str(), type_name.length());
+static void yield_types(VALUE self, bool with_aliases, RegistryIterator it,
+                        RegistryIterator end) {
+    if (with_aliases) {
+        for (; it != end; ++it) {
+            std::string const &type_name = it.getName();
+            VALUE rb_type_name =
+                rb_str_new(type_name.c_str(), type_name.length());
             rb_yield_values(2, rb_type_name, cxx2rb::type_wrap(*it, self));
         }
-    }
-    else
-    {
-        for (; it != end; ++it)
-        {
+    } else {
+        for (; it != end; ++it) {
             if (!it.isAlias())
                 rb_yield(cxx2rb::type_wrap(*it, self));
         }
@@ -405,48 +366,45 @@ static void yield_types(VALUE self, bool with_aliases, RegistryIterator it, Regi
  *     aliases
  *   @yieldparam [Model<Typelib::Type>] type a type
  */
-static
-VALUE registry_each_type(VALUE self, VALUE filter_, VALUE with_aliases_)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
+static VALUE registry_each_type(VALUE self, VALUE filter_,
+                                VALUE with_aliases_) {
+    Registry &registry = rb2cxx::object<Registry>(self);
     bool with_aliases = RTEST(with_aliases_);
     std::string filter;
     if (RTEST(filter_))
         filter = StringValuePtr(filter_);
 
-    try 
-    {
+    try {
         if (filter.empty())
             yield_types(self, with_aliases, registry.begin(), registry.end());
         else
-            yield_types(self, with_aliases, registry.begin(filter), registry.end(filter));
+            yield_types(self, with_aliases, registry.begin(filter),
+                        registry.end(filter));
 
-	return self;
-    }
-    catch(std::exception const& e)
-    {
+        return self;
+    } catch (std::exception const &e) {
         rb_raise(rb_eRuntimeError, "%s", e.what());
     }
 }
 
 /* call-seq:
  *  registry.merge_xml(xml) => registry
- * 
+ *
  * Build a registry from a string, which is formatted as Typelib's own XML
  * format.  See also #export, #import and #to_xml
  */
-static
-VALUE registry_merge_xml(VALUE rb_registry, VALUE xml)
-{
-    Registry& registry = rb2cxx::object<Registry>(rb_registry);
+static VALUE registry_merge_xml(VALUE rb_registry, VALUE xml) {
+    Registry &registry = rb2cxx::object<Registry>(rb_registry);
 
     std::istringstream istream(StringValuePtr(xml));
     config_set config;
-    try { PluginManager::load("tlb", istream, config, registry); }
-    catch(boost::bad_lexical_cast e)
-    { rb_raise(rb_eArgError, "cannot load xml: %s", e.what()); }
-    catch(std::exception const& e)
-    { rb_raise(rb_eArgError, "cannot load xml: %s", e.what()); }
+    try {
+        PluginManager::load("tlb", istream, config, registry);
+    } catch (boost::bad_lexical_cast e) {
+        rb_raise(rb_eArgError, "cannot load xml: %s", e.what());
+    } catch (std::exception const &e) {
+        rb_raise(rb_eArgError, "cannot load xml: %s", e.what());
+    }
 
     return rb_registry;
 }
@@ -457,15 +415,14 @@ VALUE registry_merge_xml(VALUE rb_registry, VALUE xml)
  *
  * Lists all the known aliases for the given type
  */
-static VALUE registry_aliases_of(VALUE self, VALUE type_)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
-    Type const& type(rb2cxx::object<Type>(type_));
-    std::set<std::string> aliases =
-        registry.getAliasesOf(type);
+static VALUE registry_aliases_of(VALUE self, VALUE type_) {
+    Registry &registry = rb2cxx::object<Registry>(self);
+    Type const &type(rb2cxx::object<Type>(type_));
+    std::set<std::string> aliases = registry.getAliasesOf(type);
 
     VALUE result = rb_ary_new();
-    for (set<string>::const_iterator it = aliases.begin(); it != aliases.end(); ++it)
+    for (set<string>::const_iterator it = aliases.begin(); it != aliases.end();
+         ++it)
         rb_ary_push(result, rb_str_new(it->c_str(), it->length()));
     return result;
 }
@@ -476,9 +433,8 @@ static VALUE registry_aliases_of(VALUE self, VALUE type_)
  *
  * Removes all aliases defined on this registry
  */
-static VALUE registry_clear_aliases(VALUE self)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
+static VALUE registry_clear_aliases(VALUE self) {
+    Registry &registry = rb2cxx::object<Registry>(self);
     registry.clearAliases();
     return Qnil;
 }
@@ -489,9 +445,8 @@ static VALUE registry_clear_aliases(VALUE self)
  *
  * Returns the number of types registered in +self+
  */
-static VALUE registry_size(VALUE self)
-{
-    Registry& registry = rb2cxx::object<Registry>(self);
+static VALUE registry_size(VALUE self) {
+    Registry &registry = rb2cxx::object<Registry>(self);
     return INT2NUM(registry.size());
 }
 
@@ -501,8 +456,7 @@ static VALUE registry_size(VALUE self)
  *
  * Returns the set of known container names
  */
-static VALUE registry_available_container(VALUE registry_module)
-{
+static VALUE registry_available_container(VALUE registry_module) {
     Typelib::Container::AvailableContainers containers =
         Typelib::Container::availableContainers();
 
@@ -511,8 +465,7 @@ static VALUE registry_available_container(VALUE registry_module)
         it = containers.begin(),
         end = containers.end();
 
-    while (it != end)
-    {
+    while (it != end) {
         std::string name = it->first;
         rb_ary_push(result, rb_str_new(name.c_str(), name.length()));
         ++it;
@@ -532,22 +485,25 @@ static VALUE registry_available_container(VALUE registry_module)
  *
  * Moreover, the method raises NotFound if +kind+ is not a known container name.
  */
-static VALUE registry_define_container(VALUE registry, VALUE kind, VALUE element, VALUE _size)
-{
-    Registry& reg = rb2cxx::object<Registry>(registry);
-    Type const& element_type(rb2cxx::object<Type>(element));
+static VALUE registry_define_container(VALUE registry, VALUE kind,
+                                       VALUE element, VALUE _size) {
+    Registry &reg = rb2cxx::object<Registry>(registry);
+    Type const &element_type(rb2cxx::object<Type>(element));
     // Check that +reg+ contains +element_type+
     if (!reg.isIncluded(element_type))
-        rb_raise(rb_eArgError, "the given type object comes from a different type registry");
+        rb_raise(rb_eArgError,
+                 "the given type object comes from a different type registry");
 
     try {
-        Container const& new_type = Container::createContainer(reg, StringValuePtr(kind), element_type);
+        Container const &new_type =
+            Container::createContainer(reg, StringValuePtr(kind), element_type);
         size_t size = NUM2INT(_size);
         if (size != 0)
             reg.get_(new_type).setSize(size);
         return cxx2rb::type_wrap(new_type, registry);
-    } catch(Typelib::UnknownContainer) {
-        rb_raise(eNotFound, "%s is not a known container type", StringValuePtr(kind));
+    } catch (Typelib::UnknownContainer) {
+        rb_raise(eNotFound, "%s is not a known container type",
+                 StringValuePtr(kind));
     }
 }
 
@@ -557,12 +513,13 @@ static VALUE registry_define_container(VALUE registry, VALUE kind, VALUE element
  *
  * Adds to +registry+  some standard C/C++ types that Typelib can represent
  */
-static VALUE registry_add_standard_cxx_types(VALUE klass, VALUE registry)
-{
-    Registry& reg = rb2cxx::object<Registry>(registry);
-    try { Typelib::CXX::addStandardTypes(reg); }
-    catch(Typelib::AlreadyDefined e)
-    { rb_raise(rb_eArgError, "%s", e.what()); }
+static VALUE registry_add_standard_cxx_types(VALUE klass, VALUE registry) {
+    Registry &reg = rb2cxx::object<Registry>(registry);
+    try {
+        Typelib::CXX::addStandardTypes(reg);
+    } catch (Typelib::AlreadyDefined e) {
+        rb_raise(rb_eArgError, "%s", e.what());
+    }
     return registry;
 }
 
@@ -572,30 +529,33 @@ static VALUE registry_add_standard_cxx_types(VALUE klass, VALUE registry)
  *
  * Creates a new compound type in which the fields are provided by +field_defs+
  */
-static VALUE registry_create_compound(VALUE registry, VALUE name, VALUE field_defs, VALUE _size)
-{
-    Registry& reg = rb2cxx::object<Registry>(registry);
+static VALUE registry_create_compound(VALUE registry, VALUE name,
+                                      VALUE field_defs, VALUE _size) {
+    Registry &reg = rb2cxx::object<Registry>(registry);
 
-    std::auto_ptr<Typelib::Compound> new_t(new Typelib::Compound(StringValuePtr(name)));
+    std::auto_ptr<Typelib::Compound> new_t(
+        new Typelib::Compound(StringValuePtr(name)));
 
     int field_count = RARRAY_LEN(field_defs);
-    for (int i = 0; i < field_count; ++i)
-    {
+    for (int i = 0; i < field_count; ++i) {
         VALUE field = rb_ary_entry(field_defs, i);
 
         VALUE rb_name = rb_ary_entry(field, 0);
         std::string field_name(StringValuePtr(rb_name));
-        Typelib::Type& field_type(rb2cxx::object<Type>(rb_ary_entry(field, 1)));
+        Typelib::Type &field_type(rb2cxx::object<Type>(rb_ary_entry(field, 1)));
         int offset(NUM2INT(rb_ary_entry(field, 2)));
         new_t->addField(field_name, field_type, offset);
     }
 
-    Typelib::Compound* type = new_t.release();
+    Typelib::Compound *type = new_t.release();
     size_t size = NUM2INT(_size);
     if (size != 0)
         type->setSize(size);
-    try { reg.add(type, true, ""); }
-    catch(std::runtime_error e) { rb_raise(rb_eArgError, "%s", e.what()); }
+    try {
+        reg.add(type, true, "");
+    } catch (std::runtime_error e) {
+        rb_raise(rb_eArgError, "%s", e.what());
+    }
     return cxx2rb::type_wrap(*type, registry);
 }
 
@@ -605,15 +565,14 @@ static VALUE registry_create_compound(VALUE registry, VALUE name, VALUE field_de
  *
  * Creates a new compound type in which the fields are provided by +field_defs+
  */
-static VALUE registry_create_enum(VALUE registry, VALUE name, VALUE symbol_defs, VALUE _size)
-{
-    Registry& reg = rb2cxx::object<Registry>(registry);
+static VALUE registry_create_enum(VALUE registry, VALUE name, VALUE symbol_defs,
+                                  VALUE _size) {
+    Registry &reg = rb2cxx::object<Registry>(registry);
 
     std::auto_ptr<Typelib::Enum> new_t(new Typelib::Enum(StringValuePtr(name)));
 
     int symbol_count = RARRAY_LEN(symbol_defs);
-    for (int i = 0; i < symbol_count; ++i)
-    {
+    for (int i = 0; i < symbol_count; ++i) {
         VALUE sym = rb_ary_entry(symbol_defs, i);
 
         VALUE rb_name = rb_ary_entry(sym, 0);
@@ -622,11 +581,15 @@ static VALUE registry_create_enum(VALUE registry, VALUE name, VALUE symbol_defs,
         new_t->add(sym_name, sym_value);
     }
 
-    Typelib::Enum* type = new_t.release();
+    Typelib::Enum *type = new_t.release();
     size_t size = NUM2INT(_size);
-    if (size != 0) type->setSize(size);
-    try { reg.add(type, true, ""); }
-    catch(std::runtime_error e) { rb_raise(rb_eArgError, "%s", e.what()); }
+    if (size != 0)
+        type->setSize(size);
+    try {
+        reg.add(type, true, "");
+    } catch (std::runtime_error e) {
+        rb_raise(rb_eArgError, "%s", e.what());
+    }
     return cxx2rb::type_wrap(*type, registry);
 }
 
@@ -636,12 +599,15 @@ static VALUE registry_create_enum(VALUE registry, VALUE name, VALUE symbol_defs,
  *
  * Creates a new opaque type with the given name and size
  */
-static VALUE registry_create_opaque(VALUE registry, VALUE _name, VALUE _size)
-{
-    Registry& reg = rb2cxx::object<Registry>(registry);
-    Typelib::Type* type = new Typelib::OpaqueType(StringValuePtr(_name), NUM2INT(_size));
-    try { reg.add(type, true, ""); }
-    catch(std::runtime_error e) { rb_raise(rb_eArgError, "%s", e.what()); }
+static VALUE registry_create_opaque(VALUE registry, VALUE _name, VALUE _size) {
+    Registry &reg = rb2cxx::object<Registry>(registry);
+    Typelib::Type *type =
+        new Typelib::OpaqueType(StringValuePtr(_name), NUM2INT(_size));
+    try {
+        reg.add(type, true, "");
+    } catch (std::runtime_error e) {
+        rb_raise(rb_eArgError, "%s", e.what());
+    }
     return cxx2rb::type_wrap(*type, registry);
 }
 
@@ -651,48 +617,70 @@ static VALUE registry_create_opaque(VALUE registry, VALUE _name, VALUE _size)
  *
  * Creates a new null type with the given name
  */
-static VALUE registry_create_null(VALUE registry, VALUE _name)
-{
-    Registry& reg = rb2cxx::object<Registry>(registry);
-    Typelib::Type* type = new Typelib::NullType(StringValuePtr(_name));
-    try { reg.add(type, true, ""); }
-    catch(std::runtime_error e) { rb_raise(rb_eArgError, "%s", e.what()); }
+static VALUE registry_create_null(VALUE registry, VALUE _name) {
+    Registry &reg = rb2cxx::object<Registry>(registry);
+    Typelib::Type *type = new Typelib::NullType(StringValuePtr(_name));
+    try {
+        reg.add(type, true, "");
+    } catch (std::runtime_error e) {
+        rb_raise(rb_eArgError, "%s", e.what());
+    }
     return cxx2rb::type_wrap(*type, registry);
 }
 
-void typelib_ruby::Typelib_init_registry()
-{
-    VALUE mTypelib  = rb_define_module("Typelib");
+void typelib_ruby::Typelib_init_registry() {
+    VALUE mTypelib = rb_define_module("Typelib");
     cRegistry = rb_define_class_under(mTypelib, "Registry", rb_cObject);
     eNotFound = rb_define_class_under(mTypelib, "NotFound", rb_eRuntimeError);
     rb_define_alloc_func(cRegistry, registry_alloc);
     rb_define_method(cRegistry, "size", RUBY_METHOD_FUNC(registry_size), 0);
     rb_define_method(cRegistry, "get", RUBY_METHOD_FUNC(registry_do_get), 1);
-    rb_define_method(cRegistry, "build", RUBY_METHOD_FUNC(registry_do_build), -1);
-    rb_define_method(cRegistry, "each_type", RUBY_METHOD_FUNC(registry_each_type), 2);
-    // do_import is called by the Ruby-defined import, which formats the 
-    // option hash (if there is one), and can detect the import type by extension
-    rb_define_method(cRegistry, "do_import", RUBY_METHOD_FUNC(registry_import), 4);
-    rb_define_method(cRegistry, "do_export", RUBY_METHOD_FUNC(registry_export), 2);
-    rb_define_method(cRegistry, "merge_xml", RUBY_METHOD_FUNC(registry_merge_xml), 1);
+    rb_define_method(cRegistry, "build", RUBY_METHOD_FUNC(registry_do_build),
+                     -1);
+    rb_define_method(cRegistry, "each_type",
+                     RUBY_METHOD_FUNC(registry_each_type), 2);
+    // do_import is called by the Ruby-defined import, which formats the
+    // option hash (if there is one), and can detect the import type by
+    // extension
+    rb_define_method(cRegistry, "do_import", RUBY_METHOD_FUNC(registry_import),
+                     4);
+    rb_define_method(cRegistry, "do_export", RUBY_METHOD_FUNC(registry_export),
+                     2);
+    rb_define_method(cRegistry, "merge_xml",
+                     RUBY_METHOD_FUNC(registry_merge_xml), 1);
     rb_define_method(cRegistry, "alias", RUBY_METHOD_FUNC(registry_alias), 2);
-    rb_define_method(cRegistry, "clear_aliases", RUBY_METHOD_FUNC(registry_clear_aliases), 0);
-    rb_define_method(cRegistry, "aliases_of", RUBY_METHOD_FUNC(registry_aliases_of), 1);
+    rb_define_method(cRegistry, "clear_aliases",
+                     RUBY_METHOD_FUNC(registry_clear_aliases), 0);
+    rb_define_method(cRegistry, "aliases_of",
+                     RUBY_METHOD_FUNC(registry_aliases_of), 1);
     rb_define_method(cRegistry, "merge", RUBY_METHOD_FUNC(registry_merge), 1);
-    rb_define_method(cRegistry, "do_minimal", RUBY_METHOD_FUNC(registry_minimal), 2);
-    rb_define_method(cRegistry, "includes?", RUBY_METHOD_FUNC(registry_includes_p), 1);
-    rb_define_method(cRegistry, "do_resize", RUBY_METHOD_FUNC(registry_resize), 1);
-    rb_define_method(cRegistry, "reverse_depends", RUBY_METHOD_FUNC(registry_reverse_depends), 1);
+    rb_define_method(cRegistry, "do_minimal",
+                     RUBY_METHOD_FUNC(registry_minimal), 2);
+    rb_define_method(cRegistry, "includes?",
+                     RUBY_METHOD_FUNC(registry_includes_p), 1);
+    rb_define_method(cRegistry, "do_resize", RUBY_METHOD_FUNC(registry_resize),
+                     1);
+    rb_define_method(cRegistry, "reverse_depends",
+                     RUBY_METHOD_FUNC(registry_reverse_depends), 1);
     rb_define_method(cRegistry, "remove", RUBY_METHOD_FUNC(registry_remove), 1);
-    rb_define_method(cRegistry, "source_id_of", RUBY_METHOD_FUNC(registry_source_id_of), 1);
-    rb_define_method(cRegistry, "do_create_compound", RUBY_METHOD_FUNC(registry_create_compound), 3);
-    rb_define_method(cRegistry, "do_create_enum", RUBY_METHOD_FUNC(registry_create_enum), 3);
-    rb_define_method(cRegistry, "create_opaque", RUBY_METHOD_FUNC(registry_create_opaque), 2);
-    rb_define_method(cRegistry, "create_null", RUBY_METHOD_FUNC(registry_create_null), 1);
+    rb_define_method(cRegistry, "source_id_of",
+                     RUBY_METHOD_FUNC(registry_source_id_of), 1);
+    rb_define_method(cRegistry, "do_create_compound",
+                     RUBY_METHOD_FUNC(registry_create_compound), 3);
+    rb_define_method(cRegistry, "do_create_enum",
+                     RUBY_METHOD_FUNC(registry_create_enum), 3);
+    rb_define_method(cRegistry, "create_opaque",
+                     RUBY_METHOD_FUNC(registry_create_opaque), 2);
+    rb_define_method(cRegistry, "create_null",
+                     RUBY_METHOD_FUNC(registry_create_null), 1);
 
-    rb_define_singleton_method(cRegistry, "add_standard_cxx_types", RUBY_METHOD_FUNC(registry_add_standard_cxx_types), 1);
+    rb_define_singleton_method(
+        cRegistry, "add_standard_cxx_types",
+        RUBY_METHOD_FUNC(registry_add_standard_cxx_types), 1);
 
-    rb_define_singleton_method(cRegistry, "available_containers", RUBY_METHOD_FUNC(registry_available_container), 0);
-    rb_define_method(cRegistry, "define_container", RUBY_METHOD_FUNC(registry_define_container), 3);
+    rb_define_singleton_method(cRegistry, "available_containers",
+                               RUBY_METHOD_FUNC(registry_available_container),
+                               0);
+    rb_define_method(cRegistry, "define_container",
+                     RUBY_METHOD_FUNC(registry_define_container), 3);
 }
-

--- a/bindings/ruby/ext/specialized_types.cc
+++ b/bindings/ruby/ext/specialized_types.cc
@@ -12,20 +12,18 @@ using namespace typelib_ruby;
  * Typelib::Compound
  */
 
-static VALUE compound_get_fields(VALUE self)
-{
+static VALUE compound_get_fields(VALUE self) {
     if (self == cCompound)
         return rb_ary_new();
 
-    Type const& type(rb2cxx::object<Type>(self));
-    Compound const& compound(dynamic_cast<Compound const&>(type));
-    Compound::FieldList const& fields(compound.getFields());
+    Type const &type(rb2cxx::object<Type>(self));
+    Compound const &compound(dynamic_cast<Compound const &>(type));
+    Compound::FieldList const &fields(compound.getFields());
     Compound::FieldList::const_iterator it, end = fields.end();
 
-    VALUE registry  = type_get_registry(self);
+    VALUE registry = type_get_registry(self);
     VALUE fieldlist = rb_ary_new();
-    for (it = fields.begin(); it != end; ++it)
-    {
+    for (it = fields.begin(); it != end; ++it) {
         VALUE field_name = rb_str_new2(it->getName().c_str());
         VALUE field_type = cxx2rb::type_wrap(it->getType(), registry);
 
@@ -41,91 +39,91 @@ static VALUE compound_get_fields(VALUE self)
 }
 
 /* Helper function for CompoundType#[] */
-static VALUE compound_field_get(VALUE rbvalue, VALUE name, VALUE raw)
-{ 
+static VALUE compound_field_get(VALUE rbvalue, VALUE name, VALUE raw) {
     VALUE registry = value_get_registry(rbvalue);
     Value value = rb2cxx::object<Value>(rbvalue);
-    if (! value.getData())
+    if (!value.getData())
         return Qnil;
 
-    try { 
+    try {
         Value field_value = value_get_field(value, StringValuePtr(name));
         if (RTEST(raw))
             return cxx2rb::value_wrap(field_value, registry, rbvalue);
-        else return typelib_to_ruby(field_value, registry, rbvalue);
-    } 
-    catch(FieldNotFound)
-    { rb_raise(rb_eArgError, "no field '%s'", StringValuePtr(name)); } 
-    catch(std::exception const& e)
-    { rb_raise(rb_eRuntimeError, "%s", e.what()); }
+        else
+            return typelib_to_ruby(field_value, registry, rbvalue);
+    } catch (FieldNotFound) {
+        rb_raise(rb_eArgError, "no field '%s'", StringValuePtr(name));
+    } catch (std::exception const &e) {
+        rb_raise(rb_eRuntimeError, "%s", e.what());
+    }
 }
 /* Helper function for CompoundType#[]= */
-static VALUE compound_field_set(VALUE self, VALUE name, VALUE newval)
-{ 
-    Value& tlib_value(rb2cxx::object<Value>(self));
+static VALUE compound_field_set(VALUE self, VALUE name, VALUE newval) {
+    Value &tlib_value(rb2cxx::object<Value>(self));
 
     try {
         Value field_value = value_get_field(tlib_value, StringValuePtr(name));
         typelib_from_ruby(field_value, newval);
         return newval;
+    } catch (FieldNotFound) {
+        rb_raise(rb_eArgError, "no field '%s' in '%s'", StringValuePtr(name),
+                 rb_obj_classname(self));
+    } catch (std::exception const &e) {
+        rb_raise(rb_eRuntimeError, "%s", e.what());
     }
-    catch(FieldNotFound)
-    { rb_raise(rb_eArgError, "no field '%s' in '%s'", StringValuePtr(name), rb_obj_classname(self)); }
-    catch(std::exception const& e)
-    { rb_raise(rb_eRuntimeError, "%s", e.what()); }
 }
 
 /* call-seq:
  *  pointer.deference => pointed-to type
  *
- * Returns the value pointed to by +self+ 
+ * Returns the value pointed to by +self+
  */
-static VALUE pointer_deference(VALUE self)
-{
+static VALUE pointer_deference(VALUE self) {
     VALUE pointed_to = rb_iv_get(self, "@points_to");
     if (!NIL_P(pointed_to))
-	return pointed_to;
+        return pointed_to;
 
-    Value const& value(rb2cxx::object<Value>(self));
-    Indirect const& indirect(static_cast<Indirect const&>(value.getType()));
-    
+    Value const &value(rb2cxx::object<Value>(self));
+    Indirect const &indirect(static_cast<Indirect const &>(value.getType()));
+
     VALUE registry = value_get_registry(self);
 
-    void* ptr_value = *reinterpret_cast<void**>(value.getData());
+    void *ptr_value = *reinterpret_cast<void **>(value.getData());
     if (!ptr_value)
         rb_raise(rb_eArgError, "cannot deference a NULL pointer");
 
-    Value new_value(ptr_value, indirect.getIndirection() );
+    Value new_value(ptr_value, indirect.getIndirection());
     return cxx2rb::value_wrap(new_value, registry, Qnil);
 }
-
 
 /* Get the C value associated with a ruby representation of an enum
  * Valid ruby representations are: symbols, strings and integer
  */
-Enum::integral_type rb2cxx::enum_value(VALUE rb_value, Enum const& e)
-{
+Enum::integral_type rb2cxx::enum_value(VALUE rb_value, Enum const &e) {
     // m_value can be either an integer, a symbol or a string
-    if (TYPE(rb_value) == T_FIXNUM)
-    {
+    if (TYPE(rb_value) == T_FIXNUM) {
         Enum::integral_type value = FIX2INT(rb_value);
-        try { 
-            e.get(value); 
+        try {
+            e.get(value);
             return value;
+        } catch (Enum::ValueNotFound) {
         }
-        catch(Enum::ValueNotFound) {  }
-        rb_raise(rb_eArgError, "%i is not a valid value for %s", value, e.getName().c_str());
+        rb_raise(rb_eArgError, "%i is not a valid value for %s", value,
+                 e.getName().c_str());
     }
 
-    char const* name;
+    char const *name;
     if (SYMBOL_P(rb_value))
         name = rb_id2name(SYM2ID(rb_value));
     else
         name = StringValuePtr(rb_value);
 
-    try { return e.get(name); }
-    catch(Enum::SymbolNotFound) {  }
-    rb_raise(rb_eArgError, "%s is not a valid symbol for %s", name, e.getName().c_str());
+    try {
+        return e.get(name);
+    } catch (Enum::SymbolNotFound) {
+    }
+    rb_raise(rb_eArgError, "%s is not a valid symbol for %s", name,
+             e.getName().c_str());
 }
 
 /* call-seq:
@@ -133,21 +131,21 @@ Enum::integral_type rb2cxx::enum_value(VALUE rb_value, Enum const& e)
  *
  * Returns a string array of all the keys defined for this enumeration
  */
-VALUE enum_keys(VALUE self)
-{
+VALUE enum_keys(VALUE self) {
     if (self == cEnum)
         return rb_hash_new();
 
-    Enum const& type = static_cast<Enum const&>(rb2cxx::object<Type>(self));
+    Enum const &type = static_cast<Enum const &>(rb2cxx::object<Type>(self));
 
     VALUE keys = rb_iv_get(self, "@values");
-    if (!NIL_P(keys)) 
+    if (!NIL_P(keys))
         return keys;
 
     keys = rb_hash_new();
     typedef std::list<std::string> string_list;
     string_list names = type.names();
-    for (string_list::const_iterator it = names.begin(); it != names.end(); ++it)
+    for (string_list::const_iterator it = names.begin(); it != names.end();
+         ++it)
         rb_hash_aset(keys, rb_str_new2(it->c_str()), INT2FIX(type.get(*it)));
 
     rb_iv_set(self, "@values", keys);
@@ -159,15 +157,15 @@ VALUE enum_keys(VALUE self)
  *
  * Returns the integral value asoociated with the given name.
  */
-static VALUE enum_value_of(VALUE self, VALUE name)
-{
-    Enum const& type = static_cast<Enum const&>(rb2cxx::object<Type>(self));
+static VALUE enum_value_of(VALUE self, VALUE name) {
+    Enum const &type = static_cast<Enum const &>(rb2cxx::object<Type>(self));
 
     try {
         int value = type.get(StringValuePtr(name));
         return INT2NUM(value);
     } catch (Enum::SymbolNotFound) {
-        rb_raise(rb_eArgError, "this enumeration has no value for %s", StringValuePtr(name));
+        rb_raise(rb_eArgError, "this enumeration has no value for %s",
+                 StringValuePtr(name));
     }
 }
 
@@ -177,15 +175,15 @@ static VALUE enum_value_of(VALUE self, VALUE name)
  * Returns the symbolic name of +integer+ in this enumeration, or raises
  * ArgumentError if there is no matching name.
  */
-static VALUE enum_name_of(VALUE self, VALUE integer)
-{
-    Enum const& type = static_cast<Enum const&>(rb2cxx::object<Type>(self));
+static VALUE enum_name_of(VALUE self, VALUE integer) {
+    Enum const &type = static_cast<Enum const &>(rb2cxx::object<Type>(self));
 
     try {
         std::string name = type.get(NUM2INT(integer));
         return rb_str_new2(name.c_str());
     } catch (Enum::ValueNotFound) {
-        rb_raise(rb_eArgError, "this enumeration has no name for %i", NUM2INT(integer));
+        rb_raise(rb_eArgError, "this enumeration has no name for %i",
+                 NUM2INT(integer));
     }
 }
 
@@ -198,30 +196,27 @@ static VALUE enum_name_of(VALUE self, VALUE integer)
  *
  * Returns the type referenced by this one
  */
-static VALUE indirect_type_deference(VALUE self)
-{
+static VALUE indirect_type_deference(VALUE self) {
     VALUE registry = type_get_registry(self);
-    Type const& type(rb2cxx::object<Type>(self));
-    Indirect const& indirect(static_cast<Indirect const&>(type));
+    Type const &type(rb2cxx::object<Type>(self));
+    Indirect const &indirect(static_cast<Indirect const &>(type));
     return cxx2rb::type_wrap(indirect.getIndirection(), registry);
 }
 
-
-static Value array_element(VALUE rbarray, VALUE rbindex)
-{
-    Value& value(rb2cxx::object<Value>(rbarray));
-    Array const& array(static_cast<Array const&>(value.getType()));
+static Value array_element(VALUE rbarray, VALUE rbindex) {
+    Value &value(rb2cxx::object<Value>(rbarray));
+    Array const &array(static_cast<Array const &>(value.getType()));
     size_t index = NUM2INT(rbindex);
-    
-    if (index >= array.getDimension())
-    {
-        rb_raise(rb_eIndexError, "Out of bounds: %lu > %lu", index, array.getDimension());
+
+    if (index >= array.getDimension()) {
+        rb_raise(rb_eIndexError, "Out of bounds: %lu > %lu", index,
+                 array.getDimension());
         return Value();
     }
 
-    Type const& array_type(array.getIndirection());
+    Type const &array_type(array.getIndirection());
 
-    int8_t* data = reinterpret_cast<int8_t*>(value.getData());
+    int8_t *data = reinterpret_cast<int8_t *>(value.getData());
     data += array_type.getSize() * index;
     return Value(data, array_type);
 }
@@ -233,45 +228,41 @@ static Value array_element(VALUE rbarray, VALUE rbindex)
  * dynamically extensible, trying to set a non-existent index will raise an
  * IndexError exception.
  */
-static VALUE array_get(int argc, VALUE* argv, VALUE self)
-{ 
-    Value& value            = rb2cxx::object<Value>(self);
-    Array const& array      = static_cast<Array const&>(value.getType());
+static VALUE array_get(int argc, VALUE *argv, VALUE self) {
+    Value &value = rb2cxx::object<Value>(self);
+    Array const &array = static_cast<Array const &>(value.getType());
     if (array.getDimension() == 0)
-	return self;
+        return self;
 
-    Type  const& array_type = array.getIndirection();
-    VALUE registry          = value_get_registry(self);
+    Type const &array_type = array.getIndirection();
+    VALUE registry = value_get_registry(self);
 
-    int8_t* data = reinterpret_cast<int8_t*>(value.getData());
+    int8_t *data = reinterpret_cast<int8_t *>(value.getData());
     size_t index = NUM2INT(argv[0]);
     if (index >= array.getDimension())
-	rb_raise(rb_eIndexError, "Out of bounds: %li > %li", index, array.getDimension());
+        rb_raise(rb_eIndexError, "Out of bounds: %li > %li", index,
+                 array.getDimension());
 
-    if (argc == 1)
-    {
-	Value v = Value(data + array_type.getSize() * index, array_type);
-	return cxx2rb::value_wrap( v, registry, self );
-    }
-    else if (argc == 2)
-    {
-	VALUE ret = rb_ary_new();
-	size_t size = NUM2INT(argv[1]);
-	if (index + size > array.getDimension())
-	    rb_raise(rb_eIndexError, "Out of bounds: %li > %li", index + size - 1, array.getDimension());
+    if (argc == 1) {
+        Value v = Value(data + array_type.getSize() * index, array_type);
+        return cxx2rb::value_wrap(v, registry, self);
+    } else if (argc == 2) {
+        VALUE ret = rb_ary_new();
+        size_t size = NUM2INT(argv[1]);
+        if (index + size > array.getDimension())
+            rb_raise(rb_eIndexError, "Out of bounds: %li > %li",
+                     index + size - 1, array.getDimension());
 
-	for (size_t i = index; i < index + size; ++i)
-	{
-	    Value v = Value(data + array_type.getSize() * i, array_type);
-	    VALUE rb_v = cxx2rb::value_wrap( v, registry, self );
+        for (size_t i = index; i < index + size; ++i) {
+            Value v = Value(data + array_type.getSize() * i, array_type);
+            VALUE rb_v = cxx2rb::value_wrap(v, registry, self);
 
-	    rb_ary_push(ret, rb_v);
-	}
+            rb_ary_push(ret, rb_v);
+        }
 
-	return ret;
-    }
-    else
-	rb_raise(rb_eArgError, "invalid argument count (%i for 1 or 2)", argc);
+        return ret;
+    } else
+        rb_raise(rb_eArgError, "invalid argument count (%i for 1 or 2)", argc);
 }
 
 /* call-seq:
@@ -281,10 +272,9 @@ static VALUE array_get(int argc, VALUE* argv, VALUE self)
  * dynamically extensible, trying to set a non-existent index will raise an
  * IndexError exception.
  */
-static VALUE array_set(VALUE self, VALUE rbindex, VALUE newvalue)
-{ 
+static VALUE array_set(VALUE self, VALUE rbindex, VALUE newvalue) {
     Value element = array_element(self, rbindex);
-    return typelib_from_ruby(element, newvalue); 
+    return typelib_from_ruby(element, newvalue);
 }
 
 /* call-seq:
@@ -292,20 +282,21 @@ static VALUE array_set(VALUE self, VALUE rbindex, VALUE newvalue)
  *
  * Iterates on all elements of the array
  */
-static VALUE array_do_each(VALUE rbarray)
-{
-    Value& value            = rb2cxx::object<Value>(rbarray);
-    Array const& array      = static_cast<Array const&>(value.getType());
+static VALUE array_do_each(VALUE rbarray) {
+    Value &value = rb2cxx::object<Value>(rbarray);
+    Array const &array = static_cast<Array const &>(value.getType());
     if (array.getDimension() == 0)
-	return rbarray;
+        return rbarray;
 
-    Type  const& array_type = array.getIndirection();
-    VALUE registry          = value_get_registry(rbarray);
+    Type const &array_type = array.getIndirection();
+    VALUE registry = value_get_registry(rbarray);
 
-    int8_t* data = reinterpret_cast<int8_t*>(value.getData());
+    int8_t *data = reinterpret_cast<int8_t *>(value.getData());
 
-    for (size_t i = 0; i < array.getDimension(); ++i, data += array_type.getSize())
-	rb_yield(cxx2rb::value_wrap( Value(data, array_type), registry, rbarray ));
+    for (size_t i = 0; i < array.getDimension();
+         ++i, data += array_type.getSize())
+        rb_yield(
+            cxx2rb::value_wrap(Value(data, array_type), registry, rbarray));
 
     return rbarray;
 }
@@ -315,10 +306,9 @@ static VALUE array_do_each(VALUE rbarray)
  *
  * Returns the count of elements in +array+
  */
-static VALUE array_size(VALUE rbarray)
-{
-    Value& value(rb2cxx::object<Value>(rbarray));
-    Array const& array(static_cast<Array const&>(value.getType()));
+static VALUE array_size(VALUE rbarray) {
+    Value &value(rb2cxx::object<Value>(rbarray));
+    Array const &array(static_cast<Array const &>(value.getType()));
     return INT2FIX(array.getDimension());
 }
 
@@ -327,9 +317,9 @@ static VALUE array_size(VALUE rbarray)
  *
  * Returns the count of elemnts in +array+
  */
-static VALUE array_class_length(VALUE rbarray)
-{
-    Array const& array(dynamic_cast<Array const&>(rb2cxx::object<Type>(rbarray)));
+static VALUE array_class_length(VALUE rbarray) {
+    Array const &array(
+        dynamic_cast<Array const &>(rb2cxx::object<Type>(rbarray)));
     return INT2FIX(array.getDimension());
 }
 
@@ -337,12 +327,11 @@ static VALUE array_class_length(VALUE rbarray)
  * call-seq:
  *  pointer.null?		=> boolean
  *
- * checks if this is a NULL pointer 
+ * checks if this is a NULL pointer
  */
-static VALUE pointer_nil_p(VALUE self)
-{
-    Value const& value(rb2cxx::object<Value>(self));
-    if ( *reinterpret_cast<void**>(value.getData()) == 0 )
+static VALUE pointer_nil_p(VALUE self) {
+    Value const &value(rb2cxx::object<Value>(self));
+    if (*reinterpret_cast<void **>(value.getData()) == 0)
         return Qtrue;
     return Qfalse;
 }
@@ -351,11 +340,12 @@ static VALUE pointer_nil_p(VALUE self)
  * call-seq:
  *  numeric.integer?	    => true or false
  *
- * Returns true if the type is an integral type and false if it is a floating-point type
+ * Returns true if the type is an integral type and false if it is a
+ *floating-point type
  */
-static VALUE numeric_type_integer_p(VALUE self)
-{
-    Numeric const& type(dynamic_cast<Numeric const&>(rb2cxx::object<Type>(self)));
+static VALUE numeric_type_integer_p(VALUE self) {
+    Numeric const &type(
+        dynamic_cast<Numeric const &>(rb2cxx::object<Type>(self)));
     return type.getNumericCategory() == Numeric::Float ? Qfalse : Qtrue;
 }
 
@@ -365,9 +355,9 @@ static VALUE numeric_type_integer_p(VALUE self)
  *
  * The size of this type in bytes
  */
-static VALUE numeric_type_size(VALUE self)
-{
-    Numeric const& type(dynamic_cast<Numeric const&>(rb2cxx::object<Type>(self)));
+static VALUE numeric_type_size(VALUE self) {
+    Numeric const &type(
+        dynamic_cast<Numeric const &>(rb2cxx::object<Type>(self)));
     return INT2FIX(type.getSize());
 }
 
@@ -378,19 +368,19 @@ static VALUE numeric_type_size(VALUE self)
  * If integer? returns true, returns whether this type is an unsigned or signed
  * integral type.
  */
-static VALUE numeric_type_unsigned_p(VALUE self)
-{
-    Numeric const& type(dynamic_cast<Numeric const&>(rb2cxx::object<Type>(self)));
-    switch(type.getNumericCategory())
-    {
-	case Numeric::SInt: return Qfalse;
-	case Numeric::UInt: return Qtrue;
-	case Numeric::Float:
-	    rb_raise(rb_eArgError, "not an integral type");
+static VALUE numeric_type_unsigned_p(VALUE self) {
+    Numeric const &type(
+        dynamic_cast<Numeric const &>(rb2cxx::object<Type>(self)));
+    switch (type.getNumericCategory()) {
+    case Numeric::SInt:
+        return Qfalse;
+    case Numeric::UInt:
+        return Qtrue;
+    case Numeric::Float:
+        rb_raise(rb_eArgError, "not an integral type");
     }
     return Qnil; // never reached
 }
-
 
 /*
  * call-seq:
@@ -399,9 +389,9 @@ static VALUE numeric_type_unsigned_p(VALUE self)
  * Returns the name of the generic container. For instance, a
  * /std/vector</double> type would return /std/vector.
  */
-static VALUE container_kind(VALUE self)
-{
-    Container const& type(dynamic_cast<Container const&>(rb2cxx::object<Type>(self)));
+static VALUE container_kind(VALUE self) {
+    Container const &type(
+        dynamic_cast<Container const &>(rb2cxx::object<Type>(self)));
     return rb_str_new2(type.kind().c_str());
 }
 
@@ -413,9 +403,9 @@ static VALUE container_kind(VALUE self)
  * the value returned by size() in case a registry has been generated on a
  * different architecture.
  */
-static VALUE container_natural_size(VALUE self)
-{
-    Container const& type(dynamic_cast<Container const&>(rb2cxx::object<Type>(self)));
+static VALUE container_natural_size(VALUE self) {
+    Container const &type(
+        dynamic_cast<Container const &>(rb2cxx::object<Type>(self)));
     return INT2FIX(type.getNaturalSize());
 }
 
@@ -425,12 +415,11 @@ static VALUE container_natural_size(VALUE self)
  *
  * Returns true if this container type is a random access container
  */
-static VALUE container_random_access_p(VALUE self)
-{
-    Container const& type(dynamic_cast<Container const&>(rb2cxx::object<Type>(self)));
+static VALUE container_random_access_p(VALUE self) {
+    Container const &type(
+        dynamic_cast<Container const &>(rb2cxx::object<Type>(self)));
     return type.isRandomAccess() ? Qtrue : Qfalse;
 }
-
 
 /*
  * call-seq:
@@ -438,10 +427,9 @@ static VALUE container_random_access_p(VALUE self)
  *
  * Returns the count of elements in +container+
  */
-static VALUE container_length(VALUE self)
-{
+static VALUE container_length(VALUE self) {
     Value value = rb2cxx::object<Value>(self);
-    Container const& type(dynamic_cast<Container const&>(value.getType()));
+    Container const &type(dynamic_cast<Container const &>(value.getType()));
 
     return INT2NUM(type.getElementCount(value.getData()));
 }
@@ -452,82 +440,81 @@ static VALUE container_length(VALUE self)
  *
  * Removes all elements from that container
  */
-static VALUE container_clear(VALUE self)
-{
+static VALUE container_clear(VALUE self) {
     Value value = rb2cxx::object<Value>(self);
-    Container const& type(dynamic_cast<Container const&>(value.getType()));
+    Container const &type(dynamic_cast<Container const &>(value.getType()));
 
     type.clear(value.getData());
     return Qnil;
 }
 
-static Typelib::Value container_element(uint64_t* buffer10, Type const& element_t, VALUE obj)
-{
+static Typelib::Value container_element(uint64_t *buffer10,
+                                        Type const &element_t, VALUE obj) {
     Typelib::Value element_v;
-    if (element_t.getCategory() == Type::Numeric && sizeof(int64_t) * 10 >= element_t.getSize())
-    {
+    if (element_t.getCategory() == Type::Numeric &&
+        sizeof(int64_t) * 10 >= element_t.getSize()) {
         // Special case: allow the caller to use Ruby numeric directly. This is
         // way faster if a lot of insertions need to be done
         element_v = Value(buffer10, element_t);
         typelib_from_ruby(element_v, obj);
-    }
-    else
-    {
-        element_v   = rb2cxx::object<Value>(obj);
+    } else {
+        element_v = rb2cxx::object<Value>(obj);
         if (element_t != element_v.getType())
-            rb_raise(rb_eArgError, "wrong type %s for new element, expected %s", element_v.getType().getName().c_str(), element_t.getName().c_str());
+            rb_raise(rb_eArgError, "wrong type %s for new element, expected %s",
+                     element_v.getType().getName().c_str(),
+                     element_t.getName().c_str());
     }
     return element_v;
 }
 
-static VALUE container_do_push(VALUE self, VALUE obj)
-{
+static VALUE container_do_push(VALUE self, VALUE obj) {
     Value container_v = rb2cxx::object<Value>(self);
-    Container const& container_t(dynamic_cast<Container const&>(container_v.getType()));
+    Container const &container_t(
+        dynamic_cast<Container const &>(container_v.getType()));
 
     uint64_t buffer[10];
-    Value element_v = container_element(buffer, container_t.getIndirection(), obj);
+    Value element_v =
+        container_element(buffer, container_t.getIndirection(), obj);
     container_t.push(container_v.getData(), element_v);
     return self;
 }
 
-static VALUE container_do_set(VALUE self, VALUE index, VALUE obj)
-{
+static VALUE container_do_set(VALUE self, VALUE index, VALUE obj) {
     Value container_v = rb2cxx::object<Value>(self);
-    Container const& container_t(dynamic_cast<Container const&>(container_v.getType()));
+    Container const &container_t(
+        dynamic_cast<Container const &>(container_v.getType()));
 
     uint64_t buffer[10];
-    Value element_v = container_element(buffer, container_t.getIndirection(), obj);
+    Value element_v =
+        container_element(buffer, container_t.getIndirection(), obj);
     container_t.setElement(container_v.getData(), NUM2INT(index), element_v);
     return self;
 }
 
-static VALUE container_do_get(VALUE self, VALUE index, VALUE raw)
-{
+static VALUE container_do_get(VALUE self, VALUE index, VALUE raw) {
     Value container_v = rb2cxx::object<Value>(self);
-    Container const& container_t(dynamic_cast<Container const&>(container_v.getType()));
+    Container const &container_t(
+        dynamic_cast<Container const &>(container_v.getType()));
     VALUE registry = value_get_registry(self);
 
     Value v = container_t.getElement(container_v.getData(), NUM2INT(index));
     if (RTEST(raw))
         return cxx2rb::value_wrap(v, registry, self);
-    else return typelib_to_ruby(v, registry, self);
+    else
+        return typelib_to_ruby(v, registry, self);
 }
 
-struct ContainerIterator : public ValueVisitor
-{
+struct ContainerIterator : public ValueVisitor {
     VALUE m_registry;
     VALUE m_parent;
     bool m_raw;
 
-    ContainerIterator(VALUE registry, VALUE parent, bool raw)
-    {
+    ContainerIterator(VALUE registry, VALUE parent, bool raw) {
         m_registry = registry;
         m_parent = parent;
         m_raw = raw;
     }
-    virtual void dispatch(Value v)
-    {
+    virtual void dispatch(Value v) {
         if (m_raw)
             rb_yield(cxx2rb::value_wrap(v, m_registry, m_parent));
         else
@@ -541,12 +528,12 @@ struct ContainerIterator : public ValueVisitor
  *
  * Iterates on the elements of the container
  */
-static VALUE container_each(VALUE self, VALUE raw)
-{
+static VALUE container_each(VALUE self, VALUE raw) {
     Value value = rb2cxx::object<Value>(self);
     VALUE registry = value_get_registry(self);
     ContainerIterator iterator(registry, self, RTEST(raw));
-    dynamic_cast<Typelib::Container const&>(value.getType()).visit(value.getData(), iterator);
+    dynamic_cast<Typelib::Container const &>(value.getType())
+        .visit(value.getData(), iterator);
     return self;
 }
 
@@ -557,13 +544,14 @@ static VALUE container_each(VALUE self, VALUE raw)
  * Removes +obj+ from the container. Returns true if +obj+ has been found and
  * deleted, and false otherwise
  */
-static VALUE container_erase(VALUE self, VALUE obj)
-{
+static VALUE container_erase(VALUE self, VALUE obj) {
     Value container_v = rb2cxx::object<Value>(self);
-    Container const& container_t(dynamic_cast<Container const&>(container_v.getType()));
+    Container const &container_t(
+        dynamic_cast<Container const &>(container_v.getType()));
 
     uint64_t buffer[10];
-    Value element_v = container_element(buffer, container_t.getIndirection(), obj);
+    Value element_v =
+        container_element(buffer, container_t.getIndirection(), obj);
 
     if (container_t.erase(container_v.getData(), element_v))
         return Qtrue;
@@ -571,8 +559,7 @@ static VALUE container_erase(VALUE self, VALUE obj)
         return Qfalse;
 }
 
-bool container_delete_if_i(Value v, VALUE registry, VALUE container)
-{
+bool container_delete_if_i(Value v, VALUE registry, VALUE container) {
     VALUE rb_v = cxx2rb::value_wrap(v, registry, container);
     if (RTEST(rb_yield(rb_v)))
         return true;
@@ -585,13 +572,15 @@ bool container_delete_if_i(Value v, VALUE registry, VALUE container)
  *
  * Removes the elements in the container for which the block returns true.
  */
-static VALUE container_delete_if(VALUE self)
-{
+static VALUE container_delete_if(VALUE self) {
     Value container_v = rb2cxx::object<Value>(self);
-    Container const& container_t(dynamic_cast<Container const&>(container_v.getType()));
+    Container const &container_t(
+        dynamic_cast<Container const &>(container_v.getType()));
 
     VALUE registry = value_get_registry(self);
-    container_t.delete_if(container_v.getData(), boost::bind(container_delete_if_i, _1, registry, self));
+    container_t.delete_if(
+        container_v.getData(),
+        boost::bind(container_delete_if_i, _1, registry, self));
     return self;
 }
 
@@ -601,10 +590,10 @@ static VALUE container_delete_if(VALUE self)
  *
  * (see ContainerType#contained_memory_id)
  */
-static VALUE vector_contained_memory_id(VALUE self)
-{
+static VALUE vector_contained_memory_id(VALUE self) {
     Value container_v = rb2cxx::object<Value>(self);
-    std::vector<uint8_t> const* vector = reinterpret_cast<std::vector<uint8_t>*>(container_v.getData());
+    std::vector<uint8_t> const *vector =
+        reinterpret_cast<std::vector<uint8_t> *>(container_v.getData());
     if (vector->empty())
         return Qnil;
     return ULL2NUM(reinterpret_cast<uint64_t>(&(*vector)[0]));
@@ -614,41 +603,40 @@ static VALUE vector_contained_memory_id(VALUE self)
  * call-seq:
  *  vector.raw_memcopy(source,size) => nil
  */
-static VALUE vector_raw_memcpy(VALUE self,VALUE _source,VALUE _size)
-{
+static VALUE vector_raw_memcpy(VALUE self, VALUE _source, VALUE _size) {
     Value container_v = rb2cxx::object<Value>(self);
     bool is_memcpy = false;
-    try
-    {
+    try {
         MemoryLayout ops = Typelib::layout_of(container_v.getType());
         is_memcpy = (ops.size() == 2 && ops[0] == MemLayout::FLAG_MEMCPY);
+    } catch (std::runtime_error) { /* No layout for this type.*/
     }
-    catch(std::runtime_error) {/* No layout for this type.*/}
-    if(!is_memcpy)
+    if (!is_memcpy)
         rb_raise(rb_eTypeError, "memcpy is not supported for this type");
 
-    std::vector<uint8_t> *vector = reinterpret_cast<std::vector<uint8_t>*>(container_v.getData());
+    std::vector<uint8_t> *vector =
+        reinterpret_cast<std::vector<uint8_t> *>(container_v.getData());
     size_t size = NUM2UINT(_size);
-    const void *source = reinterpret_cast<const void*>(NUM2ULL(_source));
+    const void *source = reinterpret_cast<const void *>(NUM2ULL(_source));
     vector->resize(size);
-    memcpy(&(*vector)[0],source,size);
+    memcpy(&(*vector)[0], source, size);
     return Qnil;
 }
 
-/* 
+/*
  * call-seq:
  *   to_ruby(value)	=> non-Typelib object or self
  *
  * Converts +self+ to its Ruby equivalent. If no equivalent
  * type is available, returns self
  */
-static VALUE numeric_to_ruby(VALUE mod, VALUE self)
-{
-    Value const& value(rb2cxx::object<Value>(self));
+static VALUE numeric_to_ruby(VALUE mod, VALUE self) {
+    Value const &value(rb2cxx::object<Value>(self));
     VALUE registry = value_get_registry(self);
     try {
-	return typelib_to_ruby(value, registry, Qnil);
-    } catch(Typelib::NullTypeFound) { }
+        return typelib_to_ruby(value, registry, Qnil);
+    } catch (Typelib::NullTypeFound) {
+    }
     rb_raise(rb_eTypeError, "trying to convert 'void'");
 }
 
@@ -661,16 +649,15 @@ static VALUE numeric_to_ruby(VALUE mod, VALUE self)
  * This particular method is not type-safe. You should use Typelib.from_ruby
  * unless you know what you are doing.
  */
-static VALUE numeric_from_ruby(VALUE self, VALUE arg)
-{
-    Value& value(rb2cxx::object<Value>(self));
+static VALUE numeric_from_ruby(VALUE self, VALUE arg) {
+    Value &value(rb2cxx::object<Value>(self));
     try {
-	typelib_from_ruby(value, arg);
+        typelib_from_ruby(value, arg);
         return self;
-    } catch(Typelib::UnsupportedType) { }
+    } catch (Typelib::UnsupportedType) {
+    }
     rb_raise(rb_eTypeError, "cannot perform the requested convertion");
 }
-
 
 /* Document-class: Typelib::NumericType
  *
@@ -696,61 +683,87 @@ static VALUE numeric_from_ruby(VALUE self, VALUE arg)
  * structures have consecutive offsets.
  */
 
-void typelib_ruby::Typelib_init_specialized_types()
-{
-    VALUE mTypelib  = rb_define_module("Typelib");
-    cNumeric   = rb_define_class_under(mTypelib, "NumericType", cType);
-    rb_define_singleton_method(cNumeric, "integer?", RUBY_METHOD_FUNC(numeric_type_integer_p), 0);
-    rb_define_singleton_method(cNumeric, "unsigned?", RUBY_METHOD_FUNC(numeric_type_unsigned_p), 0);
-    rb_define_singleton_method(cNumeric, "size", RUBY_METHOD_FUNC(numeric_type_size), 0);
-    rb_define_singleton_method(cNumeric, "to_ruby", RUBY_METHOD_FUNC(&numeric_to_ruby), 1);
-    rb_define_method(cNumeric, "typelib_from_ruby", RUBY_METHOD_FUNC(&numeric_from_ruby), 1);
+void typelib_ruby::Typelib_init_specialized_types() {
+    VALUE mTypelib = rb_define_module("Typelib");
+    cNumeric = rb_define_class_under(mTypelib, "NumericType", cType);
+    rb_define_singleton_method(cNumeric, "integer?",
+                               RUBY_METHOD_FUNC(numeric_type_integer_p), 0);
+    rb_define_singleton_method(cNumeric, "unsigned?",
+                               RUBY_METHOD_FUNC(numeric_type_unsigned_p), 0);
+    rb_define_singleton_method(cNumeric, "size",
+                               RUBY_METHOD_FUNC(numeric_type_size), 0);
+    rb_define_singleton_method(cNumeric, "to_ruby",
+                               RUBY_METHOD_FUNC(&numeric_to_ruby), 1);
+    rb_define_method(cNumeric, "typelib_from_ruby",
+                     RUBY_METHOD_FUNC(&numeric_from_ruby), 1);
 
-    cOpaque    = rb_define_class_under(mTypelib, "OpaqueType", cType);
-    cNull      = rb_define_class_under(mTypelib, "NullType", cType);
+    cOpaque = rb_define_class_under(mTypelib, "OpaqueType", cType);
+    cNull = rb_define_class_under(mTypelib, "NullType", cType);
 
-    cIndirect  = rb_define_class_under(mTypelib, "IndirectType", cType);
-    rb_define_singleton_method(cIndirect, "deference",    RUBY_METHOD_FUNC(indirect_type_deference), 0);
+    cIndirect = rb_define_class_under(mTypelib, "IndirectType", cType);
+    rb_define_singleton_method(cIndirect, "deference",
+                               RUBY_METHOD_FUNC(indirect_type_deference), 0);
 
-    cPointer  = rb_define_class_under(mTypelib, "PointerType", cIndirect);
-    rb_define_method(cPointer, "deference", RUBY_METHOD_FUNC(pointer_deference), 0);
+    cPointer = rb_define_class_under(mTypelib, "PointerType", cIndirect);
+    rb_define_method(cPointer, "deference", RUBY_METHOD_FUNC(pointer_deference),
+                     0);
     rb_define_method(cPointer, "null?", RUBY_METHOD_FUNC(pointer_nil_p), 0);
-    
+
     cCompound = rb_define_class_under(mTypelib, "CompoundType", cType);
-    rb_define_singleton_method(cCompound, "get_fields",   RUBY_METHOD_FUNC(compound_get_fields), 0);
-    rb_define_method(cCompound, "typelib_get_field", RUBY_METHOD_FUNC(compound_field_get), 2);
-    rb_define_method(cCompound, "typelib_set_field", RUBY_METHOD_FUNC(compound_field_set), 2);
+    rb_define_singleton_method(cCompound, "get_fields",
+                               RUBY_METHOD_FUNC(compound_get_fields), 0);
+    rb_define_method(cCompound, "typelib_get_field",
+                     RUBY_METHOD_FUNC(compound_field_get), 2);
+    rb_define_method(cCompound, "typelib_set_field",
+                     RUBY_METHOD_FUNC(compound_field_set), 2);
 
     cEnum = rb_define_class_under(mTypelib, "EnumType", cType);
     rb_define_singleton_method(cEnum, "keys", RUBY_METHOD_FUNC(enum_keys), 0);
-    rb_define_singleton_method(cEnum, "value_of",      RUBY_METHOD_FUNC(enum_value_of), 1);
-    rb_define_singleton_method(cEnum, "name_of",      RUBY_METHOD_FUNC(enum_name_of), 1);
-    rb_define_singleton_method(cEnum, "to_ruby",      RUBY_METHOD_FUNC(&numeric_to_ruby), 1);
-    rb_define_method(cEnum, "typelib_from_ruby",    RUBY_METHOD_FUNC(&numeric_from_ruby), 1);
+    rb_define_singleton_method(cEnum, "value_of",
+                               RUBY_METHOD_FUNC(enum_value_of), 1);
+    rb_define_singleton_method(cEnum, "name_of", RUBY_METHOD_FUNC(enum_name_of),
+                               1);
+    rb_define_singleton_method(cEnum, "to_ruby",
+                               RUBY_METHOD_FUNC(&numeric_to_ruby), 1);
+    rb_define_method(cEnum, "typelib_from_ruby",
+                     RUBY_METHOD_FUNC(&numeric_from_ruby), 1);
 
-    cArray    = rb_define_class_under(mTypelib, "ArrayType", cIndirect);
-    rb_define_singleton_method(cArray, "length", RUBY_METHOD_FUNC(array_class_length), 0);
-    rb_define_method(cArray, "do_get",  RUBY_METHOD_FUNC(array_get), -1);
-    rb_define_method(cArray, "do_set",  RUBY_METHOD_FUNC(array_set), 2);
-    rb_define_method(cArray, "do_each",    RUBY_METHOD_FUNC(array_do_each), 0);
-    rb_define_method(cArray, "size",    RUBY_METHOD_FUNC(array_size), 0);
+    cArray = rb_define_class_under(mTypelib, "ArrayType", cIndirect);
+    rb_define_singleton_method(cArray, "length",
+                               RUBY_METHOD_FUNC(array_class_length), 0);
+    rb_define_method(cArray, "do_get", RUBY_METHOD_FUNC(array_get), -1);
+    rb_define_method(cArray, "do_set", RUBY_METHOD_FUNC(array_set), 2);
+    rb_define_method(cArray, "do_each", RUBY_METHOD_FUNC(array_do_each), 0);
+    rb_define_method(cArray, "size", RUBY_METHOD_FUNC(array_size), 0);
 
     cContainer = rb_define_class_under(mTypelib, "ContainerType", cIndirect);
-    rb_define_singleton_method(cContainer, "container_kind", RUBY_METHOD_FUNC(container_kind), 0);
-    rb_define_singleton_method(cContainer, "natural_size",   RUBY_METHOD_FUNC(container_natural_size), 0);
-    rb_define_singleton_method(cContainer, "random_access?",   RUBY_METHOD_FUNC(container_random_access_p), 0);
-    rb_define_method(cContainer, "length",    RUBY_METHOD_FUNC(container_length), 0);
-    rb_define_method(cContainer, "size",    RUBY_METHOD_FUNC(container_length), 0);
-    rb_define_method(cContainer, "do_clear",    RUBY_METHOD_FUNC(container_clear), 0);
-    rb_define_method(cContainer, "do_push",    RUBY_METHOD_FUNC(container_do_push), 1);
-    rb_define_method(cContainer, "do_get",    RUBY_METHOD_FUNC(container_do_get), 2);
-    rb_define_method(cContainer, "do_set",    RUBY_METHOD_FUNC(container_do_set), 2);
-    rb_define_method(cContainer, "do_each",      RUBY_METHOD_FUNC(container_each), 1);
-    rb_define_method(cContainer, "do_erase",     RUBY_METHOD_FUNC(container_erase), 1);
-    rb_define_method(cContainer, "do_delete_if", RUBY_METHOD_FUNC(container_delete_if), 0);
+    rb_define_singleton_method(cContainer, "container_kind",
+                               RUBY_METHOD_FUNC(container_kind), 0);
+    rb_define_singleton_method(cContainer, "natural_size",
+                               RUBY_METHOD_FUNC(container_natural_size), 0);
+    rb_define_singleton_method(cContainer, "random_access?",
+                               RUBY_METHOD_FUNC(container_random_access_p), 0);
+    rb_define_method(cContainer, "length", RUBY_METHOD_FUNC(container_length),
+                     0);
+    rb_define_method(cContainer, "size", RUBY_METHOD_FUNC(container_length), 0);
+    rb_define_method(cContainer, "do_clear", RUBY_METHOD_FUNC(container_clear),
+                     0);
+    rb_define_method(cContainer, "do_push", RUBY_METHOD_FUNC(container_do_push),
+                     1);
+    rb_define_method(cContainer, "do_get", RUBY_METHOD_FUNC(container_do_get),
+                     2);
+    rb_define_method(cContainer, "do_set", RUBY_METHOD_FUNC(container_do_set),
+                     2);
+    rb_define_method(cContainer, "do_each", RUBY_METHOD_FUNC(container_each),
+                     1);
+    rb_define_method(cContainer, "do_erase", RUBY_METHOD_FUNC(container_erase),
+                     1);
+    rb_define_method(cContainer, "do_delete_if",
+                     RUBY_METHOD_FUNC(container_delete_if), 0);
 
     VALUE mVector = rb_define_module_under(cContainer, "StdVector");
-    rb_define_method(mVector, "contained_memory_id", RUBY_METHOD_FUNC(vector_contained_memory_id), 0);
-    rb_define_method(mVector, "raw_memcpy", RUBY_METHOD_FUNC(vector_raw_memcpy), 2);
+    rb_define_method(mVector, "contained_memory_id",
+                     RUBY_METHOD_FUNC(vector_contained_memory_id), 0);
+    rb_define_method(mVector, "raw_memcpy", RUBY_METHOD_FUNC(vector_raw_memcpy),
+                     2);
 }
-

--- a/bindings/ruby/ext/strings.cc
+++ b/bindings/ruby/ext/strings.cc
@@ -5,45 +5,42 @@ using namespace Typelib;
 using std::string;
 using namespace typelib_ruby;
 
-static bool is_string_handler(Registry const& registry, Type const& type, bool known_size = false)
-{
-    if (type.getCategory() != Type::Array && type.getCategory() != Type::Pointer)
+static bool is_string_handler(Registry const &registry, Type const &type,
+                              bool known_size = false) {
+    if (type.getCategory() != Type::Array &&
+        type.getCategory() != Type::Pointer)
         return false;
 
-    Type const* char_type(registry.get("/char"));
+    Type const *char_type(registry.get("/char"));
     if (!char_type)
         return false;
 
-    Type const& data_type(static_cast<Indirect const&>(type).getIndirection());
+    Type const &data_type(static_cast<Indirect const &>(type).getIndirection());
     if (data_type.getName() != char_type->getName())
         return false;
 
     if (known_size && type.getCategory() == Type::Pointer)
-	return false;
+        return false;
 
     return true;
-
 }
-static void string_buffer_get(Value const& value, char*& buffer, string::size_type& size)
-{
-    Type const& type(value.getType());
-    if (type.getCategory() == Type::Array)
-    {
-	buffer = reinterpret_cast<char*>(value.getData());
-	size = static_cast<Array const&>(type).getDimension();
-    }
-    else
-    {
-	buffer = *reinterpret_cast<char**>(value.getData());
-	size   = string::npos;
+static void string_buffer_get(Value const &value, char *&buffer,
+                              string::size_type &size) {
+    Type const &type(value.getType());
+    if (type.getCategory() == Type::Array) {
+        buffer = reinterpret_cast<char *>(value.getData());
+        size = static_cast<Array const &>(type).getDimension();
+    } else {
+        buffer = *reinterpret_cast<char **>(value.getData());
+        size = string::npos;
     }
 }
 
-static VALUE value_string_handler_p(VALUE self)
-{
-    Value const& value(rb2cxx::object<Value>(self));
-    Type  const& type(value.getType());
-    Registry const& registry = rb2cxx::object<Registry>(value_get_registry(self));
+static VALUE value_string_handler_p(VALUE self) {
+    Value const &value(rb2cxx::object<Value>(self));
+    Type const &type(value.getType());
+    Registry const &registry =
+        rb2cxx::object<Registry>(value_get_registry(self));
     return is_string_handler(registry, type) ? Qtrue : Qfalse;
 }
 
@@ -52,22 +49,25 @@ static VALUE value_string_handler_p(VALUE self)
  * It is a module function used to define #to_str on the relevant types
  * NEVER call it directly
  */
-static VALUE value_from_string(VALUE mod, VALUE self, VALUE from, VALUE known_good_type)
-{
-    Value const& value(rb2cxx::object<Value>(self));
-    Type  const& type(value.getType());
-    Registry const& registry = rb2cxx::object<Registry>(value_get_registry(self));
+static VALUE value_from_string(VALUE mod, VALUE self, VALUE from,
+                               VALUE known_good_type) {
+    Value const &value(rb2cxx::object<Value>(self));
+    Type const &type(value.getType());
+    Registry const &registry =
+        rb2cxx::object<Registry>(value_get_registry(self));
 
     if (!RTEST(known_good_type) && !is_string_handler(registry, type, true))
-	rb_raise(rb_eTypeError, "Ruby strings can only be converted to char arrays");
+        rb_raise(rb_eTypeError,
+                 "Ruby strings can only be converted to char arrays");
 
-    char * buffer;
+    char *buffer;
     string::size_type buffer_size;
     string_buffer_get(value, buffer, buffer_size);
 
     string::size_type from_length = RSTRING_LEN(StringValue(from));
     if ((buffer_size - 1) < from_length)
-        rb_raise(rb_eArgError, "array to small: %lu, while %lu was needed", buffer_size, from_length + 1);
+        rb_raise(rb_eArgError, "array to small: %lu, while %lu was needed",
+                 buffer_size, from_length + 1);
 
     strncpy(buffer, StringValueCStr(from), buffer_size);
     buffer[buffer_size - 1] = 0;
@@ -78,38 +78,37 @@ static VALUE value_from_string(VALUE mod, VALUE self, VALUE from, VALUE known_go
  * NEVER call that directly. It is used to define #to_str on the relevant
  * instances of Type
  */
-static VALUE value_to_string(VALUE mod, VALUE self, VALUE known_good_type)
-{
-    Value const& value(rb2cxx::object<Value>(self));
-    Type  const& type(value.getType());
-    Registry const& registry = rb2cxx::object<Registry>(value_get_registry(self));
+static VALUE value_to_string(VALUE mod, VALUE self, VALUE known_good_type) {
+    Value const &value(rb2cxx::object<Value>(self));
+    Type const &type(value.getType());
+    Registry const &registry =
+        rb2cxx::object<Registry>(value_get_registry(self));
 
     if (!RTEST(known_good_type) && !is_string_handler(registry, type))
-	rb_raise(rb_eRuntimeError, "invalid conversion to string");
+        rb_raise(rb_eRuntimeError, "invalid conversion to string");
 
-    char* buffer;
+    char *buffer;
     string::size_type buffer_size;
     string_buffer_get(value, buffer, buffer_size);
 
     if (buffer_size == string::npos)
         return rb_str_new2(buffer);
-    else
-    {
-	// Search the real end of the string inside the buffer
-	string::size_type real_size;
-	for (real_size = 0; real_size < buffer_size; ++real_size)
-	{
-	    if (!buffer[real_size])
-		break;
-	}
+    else {
+        // Search the real end of the string inside the buffer
+        string::size_type real_size;
+        for (real_size = 0; real_size < buffer_size; ++real_size) {
+            if (!buffer[real_size])
+                break;
+        }
         return rb_str_new(buffer, real_size);
     }
 }
 
-void typelib_ruby::Typelib_init_strings()
-{
-    rb_define_singleton_method(cType, "to_string",    RUBY_METHOD_FUNC(&value_to_string), 2);
-    rb_define_singleton_method(cType, "from_string",  RUBY_METHOD_FUNC(&value_from_string), 3);
-    rb_define_method(cType, "string_handler?", RUBY_METHOD_FUNC(&value_string_handler_p), 0);
+void typelib_ruby::Typelib_init_strings() {
+    rb_define_singleton_method(cType, "to_string",
+                               RUBY_METHOD_FUNC(&value_to_string), 2);
+    rb_define_singleton_method(cType, "from_string",
+                               RUBY_METHOD_FUNC(&value_from_string), 3);
+    rb_define_method(cType, "string_handler?",
+                     RUBY_METHOD_FUNC(&value_string_handler_p), 0);
 }
-

--- a/bindings/ruby/ext/typelib.hh
+++ b/bindings/ruby/ext/typelib.hh
@@ -11,195 +11,183 @@
 #undef VERBOSE
 
 namespace typelib_ruby {
-    extern VALUE cType;
-    extern VALUE cIndirect;
-    extern VALUE cPointer;
-    extern VALUE cArray;
-    extern VALUE cCompound;
-    extern VALUE cNumeric;
-    extern VALUE cEnum;
-    extern VALUE cContainer;
-    extern VALUE cOpaque;
-    extern VALUE cNull;
-    extern VALUE cRegistry;
-    extern VALUE cMetaData;
+extern VALUE cType;
+extern VALUE cIndirect;
+extern VALUE cPointer;
+extern VALUE cArray;
+extern VALUE cCompound;
+extern VALUE cNumeric;
+extern VALUE cEnum;
+extern VALUE cContainer;
+extern VALUE cOpaque;
+extern VALUE cNull;
+extern VALUE cRegistry;
+extern VALUE cMetaData;
 
-    extern VALUE eNotFound;
+extern VALUE eNotFound;
 
-    /** Initialization routines */
-    extern void Typelib_init_memory();
-    extern void Typelib_init_values();
-    extern void Typelib_init_strings();
-    extern void Typelib_init_specialized_types();
-    extern void Typelib_init_registry();
-    extern void Typelib_init_metadata();
+/** Initialization routines */
+extern void Typelib_init_memory();
+extern void Typelib_init_values();
+extern void Typelib_init_strings();
+extern void Typelib_init_specialized_types();
+extern void Typelib_init_registry();
+extern void Typelib_init_metadata();
 #ifdef WITH_DYNCALL
-    extern void Typelib_init_functions();
+extern void Typelib_init_functions();
 #endif
 
-    namespace cxx2rb {
-        using namespace Typelib;
+namespace cxx2rb {
+using namespace Typelib;
 
-        typedef std::map<Type const*, std::pair<bool, VALUE> > WrapperMap;
+typedef std::map<Type const *, std::pair<bool, VALUE> > WrapperMap;
 
-        struct RbRegistry
-        {
-            boost::shared_ptr<Typelib::Registry> registry;
-            /** Map that stores the mapping from Type instances to the
-             * corresponding Ruby object
-             *
-             * The boolean flag is false if the registry still owns that type,
-             * and true otherwise. The registry loses ownership of a type
-             * through the remove call
-             *
-             * In both cases, they will be deleted only when the registry is
-             * garbage collected.
-             */
-            cxx2rb::WrapperMap wrappers;
+struct RbRegistry {
+    boost::shared_ptr<Typelib::Registry> registry;
+    /** Map that stores the mapping from Type instances to the
+     * corresponding Ruby object
+     *
+     * The boolean flag is false if the registry still owns that type,
+     * and true otherwise. The registry loses ownership of a type
+     * through the remove call
+     *
+     * In both cases, they will be deleted only when the registry is
+     * garbage collected.
+     */
+    cxx2rb::WrapperMap wrappers;
 
-            RbRegistry(Typelib::Registry* registry)
-                : registry(registry) {}
-            ~RbRegistry() {}
-        };
+    RbRegistry(Typelib::Registry *registry) : registry(registry) {}
+    ~RbRegistry() {}
+};
 
-        VALUE class_of(Type const& type);
+VALUE class_of(Type const &type);
 
-        template<typename T> VALUE class_of();
-        template<> inline VALUE class_of<Value>()    { return cType; }
-        template<> inline VALUE class_of<Type>()     { return rb_cClass; }
-        template<> inline VALUE class_of<RbRegistry>() { return cRegistry; }
-        template<> inline VALUE class_of<MetaData>() { return cMetaData; }
+template <typename T> VALUE class_of();
+template <> inline VALUE class_of<Value>() { return cType; }
+template <> inline VALUE class_of<Type>() { return rb_cClass; }
+template <> inline VALUE class_of<RbRegistry>() { return cRegistry; }
+template <> inline VALUE class_of<MetaData>() { return cMetaData; }
 
-        VALUE type_wrap(Type const& type, VALUE registry);
-        VALUE metadata_wrap(MetaData& metadata);
+VALUE type_wrap(Type const &type, VALUE registry);
+VALUE metadata_wrap(MetaData &metadata);
 
-        /* Get the Ruby symbol associated with a C enum, or nil
-         * if the value is not valid for this enum
-         */
-        inline VALUE enum_symbol(Enum::integral_type value, Enum const& e)
-        {
-            try { 
-                std::string symbol = e.get(value);
-                return ID2SYM(rb_intern(symbol.c_str())); 
-            }
-            catch(Enum::ValueNotFound) { return Qnil; }
-        }
-
-        VALUE value_wrap(Value v, VALUE registry, VALUE parent = Qnil);
+/* Get the Ruby symbol associated with a C enum, or nil
+ * if the value is not valid for this enum
+ */
+inline VALUE enum_symbol(Enum::integral_type value, Enum const &e) {
+    try {
+        std::string symbol = e.get(value);
+        return ID2SYM(rb_intern(symbol.c_str()));
+    } catch (Enum::ValueNotFound) {
+        return Qnil;
     }
+}
 
-    namespace rb2cxx {
-        using namespace Typelib;
+VALUE value_wrap(Value v, VALUE registry, VALUE parent = Qnil);
+}
 
-        inline void check_is_kind_of(VALUE self, VALUE expected)
-        {
-            if (! rb_obj_is_kind_of(self, expected))
-                rb_raise(rb_eTypeError, "expected %s, got %s", rb_class2name(expected), rb_obj_classname(self));
-        }
+namespace rb2cxx {
+using namespace Typelib;
 
-        template<typename T>
-        T& get_wrapped(VALUE self)
-        {
-            void* object = 0;
-            Data_Get_Struct(self, void, object);
-            return *reinterpret_cast<T*>(object);
-        }
+inline void check_is_kind_of(VALUE self, VALUE expected) {
+    if (!rb_obj_is_kind_of(self, expected))
+        rb_raise(rb_eTypeError, "expected %s, got %s", rb_class2name(expected),
+                 rb_obj_classname(self));
+}
 
-        template<typename T> 
-        T& object(VALUE self)
-        {
-            check_is_kind_of(self, cxx2rb::class_of<T>());
-            return get_wrapped<T>(self);
-        }
+template <typename T> T &get_wrapped(VALUE self) {
+    void *object = 0;
+    Data_Get_Struct(self, void, object);
+    return *reinterpret_cast<T *>(object);
+}
 
-        template<> inline Registry& object(VALUE self)
-        {
-            return *object<cxx2rb::RbRegistry>(self).registry;
-        }
+template <typename T> T &object(VALUE self) {
+    check_is_kind_of(self, cxx2rb::class_of<T>());
+    return get_wrapped<T>(self);
+}
 
-        template<>
-        inline Type& object(VALUE self) 
-        {
-            check_is_kind_of(self, rb_cClass);
-            VALUE type = rb_iv_get(self, "@type");
-            return get_wrapped<Type>(type);
-        }
+template <> inline Registry &object(VALUE self) {
+    return *object<cxx2rb::RbRegistry>(self).registry;
+}
 
-        Enum::integral_type enum_value(VALUE rb_value, Enum const& e);
-    }
+template <> inline Type &object(VALUE self) {
+    check_is_kind_of(self, rb_cClass);
+    VALUE type = rb_iv_get(self, "@type");
+    return get_wrapped<Type>(type);
+}
 
-    class RubyGetter : public Typelib::ValueVisitor
-    {
-    protected:
-        VALUE m_value;
-        VALUE m_registry;
-        VALUE m_parent;
+Enum::integral_type enum_value(VALUE rb_value, Enum const &e);
+}
 
-        bool visit_ (int8_t  & value);
-        bool visit_ (uint8_t & value);
-        bool visit_ (int16_t & value);
-        bool visit_ (uint16_t& value);
-        bool visit_ (int32_t & value);
-        bool visit_ (uint32_t& value);
-        bool visit_ (int64_t & value);
-        bool visit_ (uint64_t& value);
-        bool visit_ (float   & value);
-        bool visit_ (double  & value);
+class RubyGetter : public Typelib::ValueVisitor {
+  protected:
+    VALUE m_value;
+    VALUE m_registry;
+    VALUE m_parent;
 
-        bool visit_(Typelib::Value const& v, Typelib::Pointer const& p);
-        bool visit_(Typelib::Value const& v, Typelib::Array const& a);
-        bool visit_(Typelib::Value const& v, Typelib::Compound const& c);
-        bool visit_(Typelib::Value const& v, Typelib::Container const& c);
-        bool visit_(Typelib::Value const& v, Typelib::OpaqueType const& c);
-        bool visit_(Typelib::Enum::integral_type& v, Typelib::Enum const& e);
-        
-    public:
-        RubyGetter();
-        ~RubyGetter();
+    bool visit_(int8_t &value);
+    bool visit_(uint8_t &value);
+    bool visit_(int16_t &value);
+    bool visit_(uint16_t &value);
+    bool visit_(int32_t &value);
+    bool visit_(uint32_t &value);
+    bool visit_(int64_t &value);
+    bool visit_(uint64_t &value);
+    bool visit_(float &value);
+    bool visit_(double &value);
 
-        VALUE apply(Typelib::Value value, VALUE registry, VALUE parent);
-    };
+    bool visit_(Typelib::Value const &v, Typelib::Pointer const &p);
+    bool visit_(Typelib::Value const &v, Typelib::Array const &a);
+    bool visit_(Typelib::Value const &v, Typelib::Compound const &c);
+    bool visit_(Typelib::Value const &v, Typelib::Container const &c);
+    bool visit_(Typelib::Value const &v, Typelib::OpaqueType const &c);
+    bool visit_(Typelib::Enum::integral_type &v, Typelib::Enum const &e);
 
-    class RubySetter : public Typelib::ValueVisitor
-    {
-    protected:
-        VALUE m_value;
+  public:
+    RubyGetter();
+    ~RubyGetter();
 
-        bool visit_ (int8_t  & value);
-        bool visit_ (uint8_t & value);
-        bool visit_ (int16_t & value);
-        bool visit_ (uint16_t& value);
-        bool visit_ (int32_t & value);
-        bool visit_ (uint32_t& value);
-        bool visit_ (int64_t & value);
-        bool visit_ (uint64_t& value);
-        bool visit_ (float   & value);
-        bool visit_ (double  & value);
+    VALUE apply(Typelib::Value value, VALUE registry, VALUE parent);
+};
 
-        bool visit_(Typelib::Value const& v, Typelib::Pointer const& p);
-        bool visit_(Typelib::Value const& v, Typelib::Array const& a);
-        bool visit_(Typelib::Value const& v, Typelib::Compound const& c);
-        bool visit_(Typelib::Value const& v, Typelib::Container const& c);
-        bool visit_(Typelib::Value const& v, Typelib::OpaqueType const& c);
-        bool visit_(Typelib::Enum::integral_type& v, Typelib::Enum const& e);
-        
-    public:
-        RubySetter();
-        ~RubySetter();
+class RubySetter : public Typelib::ValueVisitor {
+  protected:
+    VALUE m_value;
 
-        VALUE apply(Typelib::Value value, VALUE new_value);
-    };
+    bool visit_(int8_t &value);
+    bool visit_(uint8_t &value);
+    bool visit_(int16_t &value);
+    bool visit_(uint16_t &value);
+    bool visit_(int32_t &value);
+    bool visit_(uint32_t &value);
+    bool visit_(int64_t &value);
+    bool visit_(uint64_t &value);
+    bool visit_(float &value);
+    bool visit_(double &value);
 
-    extern VALUE value_get_registry(VALUE self);
-    extern VALUE type_get_registry(VALUE self);
-    extern bool memory_ref(void* ptr);
-    extern void memory_unref(void* ptr);
-    extern void memory_delete(void* ptr);
-    extern VALUE memory_wrap(void* ptr, bool take_ownership, void* root_ptr);
-    extern VALUE memory_allocate(size_t size);
-    extern void  memory_init(VALUE ptr, VALUE type);
-    extern void* memory_cptr(VALUE ptr);
+    bool visit_(Typelib::Value const &v, Typelib::Pointer const &p);
+    bool visit_(Typelib::Value const &v, Typelib::Array const &a);
+    bool visit_(Typelib::Value const &v, Typelib::Compound const &c);
+    bool visit_(Typelib::Value const &v, Typelib::Container const &c);
+    bool visit_(Typelib::Value const &v, Typelib::OpaqueType const &c);
+    bool visit_(Typelib::Enum::integral_type &v, Typelib::Enum const &e);
+
+  public:
+    RubySetter();
+    ~RubySetter();
+
+    VALUE apply(Typelib::Value value, VALUE new_value);
+};
+
+extern VALUE value_get_registry(VALUE self);
+extern VALUE type_get_registry(VALUE self);
+extern bool memory_ref(void *ptr);
+extern void memory_unref(void *ptr);
+extern void memory_delete(void *ptr);
+extern VALUE memory_wrap(void *ptr, bool take_ownership, void *root_ptr);
+extern VALUE memory_allocate(size_t size);
+extern void memory_init(VALUE ptr, VALUE type);
+extern void *memory_cptr(VALUE ptr);
 }
 
 #endif
-

--- a/bindings/ruby/ext/typelib_ruby.cc
+++ b/bindings/ruby/ext/typelib_ruby.cc
@@ -10,7 +10,7 @@ using utilmm::config_set;
 using std::string;
 
 using namespace typelib_ruby;
-static VALUE mTypelib   = Qnil;
+static VALUE mTypelib = Qnil;
 
 /**********************************************************************
  *
@@ -18,21 +18,22 @@ static VALUE mTypelib   = Qnil;
  *
  */
 
-static VALUE kernel_is_immediate(VALUE klass, VALUE object)
-{ return IMMEDIATE_P(object) ? Qtrue : Qfalse; }
+static VALUE kernel_is_immediate(VALUE klass, VALUE object) {
+    return IMMEDIATE_P(object) ? Qtrue : Qfalse;
+}
 /* call-seq:
  *  numeric?	=> true or false
  *
  * Returns true if the receiver is either a Fixnum or a Float
  */
-static VALUE kernel_is_numeric(VALUE klass, VALUE object)
-{ 
-    return (FIXNUM_P(object) || TYPE(object) == T_FLOAT || TYPE(object) == T_BIGNUM) ? Qtrue : Qfalse;
+static VALUE kernel_is_numeric(VALUE klass, VALUE object) {
+    return (FIXNUM_P(object) || TYPE(object) == T_FLOAT ||
+            TYPE(object) == T_BIGNUM)
+               ? Qtrue
+               : Qfalse;
 }
 
-
-static VALUE typelib_with_dyncall(VALUE klass)
-{
+static VALUE typelib_with_dyncall(VALUE klass) {
     return
 #ifdef WITH_DYNCALL
         Qtrue;
@@ -41,9 +42,8 @@ static VALUE typelib_with_dyncall(VALUE klass)
 #endif
 }
 
-extern "C" void Init_typelib_ruby()
-{
-    mTypelib  = rb_define_module("Typelib");
+extern "C" void Init_typelib_ruby() {
+    mTypelib = rb_define_module("Typelib");
 #ifdef WITH_DYNCALL
     Typelib_init_functions();
 #endif
@@ -52,9 +52,11 @@ extern "C" void Init_typelib_ruby()
     Typelib_init_registry();
     Typelib_init_memory();
     Typelib_init_metadata();
-    
-    rb_define_singleton_method(mTypelib, "with_dyncall?", RUBY_METHOD_FUNC(typelib_with_dyncall), 0);
-    rb_define_singleton_method(rb_mKernel, "immediate?", RUBY_METHOD_FUNC(kernel_is_immediate), 1);
-    rb_define_singleton_method(rb_mKernel, "numeric?", RUBY_METHOD_FUNC(kernel_is_numeric), 1);
-}
 
+    rb_define_singleton_method(mTypelib, "with_dyncall?",
+                               RUBY_METHOD_FUNC(typelib_with_dyncall), 0);
+    rb_define_singleton_method(rb_mKernel, "immediate?",
+                               RUBY_METHOD_FUNC(kernel_is_immediate), 1);
+    rb_define_singleton_method(rb_mKernel, "numeric?",
+                               RUBY_METHOD_FUNC(kernel_is_numeric), 1);
+}

--- a/bindings/ruby/ext/typelib_ruby.hh
+++ b/bindings/ruby/ext/typelib_ruby.hh
@@ -14,4 +14,3 @@ VALUE typelib_to_ruby(Typelib::Value v, VALUE registry, VALUE parent);
 VALUE typelib_from_ruby(Typelib::Value value, VALUE new_value);
 
 #endif
-

--- a/bindings/ruby/ext/value.cc
+++ b/bindings/ruby/ext/value.cc
@@ -18,20 +18,17 @@ using std::numeric_limits;
 using std::vector;
 using namespace typelib_ruby;
 
-void* value_root_ptr(VALUE value)
-{
+void *value_root_ptr(VALUE value) {
     VALUE parent = Qnil;
-    while (RTEST(value))
-    {
+    while (RTEST(value)) {
         parent = value;
         value = rb_iv_get(value, "@parent");
     }
-    if (RTEST(parent))
-    {
+    if (RTEST(parent)) {
         Value v = rb2cxx::object<Value>(parent);
         return v.getData();
-    }
-    else return 0;
+    } else
+        return 0;
 }
 
 /* There are constraints when creating a Ruby wrapper for a Type, mainly
@@ -42,20 +39,23 @@ void* value_root_ptr(VALUE value)
  * pointer. Problems arise when one of the two following situations are met:
  * * we reference a memory zone inside another memory zone (for instance,
  *   an array element or a structure field). In that case, the DLPtr object
- *   must not free the allocated zone. 
+ *   must not free the allocated zone.
  * * two Typelib objects reference the same memory zone (first array
  *   element or first field of a structure). In that case, we must reuse the
  *   same DLPtr object, or DL will override the free function of the other
  *   DLPtr object -- which is obviously wrong, but nevertheless done.
  */
-VALUE cxx2rb::value_wrap(Value v, VALUE registry, VALUE parent)
-{
+VALUE cxx2rb::value_wrap(Value v, VALUE registry, VALUE parent) {
     VALUE type = type_wrap(v.getType(), registry);
-#   ifdef VERBOSE
+#ifdef VERBOSE
     Value parent_value = rb2cxx::object<Value>(parent);
-    fprintf(stderr, "wrapping Typelib::Value %p from C++, type=%s, parent=%p and root=%p\n", v.getData(), v.getType().getName().c_str(), parent_value.getData(), value_root_ptr(parent));
-#   endif
-    VALUE ptr  = memory_wrap(v.getData(), false, value_root_ptr(parent));
+    fprintf(
+        stderr,
+        "wrapping Typelib::Value %p from C++, type=%s, parent=%p and root=%p\n",
+        v.getData(), v.getType().getName().c_str(), parent_value.getData(),
+        value_root_ptr(parent));
+#endif
+    VALUE ptr = memory_wrap(v.getData(), false, value_root_ptr(parent));
     VALUE wrapper = rb_funcall(type, rb_intern("wrap"), 1, ptr);
 
     rb_iv_set(wrapper, "@parent", parent);
@@ -63,69 +63,79 @@ VALUE cxx2rb::value_wrap(Value v, VALUE registry, VALUE parent)
     return wrapper;
 }
 
-static VALUE value_allocate(Type const& type, VALUE registry)
-{
+static VALUE value_allocate(Type const &type, VALUE registry) {
     VALUE rb_type = cxx2rb::type_wrap(type, registry);
-#   ifdef VERBOSE
-    fprintf(stderr, "allocating new value of type %s\n", type.getName().c_str());
-#   endif
-    VALUE ptr     = memory_allocate(type.getSize());
+#ifdef VERBOSE
+    fprintf(stderr, "allocating new value of type %s\n",
+            type.getName().c_str());
+#endif
+    VALUE ptr = memory_allocate(type.getSize());
     memory_init(ptr, rb_type);
     VALUE wrapper = rb_funcall(rb_type, rb_intern("wrap"), 1, ptr);
     return wrapper;
 }
 
 namespace typelib_ruby {
-    VALUE cType	 = Qnil;
-    VALUE cNumeric	 = Qnil;
-    VALUE cOpaque	 = Qnil;
-    VALUE cNull	 = Qnil;
-    VALUE cIndirect  = Qnil;
-    VALUE cPointer   = Qnil;
-    VALUE cArray     = Qnil;
-    VALUE cCompound  = Qnil;
-    VALUE cEnum      = Qnil;
-    VALUE cContainer = Qnil;
+VALUE cType = Qnil;
+VALUE cNumeric = Qnil;
+VALUE cOpaque = Qnil;
+VALUE cNull = Qnil;
+VALUE cIndirect = Qnil;
+VALUE cPointer = Qnil;
+VALUE cArray = Qnil;
+VALUE cCompound = Qnil;
+VALUE cEnum = Qnil;
+VALUE cContainer = Qnil;
 }
 
-VALUE cxx2rb::class_of(Typelib::Type const& type)
-{
+VALUE cxx2rb::class_of(Typelib::Type const &type) {
     using Typelib::Type;
-    switch(type.getCategory()) {
-	case Type::Numeric:	return cNumeric;
-	case Type::Compound:    return cCompound;
-	case Type::Pointer:     return cPointer;
-	case Type::Array:       return cArray;
-	case Type::Enum:        return cEnum;
-        case Type::Container:   return cContainer;
-        case Type::Opaque:      return cOpaque;
-        case Type::NullType:    return cNull;
-	default:                return cType;
+    switch (type.getCategory()) {
+    case Type::Numeric:
+        return cNumeric;
+    case Type::Compound:
+        return cCompound;
+    case Type::Pointer:
+        return cPointer;
+    case Type::Array:
+        return cArray;
+    case Type::Enum:
+        return cEnum;
+    case Type::Container:
+        return cContainer;
+    case Type::Opaque:
+        return cOpaque;
+    case Type::NullType:
+        return cNull;
+    default:
+        return cType;
     }
 }
 
-VALUE cxx2rb::type_wrap(Type const& type, VALUE registry)
-{
+VALUE cxx2rb::type_wrap(Type const &type, VALUE registry) {
     // Type objects are unique, we can register Ruby wrappers based
     // on the type pointer (instead of using names)
-    WrapperMap& wrappers = rb2cxx::object<RbRegistry>(registry).wrappers;
+    WrapperMap &wrappers = rb2cxx::object<RbRegistry>(registry).wrappers;
 
     WrapperMap::const_iterator it = wrappers.find(&type);
     if (it != wrappers.end())
-	return it->second.second;
+        return it->second.second;
 
-    VALUE base  = class_of(type);
+    VALUE base = class_of(type);
     VALUE klass = rb_funcall(rb_cClass, rb_intern("new"), 1, base);
-    VALUE rb_type = Data_Wrap_Struct(rb_cObject, 0, 0, const_cast<Type*>(&type));
+    VALUE rb_type =
+        Data_Wrap_Struct(rb_cObject, 0, 0, const_cast<Type *>(&type));
     rb_iv_set(klass, "@registry", registry);
     rb_iv_set(klass, "@type", rb_type);
     rb_iv_set(klass, "@name", rb_str_new2(type.getName().c_str()));
-    rb_iv_set(klass, "@null", (type.getCategory() == Type::NullType) ? Qtrue : Qfalse);
-    rb_iv_set(klass, "@opaque", (type.getCategory() == Type::Opaque) ? Qtrue : Qfalse);
+    rb_iv_set(klass, "@null",
+              (type.getCategory() == Type::NullType) ? Qtrue : Qfalse);
+    rb_iv_set(klass, "@opaque",
+              (type.getCategory() == Type::Opaque) ? Qtrue : Qfalse);
     rb_iv_set(klass, "@metadata", cxx2rb::metadata_wrap(type.getMetaData()));
 
     if (rb_respond_to(klass, rb_intern("subclass_initialize")))
-	rb_funcall(klass, rb_intern("subclass_initialize"), 0);
+        rb_funcall(klass, rb_intern("subclass_initialize"), 0);
 
     wrappers.insert(std::make_pair(&type, std::make_pair(false, klass)));
     return klass;
@@ -137,29 +147,30 @@ VALUE cxx2rb::type_wrap(Type const& type, VALUE registry)
 
 /* @overload type.to_csv([basename [, separator]])
  *
- * Returns a one-line representation of this type, using +separator+ 
- * to separate each fields. If +basename+ is given, use it as a 
+ * Returns a one-line representation of this type, using +separator+
+ * to separate each fields. If +basename+ is given, use it as a
  * 'variable name'. For instance, calling this method on an array
  * with a basename of 'array' will return
- *  
+ *
  *   array[0] array[1]
  *
- * without basename, it would be 
+ * without basename, it would be
  *
  *   [0] [1]
  *
  */
-static VALUE type_to_csv(int argc, VALUE* argv, VALUE rbself)
-{
+static VALUE type_to_csv(int argc, VALUE *argv, VALUE rbself) {
     VALUE basename = Qnil;
     VALUE separator = Qnil;
     rb_scan_args(argc, argv, "02", &basename, &separator);
 
     std::string bname = "", sep = " ";
-    if (!NIL_P(basename)) bname = StringValuePtr(basename);
-    if (!NIL_P(separator)) sep = StringValuePtr(separator);
+    if (!NIL_P(basename))
+        bname = StringValuePtr(basename);
+    if (!NIL_P(separator))
+        sep = StringValuePtr(separator);
 
-    Type const& self(rb2cxx::object<Type>(rbself));
+    Type const &self(rb2cxx::object<Type>(rbself));
     std::ostringstream stream;
     stream << csv_header(self, bname, sep);
     std::string str = stream.str();
@@ -173,15 +184,13 @@ static VALUE type_to_csv(int argc, VALUE* argv, VALUE rbself)
  *
  * @return [String]
  */
-static VALUE typelib_do_basename(VALUE mod, VALUE name)
-{
+static VALUE typelib_do_basename(VALUE mod, VALUE name) {
     std::string result = Typelib::getTypename(StringValuePtr(name));
     return rb_str_new(result.c_str(), result.length());
 }
 
 /* Internal helper method for Type#namespace */
-static VALUE typelib_do_namespace(VALUE mod, VALUE name)
-{
+static VALUE typelib_do_namespace(VALUE mod, VALUE name) {
     std::string result = Typelib::getNamespace(StringValuePtr(name));
     return rb_str_new(result.c_str(), result.length());
 }
@@ -189,18 +198,18 @@ static VALUE typelib_do_namespace(VALUE mod, VALUE name)
 /* @overload split_typename
  *
  * Splits the typename of self into its components
- * 
+ *
  * @return [Array<String>]
  */
-static VALUE typelib_do_split_name(VALUE mod, VALUE name)
-{
-    std::list<std::string> splitted = Typelib::splitTypename(StringValuePtr(name));
+static VALUE typelib_do_split_name(VALUE mod, VALUE name) {
+    std::list<std::string> splitted =
+        Typelib::splitTypename(StringValuePtr(name));
     VALUE result = rb_ary_new();
-    for (std::list<std::string>::const_iterator it = splitted.begin(); it != splitted.end(); ++it)
+    for (std::list<std::string>::const_iterator it = splitted.begin();
+         it != splitted.end(); ++it)
         rb_ary_push(result, rb_str_new(it->c_str(), it->length()));
     return result;
 }
-
 
 /* @overload t1 == t2
  *
@@ -208,17 +217,17 @@ static VALUE typelib_do_split_name(VALUE mod, VALUE name)
  *
  * @return [Boolean]
  */
-static VALUE type_equal_operator(VALUE rbself, VALUE rbwith)
-{ 
+static VALUE type_equal_operator(VALUE rbself, VALUE rbwith) {
     if (rbself == rbwith)
         return Qtrue;
     if (!rb_obj_is_kind_of(rbwith, rb_cClass))
         return Qfalse;
-    if ((rbwith == cType) || !RTEST(rb_funcall(rbwith, rb_intern("<"), 1, cType)))
-	return Qfalse;
+    if ((rbwith == cType) ||
+        !RTEST(rb_funcall(rbwith, rb_intern("<"), 1, cType)))
+        return Qfalse;
 
-    Type const& self(rb2cxx::object<Type>(rbself));
-    Type const& with(rb2cxx::object<Type>(rbwith));
+    Type const &self(rb2cxx::object<Type>(rbself));
+    Type const &with(rb2cxx::object<Type>(rbwith));
     bool result = (self == with) || self.isSame(with);
     return result ? Qtrue : Qfalse;
 }
@@ -227,25 +236,24 @@ static VALUE type_equal_operator(VALUE rbself, VALUE rbwith)
  *
  * Returns the size in bytes of instances of +type+
  */
-static VALUE type_size(VALUE self)
-{
-    Type const& type(rb2cxx::object<Type>(self));
+static VALUE type_size(VALUE self) {
+    Type const &type(rb2cxx::object<Type>(self));
     return INT2FIX(type.getSize());
 }
 
 /* Returns the set of Type subclasses that represent the types needed to build
  * +type+.
  */
-static VALUE type_dependencies(VALUE self)
-{
-    Type const& type(rb2cxx::object<Type>(self));
+static VALUE type_dependencies(VALUE self) {
+    Type const &type(rb2cxx::object<Type>(self));
 
-    typedef std::set<Type const*> TypeSet;
+    typedef std::set<Type const *> TypeSet;
     TypeSet dependencies = type.dependsOn();
     VALUE registry = type_get_registry(self);
 
     VALUE result = rb_ary_new();
-    for (TypeSet::const_iterator it = dependencies.begin(); it != dependencies.end(); ++it)
+    for (TypeSet::const_iterator it = dependencies.begin();
+         it != dependencies.end(); ++it)
         rb_ary_push(result, cxx2rb::type_wrap(**it, registry));
     return result;
 }
@@ -255,23 +263,23 @@ static VALUE type_dependencies(VALUE self)
  * Returns true if a value that is described by +type+ can be manipulated using
  * +other_type+. This is a weak form of equality
  */
-static VALUE type_can_cast_to(VALUE self, VALUE to)
-{
-    Type const& from_type(rb2cxx::object<Type>(self));
-    Type const& to_type(rb2cxx::object<Type>(to));
+static VALUE type_can_cast_to(VALUE self, VALUE to) {
+    Type const &from_type(rb2cxx::object<Type>(self));
+    Type const &to_type(rb2cxx::object<Type>(to));
     return from_type.canCastTo(to_type) ? Qtrue : Qfalse;
 }
 
 /*
- *  type.do_memory_layout(VALUE accept_pointers, VALUE accept_opaques, VALUE merge_skip_copy, VALUE remove_trailing_skips) => [operations]
+ *  type.do_memory_layout(VALUE accept_pointers, VALUE accept_opaques, VALUE
+ *merge_skip_copy, VALUE remove_trailing_skips) => [operations]
  *
  * Returns a representation of the MemoryLayout for this type. If
  * +with_pointers+ is true, then pointers will be included in the layout.
  * Otherwise, an exception is raised if pointers are part of the type
  */
-static VALUE type_memory_layout(VALUE self, VALUE pointers, VALUE opaques, VALUE merge, VALUE remove_trailing_skips)
-{
-    Type const& type(rb2cxx::object<Type>(self));
+static VALUE type_memory_layout(VALUE self, VALUE pointers, VALUE opaques,
+                                VALUE merge, VALUE remove_trailing_skips) {
+    Type const &type(rb2cxx::object<Type>(self));
     VALUE registry = type_get_registry(self);
 
     VALUE result = rb_ary_new();
@@ -283,38 +291,42 @@ static VALUE type_memory_layout(VALUE self, VALUE pointers, VALUE opaques, VALUE
     VALUE rb_container = ID2SYM(rb_intern("FLAG_CONTAINER"));
 
     try {
-        MemoryLayout layout = Typelib::layout_of(type, RTEST(pointers), RTEST(opaques), RTEST(merge), RTEST(remove_trailing_skips));
+        MemoryLayout layout =
+            Typelib::layout_of(type, RTEST(pointers), RTEST(opaques),
+                               RTEST(merge), RTEST(remove_trailing_skips));
 
         // Now, convert into something representable in Ruby
-        for (MemoryLayout::const_iterator it = layout.begin(); it != layout.end(); ++it)
-        {
-            switch(*it)
-            {
-                case MemLayout::FLAG_MEMCPY:
-                    rb_ary_push(result, rb_memcpy);
-                    rb_ary_push(result, LONG2NUM(*(++it)));
-                    break;
-                case MemLayout::FLAG_SKIP:
-                    rb_ary_push(result, rb_skip);
-                    rb_ary_push(result, LONG2NUM(*(++it)));
-                    break;
-                case MemLayout::FLAG_ARRAY:
-                    rb_ary_push(result, rb_array);
-                    rb_ary_push(result, LONG2NUM(*(++it)));
-                    break;
-                case MemLayout::FLAG_END:
-                    rb_ary_push(result, rb_end);
-                    break;
-                case MemLayout::FLAG_CONTAINER:
-                    rb_ary_push(result, rb_container);
-                    rb_ary_push(result, cxx2rb::type_wrap(*reinterpret_cast<Container*>(*(++it)), registry));
-                    break;
-                default:
-                    rb_raise(rb_eArgError, "error encountered while parsing memory layout");
+        for (MemoryLayout::const_iterator it = layout.begin();
+             it != layout.end(); ++it) {
+            switch (*it) {
+            case MemLayout::FLAG_MEMCPY:
+                rb_ary_push(result, rb_memcpy);
+                rb_ary_push(result, LONG2NUM(*(++it)));
+                break;
+            case MemLayout::FLAG_SKIP:
+                rb_ary_push(result, rb_skip);
+                rb_ary_push(result, LONG2NUM(*(++it)));
+                break;
+            case MemLayout::FLAG_ARRAY:
+                rb_ary_push(result, rb_array);
+                rb_ary_push(result, LONG2NUM(*(++it)));
+                break;
+            case MemLayout::FLAG_END:
+                rb_ary_push(result, rb_end);
+                break;
+            case MemLayout::FLAG_CONTAINER:
+                rb_ary_push(result, rb_container);
+                rb_ary_push(result, cxx2rb::type_wrap(
+                                        *reinterpret_cast<Container *>(*(++it)),
+                                        registry));
+                break;
+            default:
+                rb_raise(rb_eArgError,
+                         "error encountered while parsing memory layout");
             }
         }
 
-    } catch(std::exception const& e) {
+    } catch (std::exception const &e) {
         rb_raise(rb_eArgError, "%s", e.what());
     }
 
@@ -322,14 +334,13 @@ static VALUE type_memory_layout(VALUE self, VALUE pointers, VALUE opaques, VALUE
 }
 
 /* PODs are assignable, pointers are dereferenced */
-static VALUE type_is_assignable(Type const& type)
-{
-    switch(type.getCategory())
-    {
+static VALUE type_is_assignable(Type const &type) {
+    switch (type.getCategory()) {
     case Type::Numeric:
         return INT2FIX(1);
     case Type::Pointer:
-        return type_is_assignable( dynamic_cast<Pointer const&>(type).getIndirection());
+        return type_is_assignable(
+            dynamic_cast<Pointer const &>(type).getIndirection());
     case Type::Enum:
         return INT2FIX(1);
     default:
@@ -338,11 +349,9 @@ static VALUE type_is_assignable(Type const& type)
     // never reached
 }
 
-VALUE typelib_ruby::type_get_registry(VALUE self)
-{
+VALUE typelib_ruby::type_get_registry(VALUE self) {
     return rb_iv_get(self, "@registry");
 }
-
 
 /***********************************************************************************
  *
@@ -350,26 +359,23 @@ VALUE typelib_ruby::type_get_registry(VALUE self)
  *
  */
 
-static void value_delete(void* self) { delete reinterpret_cast<Value*>(self); }
+static void value_delete(void *self) { delete reinterpret_cast<Value *>(self); }
 
-static VALUE value_alloc(VALUE klass)
-{ return Data_Wrap_Struct(klass, 0, value_delete, new Value); }
+static VALUE value_alloc(VALUE klass) {
+    return Data_Wrap_Struct(klass, 0, value_delete, new Value);
+}
 
 /** Allocates a new Typelib object, which wraps an untyped, unallocated Value
  * object
  */
-static
-VALUE value_create_empty(VALUE klass)
-{
-    Type const& t(rb2cxx::object<Type>(klass));
+static VALUE value_create_empty(VALUE klass) {
+    Type const &t(rb2cxx::object<Type>(klass));
     VALUE value = Data_Wrap_Struct(klass, 0, value_delete, new Value(NULL, t));
     rb_iv_set(value, "@parent", Qnil);
     return value;
 }
 
-static
-void value_call_typelib_initialize(VALUE obj)
-{
+static void value_call_typelib_initialize(VALUE obj) {
     rb_iv_set(obj, "@__typelib_invalidated", Qfalse);
     rb_iv_set(obj, "@parent", Qnil);
     rb_funcall(obj, rb_intern("typelib_initialize"), 0);
@@ -382,18 +388,17 @@ void value_call_typelib_initialize(VALUE obj)
  *
  * Allocates a new Typelib object that uses a given MemoryZone object
  */
-static
-VALUE value_from_memory_zone(VALUE klass, VALUE ptr)
-{
+static VALUE value_from_memory_zone(VALUE klass, VALUE ptr) {
     VALUE result = value_create_empty(klass);
-    Value& value  = rb2cxx::object<Value>(result);
-    
+    Value &value = rb2cxx::object<Value>(result);
+
     // Protect the memory zone against GC until we don't need it anymore
     rb_iv_set(result, "@ptr", ptr);
     value = Value(memory_cptr(ptr), value.getType());
-#   ifdef VERBOSE
-    fprintf(stderr, "object %llu wraps memory zone %p\n", NUM2ULL(rb_obj_id(result)), value.getData());
-#   endif
+#ifdef VERBOSE
+    fprintf(stderr, "object %llu wraps memory zone %p\n",
+            NUM2ULL(rb_obj_id(result)), value.getData());
+#endif
     value_call_typelib_initialize(result);
     return result;
 }
@@ -404,32 +409,34 @@ VALUE value_from_memory_zone(VALUE klass, VALUE ptr)
  *
  * Allocates a new Typelib object that has a freshly initialized buffer inside
  */
-static
-VALUE value_new(VALUE klass)
-{
-    Type const& type(rb2cxx::object<Type>(klass));
-#   ifdef VERBOSE
-    fprintf(stderr, "allocating new value of type %s\n", type.getName().c_str());
-#   endif
+static VALUE value_new(VALUE klass) {
+    Type const &type(rb2cxx::object<Type>(klass));
+#ifdef VERBOSE
+    fprintf(stderr, "allocating new value of type %s\n",
+            type.getName().c_str());
+#endif
     VALUE buffer = memory_allocate(type.getSize());
     memory_init(buffer, klass);
 
     return value_from_memory_zone(klass, buffer);
 }
 
-static
-VALUE value_do_from_buffer(VALUE rbself, VALUE string, VALUE pointers, VALUE opaques, VALUE merge, VALUE remove_trailing_skips)
-{
-    Value value  = rb2cxx::object<Value>(rbself);
+static VALUE value_do_from_buffer(VALUE rbself, VALUE string, VALUE pointers,
+                                  VALUE opaques, VALUE merge,
+                                  VALUE remove_trailing_skips) {
+    Value value = rb2cxx::object<Value>(rbself);
 
-    MemoryLayout layout = Typelib::layout_of(value.getType(),
-            RTEST(pointers), RTEST(opaques), RTEST(merge), RTEST(remove_trailing_skips));
+    MemoryLayout layout =
+        Typelib::layout_of(value.getType(), RTEST(pointers), RTEST(opaques),
+                           RTEST(merge), RTEST(remove_trailing_skips));
 
-    char* ruby_buffer = StringValuePtr(string);
+    char *ruby_buffer = StringValuePtr(string);
     vector<uint8_t> cxx_buffer(ruby_buffer, ruby_buffer + RSTRING_LEN(string));
-    try { Typelib::load(value, cxx_buffer, layout); }
-    catch(std::exception const& e)
-    { rb_raise(rb_eArgError, "%s", e.what()); }
+    try {
+        Typelib::load(value, cxx_buffer, layout);
+    } catch (std::exception const &e) {
+        rb_raise(rb_eArgError, "%s", e.what());
+    }
     return rbself;
 }
 
@@ -440,12 +447,10 @@ VALUE value_do_from_buffer(VALUE rbself, VALUE string, VALUE pointers, VALUE opa
  * @param [Integer] address
  * @return [Typelib::Type]
  */
-static
-VALUE value_from_address(VALUE klass, VALUE address)
-{
+static VALUE value_from_address(VALUE klass, VALUE address) {
     VALUE result = value_create_empty(klass);
-    Value& value  = rb2cxx::object<Value>(result);
-    value = Value(reinterpret_cast<void*>(NUM2ULL(address)), value.getType());
+    Value &value = rb2cxx::object<Value>(result);
+    value = Value(reinterpret_cast<void *>(NUM2ULL(address)), value.getType());
     rb_iv_set(result, "@ptr", memory_wrap(value.getData(), false, NULL));
     value_call_typelib_initialize(result);
     return result;
@@ -455,9 +460,7 @@ VALUE value_from_address(VALUE klass, VALUE address)
  *
  * @return [Integer] returns the address of the memory zone this value wraps
  */
-static
-VALUE value_address(VALUE self)
-{
+static VALUE value_address(VALUE self) {
     Value value = rb2cxx::object<Value>(self);
     return LONG2NUM((long)value.getData());
 }
@@ -469,15 +472,13 @@ VALUE value_address(VALUE self)
  * @return [Typelib::Type] a new value whose endianness has been swapped
  * @see endian_swap!
  */
-static
-VALUE value_endian_swap(VALUE self)
-{
-    Value& value = rb2cxx::object<Value>(self);
+static VALUE value_endian_swap(VALUE self) {
+    Value &value = rb2cxx::object<Value>(self);
     CompileEndianSwapVisitor compiled;
     compiled.apply(value.getType());
 
     VALUE registry = value_get_registry(self);
-    VALUE result   = value_allocate(value.getType(), registry);
+    VALUE result = value_allocate(value.getType(), registry);
     compiled.swap(value, rb2cxx::object<Value>(result));
     return result;
 }
@@ -489,56 +490,52 @@ VALUE value_endian_swap(VALUE self)
  * @return [Typelib::Type] self
  * @see endian_swap
  */
-static
-VALUE value_endian_swap_b(VALUE self, VALUE rb_compile)
-{
-    Value& value = rb2cxx::object<Value>(self);
+static VALUE value_endian_swap_b(VALUE self, VALUE rb_compile) {
+    Value &value = rb2cxx::object<Value>(self);
     endian_swap(value);
     return self;
 }
 
-static
-VALUE value_do_cast(VALUE self, VALUE target_type)
-{
-    Value& value = rb2cxx::object<Value>(self);
-    Type const& to_type(rb2cxx::object<Type>(target_type));
+static VALUE value_do_cast(VALUE self, VALUE target_type) {
+    Value &value = rb2cxx::object<Value>(self);
+    Type const &to_type(rb2cxx::object<Type>(target_type));
 
     if (value.getType() == to_type)
         return self;
 
     VALUE registry = rb_iv_get(target_type, "@registry");
     Value casted(value.getData(), to_type);
-#   ifdef VERBOSE
+#ifdef VERBOSE
     fprintf(stderr, "wrapping casted value\n");
-#   endif
+#endif
 
     return cxx2rb::value_wrap(casted, registry, self);
 }
 
-static
-VALUE value_invalidate(VALUE self)
-{
+static VALUE value_invalidate(VALUE self) {
     if (NIL_P(rb_iv_get(self, "@parent")))
         rb_raise(rb_eArgError, "cannot invalidate a toplevel value");
 
-    Value& value = rb2cxx::object<Value>(self);
+    Value &value = rb2cxx::object<Value>(self);
 #ifdef VERBOSE
-    fprintf(stderr, "invalidating %llu, ptr=%p\n", NUM2ULL(rb_obj_id(self)), value.getData());
+    fprintf(stderr, "invalidating %llu, ptr=%p\n", NUM2ULL(rb_obj_id(self)),
+            value.getData());
 #endif
     value = Value(0, value.getType());
     rb_funcall(rb_iv_get(self, "@ptr"), rb_intern("invalidate"), 0);
     return Qnil;
 }
 
-static
-VALUE value_do_byte_array(VALUE self, VALUE pointers, VALUE opaques, VALUE merge, VALUE remove_trailing_skips)
-{
-    Value& value = rb2cxx::object<Value>(self);
-    MemoryLayout layout = Typelib::layout_of(value.getType(), RTEST(pointers), RTEST(opaques), RTEST(merge), RTEST(remove_trailing_skips));
+static VALUE value_do_byte_array(VALUE self, VALUE pointers, VALUE opaques,
+                                 VALUE merge, VALUE remove_trailing_skips) {
+    Value &value = rb2cxx::object<Value>(self);
+    MemoryLayout layout =
+        Typelib::layout_of(value.getType(), RTEST(pointers), RTEST(opaques),
+                           RTEST(merge), RTEST(remove_trailing_skips));
 
     vector<uint8_t> buffer;
     Typelib::dump(value, buffer, layout);
-    return rb_str_new(reinterpret_cast<char*>(&buffer[0]), buffer.size());
+    return rb_str_new(reinterpret_cast<char *>(&buffer[0]), buffer.size());
 }
 
 /* call-seq:
@@ -547,49 +544,48 @@ VALUE value_do_byte_array(VALUE self, VALUE pointers, VALUE opaques, VALUE merge
  * Returns the size of this value once marshalled by Typelib, i.e. the size of
  * the byte array returned by #to_byte_array
  */
-static
-VALUE value_marshalling_size(VALUE self)
-{
-    Value& value = rb2cxx::object<Value>(self);
-    try { return INT2NUM(Typelib::getDumpSize(value)); }
-    catch(Typelib::NoLayout)
-    { return Qnil; }
+static VALUE value_marshalling_size(VALUE self) {
+    Value &value = rb2cxx::object<Value>(self);
+    try {
+        return INT2NUM(Typelib::getDumpSize(value));
+    } catch (Typelib::NoLayout) {
+        return Qnil;
+    }
 }
 
-VALUE value_memory_eql_p(VALUE rbself, VALUE rbwith)
-{
-    Value& self = rb2cxx::object<Value>(rbself);
-    Value& with = rb2cxx::object<Value>(rbwith);
-	
+VALUE value_memory_eql_p(VALUE rbself, VALUE rbwith) {
+    Value &self = rb2cxx::object<Value>(rbself);
+    Value &with = rb2cxx::object<Value>(rbwith);
+
     if (self.getData() == with.getData())
-	return Qtrue;
-    
+        return Qtrue;
+
     // Type#== checks for type equality before calling memory_equal?
-    Type const& type = self.getType();
-    return memcmp(self.getData(), with.getData(), type.getSize()) == 0 ? Qtrue : Qfalse;
+    Type const &type = self.getType();
+    return memcmp(self.getData(), with.getData(), type.getSize()) == 0 ? Qtrue
+                                                                       : Qfalse;
 }
 
-VALUE typelib_ruby::value_get_registry(VALUE self)
-{
+VALUE typelib_ruby::value_get_registry(VALUE self) {
     VALUE type = rb_funcall(self, rb_intern("class"), 0);
     return rb_iv_get(type, "@registry");
 }
 
-/** 
+/**
  * call-seq:
  *   value.to_csv([separator])	    => string
  *
- * Returns a one-line representation of this value, using +separator+ 
+ * Returns a one-line representation of this value, using +separator+
  * to separate each fields
  */
-static VALUE value_to_csv(int argc, VALUE* argv, VALUE self)
-{
+static VALUE value_to_csv(int argc, VALUE *argv, VALUE self) {
     VALUE separator = Qnil;
     rb_scan_args(argc, argv, "01", &separator);
 
-    Value const& value(rb2cxx::object<Value>(self));
+    Value const &value(rb2cxx::object<Value>(self));
     std::string sep = " ";
-    if (!NIL_P(separator)) sep = StringValuePtr(separator);
+    if (!NIL_P(separator))
+        sep = StringValuePtr(separator);
 
     std::ostringstream stream;
     stream << csv(value.getType(), value.getData(), sep);
@@ -598,20 +594,17 @@ static VALUE value_to_csv(int argc, VALUE* argv, VALUE self)
 }
 
 /* Initializes the memory to 0 */
-static VALUE value_zero(VALUE self)
-{
-    Value const& value(rb2cxx::object<Value>(self));
+static VALUE value_zero(VALUE self) {
+    Value const &value(rb2cxx::object<Value>(self));
     Typelib::zero(value);
     return self;
 }
 
-static VALUE typelib_do_copy(VALUE, VALUE to, VALUE from)
-{
+static VALUE typelib_do_copy(VALUE, VALUE to, VALUE from) {
     Value v_from = rb2cxx::object<Value>(from);
-    Value v_to   = rb2cxx::object<Value>(to);
+    Value v_to = rb2cxx::object<Value>(to);
 
-    if (v_from.getType() != v_to.getType())
-    {
+    if (v_from.getType() != v_to.getType()) {
         // Do a deep check for type equality
         if (!v_from.getType().canCastTo(v_to.getType()))
             rb_raise(rb_eArgError, "cannot copy: types are not compatible");
@@ -626,63 +619,81 @@ static VALUE typelib_do_copy(VALUE, VALUE to, VALUE from)
  * Proper comparison of two values. +to+ and +from+'s types do not have to be of
  * the same registries, as long as the types can be cast'ed into each other.
  */
-static VALUE typelib_compare(VALUE, VALUE to, VALUE from)
-{
+static VALUE typelib_compare(VALUE, VALUE to, VALUE from) {
     Value v_from = rb2cxx::object<Value>(from);
-    Value v_to   = rb2cxx::object<Value>(to);
+    Value v_to = rb2cxx::object<Value>(to);
 
-    if (v_from.getType() != v_to.getType())
-    {
+    if (v_from.getType() != v_to.getType()) {
         // Do a deep check for type equality
         if (!v_from.getType().canCastTo(v_to.getType()))
-            rb_raise(rb_eArgError, "cannot compare: %s and %s are not compatible types",
-                    v_from.getType().getName().c_str(),
-                    v_to.getType().getName().c_str());
+            rb_raise(rb_eArgError,
+                     "cannot compare: %s and %s are not compatible types",
+                     v_from.getType().getName().c_str(),
+                     v_to.getType().getName().c_str());
     }
     try {
-        bool result = Typelib::compare(v_to.getData(), v_from.getData(), v_from.getType());
+        bool result = Typelib::compare(v_to.getData(), v_from.getData(),
+                                       v_from.getType());
         return result ? Qtrue : Qfalse;
-    } catch(std::exception const& e) {
+    } catch (std::exception const &e) {
         rb_raise(rb_eArgError, "%s", e.what());
     }
 }
 
+void typelib_ruby::Typelib_init_values() {
+    VALUE mTypelib = rb_define_module("Typelib");
+    rb_define_singleton_method(mTypelib, "do_copy",
+                               RUBY_METHOD_FUNC(typelib_do_copy), 2);
+    rb_define_singleton_method(mTypelib, "compare",
+                               RUBY_METHOD_FUNC(typelib_compare), 2);
 
-void typelib_ruby::Typelib_init_values()
-{
-    VALUE mTypelib  = rb_define_module("Typelib");
-    rb_define_singleton_method(mTypelib, "do_copy", RUBY_METHOD_FUNC(typelib_do_copy), 2);
-    rb_define_singleton_method(mTypelib, "compare", RUBY_METHOD_FUNC(typelib_compare), 2);
-
-    cType     = rb_define_class_under(mTypelib, "Type", rb_cObject);
+    cType = rb_define_class_under(mTypelib, "Type", rb_cObject);
     rb_define_alloc_func(cType, value_alloc);
-    rb_define_singleton_method(cType, "==",	       RUBY_METHOD_FUNC(type_equal_operator), 1);
-    rb_define_singleton_method(cType, "size",          RUBY_METHOD_FUNC(&type_size), 0);
-    rb_define_singleton_method(cType, "do_memory_layout", RUBY_METHOD_FUNC(&type_memory_layout), 4);
-    rb_define_singleton_method(cType, "do_dependencies",  RUBY_METHOD_FUNC(&type_dependencies), 0);
-    rb_define_singleton_method(cType, "casts_to?",     RUBY_METHOD_FUNC(&type_can_cast_to), 1);
-    rb_define_singleton_method(cType, "value_new", RUBY_METHOD_FUNC(&value_new), 0);
-    rb_define_singleton_method(cType, "from_memory_zone", RUBY_METHOD_FUNC(&value_from_memory_zone), 1);
-    rb_define_singleton_method(cType, "from_address", RUBY_METHOD_FUNC(&value_from_address), 1);
+    rb_define_singleton_method(cType, "==",
+                               RUBY_METHOD_FUNC(type_equal_operator), 1);
+    rb_define_singleton_method(cType, "size", RUBY_METHOD_FUNC(&type_size), 0);
+    rb_define_singleton_method(cType, "do_memory_layout",
+                               RUBY_METHOD_FUNC(&type_memory_layout), 4);
+    rb_define_singleton_method(cType, "do_dependencies",
+                               RUBY_METHOD_FUNC(&type_dependencies), 0);
+    rb_define_singleton_method(cType, "casts_to?",
+                               RUBY_METHOD_FUNC(&type_can_cast_to), 1);
+    rb_define_singleton_method(cType, "value_new", RUBY_METHOD_FUNC(&value_new),
+                               0);
+    rb_define_singleton_method(cType, "from_memory_zone",
+                               RUBY_METHOD_FUNC(&value_from_memory_zone), 1);
+    rb_define_singleton_method(cType, "from_address",
+                               RUBY_METHOD_FUNC(&value_from_address), 1);
 
-    rb_define_method(cType, "do_from_buffer", RUBY_METHOD_FUNC(&value_do_from_buffer), 5);
-    rb_define_method(cType, "zero!",      RUBY_METHOD_FUNC(&value_zero), 0);
-    rb_define_method(cType, "memory_eql?",      RUBY_METHOD_FUNC(&value_memory_eql_p), 1);
-    rb_define_method(cType, "endian_swap",      RUBY_METHOD_FUNC(&value_endian_swap), 0);
-    rb_define_method(cType, "endian_swap!",      RUBY_METHOD_FUNC(&value_endian_swap_b), 0);
-    rb_define_method(cType, "zone_address", RUBY_METHOD_FUNC(&value_address), 0);
+    rb_define_method(cType, "do_from_buffer",
+                     RUBY_METHOD_FUNC(&value_do_from_buffer), 5);
+    rb_define_method(cType, "zero!", RUBY_METHOD_FUNC(&value_zero), 0);
+    rb_define_method(cType, "memory_eql?",
+                     RUBY_METHOD_FUNC(&value_memory_eql_p), 1);
+    rb_define_method(cType, "endian_swap", RUBY_METHOD_FUNC(&value_endian_swap),
+                     0);
+    rb_define_method(cType, "endian_swap!",
+                     RUBY_METHOD_FUNC(&value_endian_swap_b), 0);
+    rb_define_method(cType, "zone_address", RUBY_METHOD_FUNC(&value_address),
+                     0);
     rb_define_method(cType, "do_cast", RUBY_METHOD_FUNC(&value_do_cast), 1);
-    rb_define_method(cType, "do_invalidate", RUBY_METHOD_FUNC(&value_invalidate), 0);
+    rb_define_method(cType, "do_invalidate",
+                     RUBY_METHOD_FUNC(&value_invalidate), 0);
 
-    rb_define_singleton_method(mTypelib, "do_basename",  RUBY_METHOD_FUNC(typelib_do_basename), 1);
-    rb_define_singleton_method(mTypelib, "do_namespace", RUBY_METHOD_FUNC(typelib_do_namespace), 1);
-    rb_define_singleton_method(mTypelib, "split_typename", RUBY_METHOD_FUNC(typelib_do_split_name), 1);
+    rb_define_singleton_method(mTypelib, "do_basename",
+                               RUBY_METHOD_FUNC(typelib_do_basename), 1);
+    rb_define_singleton_method(mTypelib, "do_namespace",
+                               RUBY_METHOD_FUNC(typelib_do_namespace), 1);
+    rb_define_singleton_method(mTypelib, "split_typename",
+                               RUBY_METHOD_FUNC(typelib_do_split_name), 1);
 
-    rb_define_singleton_method(cType, "to_csv", RUBY_METHOD_FUNC(type_to_csv), -1);
+    rb_define_singleton_method(cType, "to_csv", RUBY_METHOD_FUNC(type_to_csv),
+                               -1);
     rb_define_method(cType, "to_csv", RUBY_METHOD_FUNC(value_to_csv), -1);
-    rb_define_method(cType, "do_byte_array", RUBY_METHOD_FUNC(value_do_byte_array), 4);
-    rb_define_method(cType, "marshalling_size", RUBY_METHOD_FUNC(value_marshalling_size), 0);
+    rb_define_method(cType, "do_byte_array",
+                     RUBY_METHOD_FUNC(value_do_byte_array), 4);
+    rb_define_method(cType, "marshalling_size",
+                     RUBY_METHOD_FUNC(value_marshalling_size), 0);
 
     Typelib_init_specialized_types();
 }
-

--- a/lang/csupport/containers.cc
+++ b/lang/csupport/containers.cc
@@ -12,75 +12,62 @@
 using namespace Typelib;
 using namespace std;
 
-BOOST_STATIC_ASSERT(( sizeof(vector<void*>) == sizeof(vector<char>) ));
+BOOST_STATIC_ASSERT((sizeof(vector<void *>) == sizeof(vector<char>)));
 
-string Vector::fullName(std::string const& element_name)
-{ return "/std/vector<" + element_name + ">"; }
+string Vector::fullName(std::string const &element_name) {
+    return "/std/vector<" + element_name + ">";
+}
 
-Vector::Vector(Type const& on)
-    : Container("/std/vector", fullName(on.getName()), getNaturalSize(), on)
-    , is_memcpy(false)
-{
+Vector::Vector(Type const &on)
+    : Container("/std/vector", fullName(on.getName()), getNaturalSize(), on),
+      is_memcpy(false) {
     try {
         MemoryLayout ops = Typelib::layout_of(on);
         is_memcpy = (ops.size() == 2 && ops[0] == MemLayout::FLAG_MEMCPY);
-    }
-    catch(std::runtime_error)
-    {
+    } catch (std::runtime_error) {
         // No layout for this type. Simply disable memcpy
         is_memcpy = false;
     }
 }
 
-size_t Vector::getElementCount(void const* ptr) const
-{
-    size_t byte_count = reinterpret_cast< std::vector<int8_t> const* >(ptr)->size();
+size_t Vector::getElementCount(void const *ptr) const {
+    size_t byte_count =
+        reinterpret_cast<std::vector<int8_t> const *>(ptr)->size();
     return byte_count / getIndirection().getSize();
 }
-void Vector::init(void* ptr) const
-{
-    new(ptr) vector<int8_t>();
-}
-void Vector::destroy(void* ptr) const
-{
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
+void Vector::init(void *ptr) const { new (ptr) vector<int8_t>(); }
+void Vector::destroy(void *ptr) const {
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(ptr);
     resize(vector_ptr, 0);
     vector_ptr->~vector<uint8_t>();
 }
-void Vector::clear(void* ptr) const
-{
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
+void Vector::clear(void *ptr) const {
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(ptr);
     resize(vector_ptr, 0);
 }
 
-bool Vector::isRandomAccess() const
-{ return true; }
-void Vector::setElement(void* ptr, int idx, Typelib::Value value) const
-{
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
-    Typelib::copy(
-        Value(&(*vector_ptr)[idx * getIndirection().getSize()], getIndirection()),
-        value);
+bool Vector::isRandomAccess() const { return true; }
+void Vector::setElement(void *ptr, int idx, Typelib::Value value) const {
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(ptr);
+    Typelib::copy(Value(&(*vector_ptr)[idx * getIndirection().getSize()],
+                        getIndirection()),
+                  value);
 }
 
-Typelib::Value Vector::getElement(void* ptr, int idx) const
-{
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
-    return Value(&(*vector_ptr)[idx * getIndirection().getSize()], getIndirection());
+Typelib::Value Vector::getElement(void *ptr, int idx) const {
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(ptr);
+    return Value(&(*vector_ptr)[idx * getIndirection().getSize()],
+                 getIndirection());
 }
 
-long Vector::getNaturalSize() const
-{
-    return sizeof(std::vector<void*>);
-}
+long Vector::getNaturalSize() const { return sizeof(std::vector<void *>); }
 
-void Vector::resize(std::vector<uint8_t>* ptr, size_t new_size) const
-{
-    Type const& element_t = getIndirection();
+void Vector::resize(std::vector<uint8_t> *ptr, size_t new_size) const {
+    Type const &element_t = getIndirection();
     size_t element_size = getIndirection().getSize();
 
     //
@@ -95,12 +82,11 @@ void Vector::resize(std::vector<uint8_t>* ptr, size_t new_size) const
     // This assumption is tested in test_containers.cc in the C++ test suite
     //
 
-    size_t old_raw_size   = ptr->size();
-    size_t old_size       = getElementCount(ptr);
-    size_t new_raw_size   = new_size * element_size;
+    size_t old_raw_size = ptr->size();
+    size_t old_size = getElementCount(ptr);
+    size_t new_raw_size = new_size * element_size;
 
-    if (!is_memcpy && old_size > new_size)
-    {
+    if (!is_memcpy && old_size > new_size) {
         // Need to destroy the elements that are at the end of the container
         for (size_t i = new_raw_size; i < old_raw_size; i += element_size)
             Typelib::destroy(Value(&(*ptr)[i], element_t));
@@ -108,48 +94,43 @@ void Vector::resize(std::vector<uint8_t>* ptr, size_t new_size) const
 
     ptr->resize(new_raw_size);
 
-    if (!is_memcpy && old_size < new_size)
-    {
+    if (!is_memcpy && old_size < new_size) {
         // Need to initialize the new elements at the end of the container
         for (size_t i = old_raw_size; i < new_raw_size; i += element_size)
             Typelib::init(Value(&(*ptr)[i], element_t));
     }
 }
 
-void Vector::push(void* ptr, Value v) const
-{
+void Vector::push(void *ptr, Value v) const {
     if (v.getType() != getIndirection())
         throw std::runtime_error("type mismatch in vector insertion");
 
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(ptr);
 
     size_t size = getElementCount(ptr);
     resize(vector_ptr, size + 1);
-    Typelib::copy(
-            Value(&(*vector_ptr)[size * getIndirection().getSize()], getIndirection()),
-            v);
+    Typelib::copy(Value(&(*vector_ptr)[size * getIndirection().getSize()],
+                        getIndirection()),
+                  v);
 }
 
-bool Vector::erase(void* ptr, Value v) const
-{
+bool Vector::erase(void *ptr, Value v) const {
     if (v.getType() != getIndirection())
         throw std::runtime_error("type mismatch in vector insertion");
 
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
-    Type const& element_t  = getIndirection();
-    size_t   element_size  = element_t.getSize();
-    size_t   element_count = getElementCount(vector_ptr);
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(ptr);
+    Type const &element_t = getIndirection();
+    size_t element_size = element_t.getSize();
+    size_t element_count = getElementCount(vector_ptr);
 
-    uint8_t* base_ptr = &(*vector_ptr)[0];
+    uint8_t *base_ptr = &(*vector_ptr)[0];
 
-    for (size_t i = 0; i < element_count; ++i)
-    {
-        uint8_t* element_ptr = base_ptr + i * element_size;
-        Value    element_v(element_ptr, element_t);
-        if (Typelib::compare(element_v, v))
-        {
+    for (size_t i = 0; i < element_count; ++i) {
+        uint8_t *element_ptr = base_ptr + i * element_size;
+        Value element_v(element_ptr, element_t);
+        if (Typelib::compare(element_v, v)) {
             erase(vector_ptr, i);
             return true;
         }
@@ -157,8 +138,7 @@ bool Vector::erase(void* ptr, Value v) const
     return false;
 }
 
-void Vector::erase(std::vector<uint8_t>* ptr, size_t idx) const
-{
+void Vector::erase(std::vector<uint8_t> *ptr, size_t idx) const {
     // Copy the remaining elements to the right place
     size_t element_count = getElementCount(ptr);
     if (element_count > idx + 1)
@@ -168,76 +148,65 @@ void Vector::erase(std::vector<uint8_t>* ptr, size_t idx) const
     resize(ptr, element_count - 1);
 }
 
-bool Vector::compare(void* ptr, void* other) const
-{
-    std::vector<uint8_t>* a_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
-    std::vector<uint8_t>* b_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(other);
+bool Vector::compare(void *ptr, void *other) const {
+    std::vector<uint8_t> *a_ptr = reinterpret_cast<std::vector<uint8_t> *>(ptr);
+    std::vector<uint8_t> *b_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(other);
 
-    size_t   element_count = getElementCount(a_ptr);
-    Type const& element_t  = getIndirection();
-    size_t   element_size  = element_t.getSize();
+    size_t element_count = getElementCount(a_ptr);
+    Type const &element_t = getIndirection();
+    size_t element_size = element_t.getSize();
     if (element_count != getElementCount(b_ptr))
         return false;
 
-    uint8_t* base_a = &(*a_ptr)[0];
-    uint8_t* base_b = &(*b_ptr)[0];
-    for (size_t i = 0; i < element_count; ++i)
-    {
-        if (!Typelib::compare(
-                    Value(base_a + i * element_size, element_t),
-                    Value(base_b + i * element_size, element_t)))
+    uint8_t *base_a = &(*a_ptr)[0];
+    uint8_t *base_b = &(*b_ptr)[0];
+    for (size_t i = 0; i < element_count; ++i) {
+        if (!Typelib::compare(Value(base_a + i * element_size, element_t),
+                              Value(base_b + i * element_size, element_t)))
             return false;
     }
     return true;
 }
 
-void Vector::copy(void* dst, void* src) const
-{
-    std::vector<uint8_t>* dst_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(dst);
-    std::vector<uint8_t>* src_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(src);
+void Vector::copy(void *dst, void *src) const {
+    std::vector<uint8_t> *dst_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(dst);
+    std::vector<uint8_t> *src_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(src);
 
     size_t element_count = getElementCount(src_ptr);
     resize(dst_ptr, element_count);
     copy(dst_ptr, 0, src_ptr, 0, element_count);
 }
 
-void Vector::copy(std::vector<uint8_t>* dst_ptr, size_t dst_idx, std::vector<uint8_t>* src_ptr, size_t src_idx, size_t count) const
-{
-    Type const& element_t = getIndirection();
+void Vector::copy(std::vector<uint8_t> *dst_ptr, size_t dst_idx,
+                  std::vector<uint8_t> *src_ptr, size_t src_idx,
+                  size_t count) const {
+    Type const &element_t = getIndirection();
     size_t element_size = element_t.getSize();
-    uint8_t* base_src = &(*src_ptr)[src_idx * element_size];
-    uint8_t* base_dst = &(*dst_ptr)[dst_idx * element_size];
-    if (is_memcpy)
-    {
+    uint8_t *base_src = &(*src_ptr)[src_idx * element_size];
+    uint8_t *base_dst = &(*dst_ptr)[dst_idx * element_size];
+    if (is_memcpy) {
         if (dst_ptr == src_ptr)
             memmove(base_dst, base_src, element_size * count);
         else
             memcpy(base_dst, base_src, element_size * count);
-    }
-    else
-    {
-        for (size_t i = 0; i < count; ++i)
-        {
-            Typelib::copy(
-                    Value(base_dst + i * element_size, element_t),
-                    Value(base_src + i * element_size, element_t));
+    } else {
+        for (size_t i = 0; i < count; ++i) {
+            Typelib::copy(Value(base_dst + i * element_size, element_t),
+                          Value(base_src + i * element_size, element_t));
         }
     }
 }
 
-
-bool Vector::visit(void* ptr, ValueVisitor& visitor) const
-{
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
-    uint8_t* base = &(*vector_ptr)[0];
-    size_t   element_size  = getIndirection().getSize();
-    size_t   element_count = getElementCount(vector_ptr);
-    const Type &indirect(getIndirection()); 
+bool Vector::visit(void *ptr, ValueVisitor &visitor) const {
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(ptr);
+    uint8_t *base = &(*vector_ptr)[0];
+    size_t element_size = getIndirection().getSize();
+    size_t element_count = getElementCount(vector_ptr);
+    const Type &indirect(getIndirection());
 
     for (size_t i = 0; i < element_count; ++i)
         visitor.dispatch(Value(base + i * element_size, indirect));
@@ -245,186 +214,151 @@ bool Vector::visit(void* ptr, ValueVisitor& visitor) const
     return true;
 }
 
-void Vector::delete_if_impl(void* ptr, DeleteIfPredicate& pred) const
-{
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(ptr);
+void Vector::delete_if_impl(void *ptr, DeleteIfPredicate &pred) const {
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(ptr);
 
-    size_t   element_count = getElementCount(vector_ptr);
-    Type const&  element_t = getIndirection();
-    size_t   element_size  = element_t.getSize();
+    size_t element_count = getElementCount(vector_ptr);
+    Type const &element_t = getIndirection();
+    size_t element_size = element_t.getSize();
 
-    uint8_t* base = &(*vector_ptr)[0];
-    for (size_t i = 0; i < element_count; )
-    {
-        uint8_t* element_ptr = base + i * element_size;
-        Value    element_v(element_ptr, element_t);
-        if (pred.should_delete(element_v))
-        {
+    uint8_t *base = &(*vector_ptr)[0];
+    for (size_t i = 0; i < element_count;) {
+        uint8_t *element_ptr = base + i * element_size;
+        Value element_v(element_ptr, element_t);
+        if (pred.should_delete(element_v)) {
             erase(vector_ptr, i);
             element_count--;
-        }
-        else
+        } else
             ++i;
     }
 }
 
-Container::MarshalOps::const_iterator Vector::dump(
-        void const* container_ptr, size_t element_count, OutputStream& stream,
-        MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const
-{
-    std::vector<uint8_t> const* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t> const* >(container_ptr);
+Container::MarshalOps::const_iterator
+Vector::dump(void const *container_ptr, size_t element_count,
+             OutputStream &stream, MarshalOps::const_iterator const begin,
+             MarshalOps::const_iterator const end) const {
+    std::vector<uint8_t> const *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> const *>(container_ptr);
 
     MarshalOps::const_iterator it = begin;
-    if (is_memcpy)
-    {
+    if (is_memcpy) {
         // optimize a bit: do a huge memcpy if possible
-        size_t size       = *(++it) * element_count;
+        size_t size = *(++it) * element_count;
         stream.write(&(*vector_ptr)[0], size);
         return begin + 2;
-    }
-    else
-    {
+    } else {
         MarshalOps::const_iterator it_end = begin;
         size_t in_offset = 0;
-        for (size_t i = 0; i < element_count; ++i)
-        {
-            boost::tie(in_offset, it_end) = ValueOps::dump(
-                    &(*vector_ptr)[i * getIndirection().getSize()], 0,
-                    stream, begin, end);
+        for (size_t i = 0; i < element_count; ++i) {
+            boost::tie(in_offset, it_end) =
+                ValueOps::dump(&(*vector_ptr)[i * getIndirection().getSize()],
+                               0, stream, begin, end);
         }
         return it_end;
     }
 }
 
-Container::MarshalOps::const_iterator Vector::load(
-        void* container_ptr, size_t element_count,
-        InputStream& stream,
-        MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const
-{
-    std::vector<uint8_t>* vector_ptr =
-        reinterpret_cast< std::vector<uint8_t>* >(container_ptr);
+Container::MarshalOps::const_iterator
+Vector::load(void *container_ptr, size_t element_count, InputStream &stream,
+             MarshalOps::const_iterator const begin,
+             MarshalOps::const_iterator const end) const {
+    std::vector<uint8_t> *vector_ptr =
+        reinterpret_cast<std::vector<uint8_t> *>(container_ptr);
 
-    Type const& element_t = getIndirection();
-    size_t      element_size = element_t.getSize();
+    Type const &element_t = getIndirection();
+    size_t element_size = element_t.getSize();
     resize(vector_ptr, element_count);
 
     MarshalOps::const_iterator it = begin;
-    if (is_memcpy)
-    {
-        size_t size       = *(++it) * element_count;
+    if (is_memcpy) {
+        size_t size = *(++it) * element_count;
         stream.read(&(*vector_ptr)[0], size);
         return begin + 2;
-    }
-    else
-    {
+    } else {
         MarshalOps::const_iterator it_end;
         size_t out_offset = 0;
-        for (size_t i = 0; i < element_count; ++i)
-        {
-            boost::tie(out_offset, it_end) =
-                ValueOps::load(&(*vector_ptr)[i * element_size], 0,
-                    stream, begin, end);
+        for (size_t i = 0; i < element_count; ++i) {
+            boost::tie(out_offset, it_end) = ValueOps::load(
+                &(*vector_ptr)[i * element_size], 0, stream, begin, end);
         }
         return it_end;
     }
 }
 
-std::string Vector::getIndirectTypeName(std::string const& element_name) const
-{
+std::string Vector::getIndirectTypeName(std::string const &element_name) const {
     return Vector::fullName(element_name);
 }
 
-Container const& Vector::factory(Registry& registry, std::list<Type const*> const& on)
-{
+Container const &Vector::factory(Registry &registry,
+                                 std::list<Type const *> const &on) {
     if (on.size() != 1)
-        throw std::runtime_error("expected only one template argument for std::vector");
+        throw std::runtime_error(
+            "expected only one template argument for std::vector");
 
-    Type const& contained_type = *on.front();
+    Type const &contained_type = *on.front();
     std::string full_name = Vector::fullName(contained_type.getName());
-    if (! registry.has(full_name))
-    {
-        Vector* new_type = new Vector(contained_type);
+    if (!registry.has(full_name)) {
+        Vector *new_type = new Vector(contained_type);
         registry.add(new_type);
         return *new_type;
-    }
-    else
-        return dynamic_cast<Container const&>(*registry.get(full_name));
+    } else
+        return dynamic_cast<Container const &>(*registry.get(full_name));
 }
 Container::ContainerFactory Vector::getFactory() const { return factory; }
 
-
-Type const& String::getElementType(Typelib::Registry const& registry)
-{
+Type const &String::getElementType(Typelib::Registry const &registry) {
     if (std::numeric_limits<char>::is_signed)
         return *registry.get("/int8_t");
     else
         return *registry.get("/uint8_t");
 }
-String::String(Typelib::Registry const& registry)
-    : Container("/std/string", "/std/string", getNaturalSize(), String::getElementType(registry)) {}
+String::String(Typelib::Registry const &registry)
+    : Container("/std/string", "/std/string", getNaturalSize(),
+                String::getElementType(registry)) {}
 
-size_t String::getElementCount(void const* ptr) const
-{
-    size_t byte_count = reinterpret_cast< std::string const* >(ptr)->length();
+size_t String::getElementCount(void const *ptr) const {
+    size_t byte_count = reinterpret_cast<std::string const *>(ptr)->length();
     return byte_count / getIndirection().getSize();
 }
-void String::init(void* ptr) const
-{
-    new(ptr) std::string();
+void String::init(void *ptr) const { new (ptr) std::string(); }
+void String::destroy(void *ptr) const {
+    reinterpret_cast<std::string *>(ptr)->~string();
 }
-void String::destroy(void* ptr) const
-{
-    reinterpret_cast< std::string* >(ptr)->~string();
-}
-void String::clear(void* ptr) const
-{
-    reinterpret_cast< std::string* >(ptr)->clear();
+void String::clear(void *ptr) const {
+    reinterpret_cast<std::string *>(ptr)->clear();
 }
 
+long String::getNaturalSize() const { return sizeof(std::string); }
 
-long String::getNaturalSize() const
-{
-    return sizeof(std::string);
-}
-
-void String::push(void* ptr, Value v) const
-{
+void String::push(void *ptr, Value v) const {
     if (v.getType() != getIndirection())
         throw std::runtime_error("type mismatch in string insertion");
 
-    std::string* string_ptr =
-        reinterpret_cast< std::string* >(ptr);
+    std::string *string_ptr = reinterpret_cast<std::string *>(ptr);
 
-    string_ptr->append(reinterpret_cast<std::string::value_type*>(v.getData()), 1);
+    string_ptr->append(reinterpret_cast<std::string::value_type *>(v.getData()),
+                       1);
 }
 
-bool String::erase(void* ptr, Value v) const
-{
-    return false;
-}
+bool String::erase(void *ptr, Value v) const { return false; }
 
-bool String::compare(void* ptr, void* other) const
-{
-    std::string* a_ptr = reinterpret_cast< std::string* >(ptr);
-    std::string* b_ptr = reinterpret_cast< std::string* >(other);
+bool String::compare(void *ptr, void *other) const {
+    std::string *a_ptr = reinterpret_cast<std::string *>(ptr);
+    std::string *b_ptr = reinterpret_cast<std::string *>(other);
     return *a_ptr == *b_ptr;
 }
 
-void String::copy(void* dst, void* src) const
-{
-    std::string* dst_ptr = reinterpret_cast< std::string* >(dst);
-    std::string* src_ptr = reinterpret_cast< std::string* >(src);
+void String::copy(void *dst, void *src) const {
+    std::string *dst_ptr = reinterpret_cast<std::string *>(dst);
+    std::string *src_ptr = reinterpret_cast<std::string *>(src);
     *dst_ptr = *src_ptr;
 }
 
-bool String::visit(void* ptr, ValueVisitor& visitor) const
-{
-    std::string* string_ptr =
-        reinterpret_cast< std::string* >(ptr);
-    char* base = const_cast<char*>(string_ptr->c_str());
-    size_t   element_count = string_ptr->length();
+bool String::visit(void *ptr, ValueVisitor &visitor) const {
+    std::string *string_ptr = reinterpret_cast<std::string *>(ptr);
+    char *base = const_cast<char *>(string_ptr->c_str());
+    size_t element_count = string_ptr->length();
 
     for (size_t i = 0; i < element_count; ++i)
         visitor.dispatch(Value(base + i, getIndirection()));
@@ -432,50 +366,51 @@ bool String::visit(void* ptr, ValueVisitor& visitor) const
     return true;
 }
 
-Container::MarshalOps::const_iterator String::dump(
-        void const* container_ptr, size_t element_count, OutputStream& stream,
-        MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const
-{
-    const std::string* string_ptr =
-        reinterpret_cast< const std::string* >(container_ptr);
+Container::MarshalOps::const_iterator
+String::dump(void const *container_ptr, size_t element_count,
+             OutputStream &stream, MarshalOps::const_iterator const begin,
+             MarshalOps::const_iterator const end) const {
+    const std::string *string_ptr =
+        reinterpret_cast<const std::string *>(container_ptr);
 
-    stream.write(reinterpret_cast<uint8_t const*>(string_ptr->c_str()), element_count);
+    stream.write(reinterpret_cast<uint8_t const *>(string_ptr->c_str()),
+                 element_count);
     return begin + 2;
 }
 
-Container::MarshalOps::const_iterator String::load(
-        void* container_ptr, size_t element_count,
-        InputStream& stream,
-        MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const
-{
-    std::string* string_ptr =
-        reinterpret_cast< std::string* >(container_ptr);
+Container::MarshalOps::const_iterator
+String::load(void *container_ptr, size_t element_count, InputStream &stream,
+             MarshalOps::const_iterator const begin,
+             MarshalOps::const_iterator const end) const {
+    std::string *string_ptr = reinterpret_cast<std::string *>(container_ptr);
 
     std::vector<uint8_t> buffer;
     buffer.resize(element_count);
     stream.read(&buffer[0], element_count);
-    (*string_ptr).append(reinterpret_cast<const char*>(&buffer[0]), element_count);
+    (*string_ptr)
+        .append(reinterpret_cast<const char *>(&buffer[0]), element_count);
     return begin + 2;
 }
-void String::delete_if_impl(void* ptr, DeleteIfPredicate& pred) const
-{}
+void String::delete_if_impl(void *ptr, DeleteIfPredicate &pred) const {}
 
-Container const& String::factory(Registry& registry, std::list<Type const*> const& on)
-{
+Container const &String::factory(Registry &registry,
+                                 std::list<Type const *> const &on) {
     if (registry.has("/std/string"))
-        return dynamic_cast<Container const&>(*registry.get("/std/string"));
+        return dynamic_cast<Container const &>(*registry.get("/std/string"));
 
     if (on.size() != 1)
-        throw std::runtime_error("expected only one template argument for std::string");
+        throw std::runtime_error(
+            "expected only one template argument for std::string");
 
-    Type const& contained_type = *on.front();
-    Type const& expected_type  = String::getElementType(registry);
+    Type const &contained_type = *on.front();
+    Type const &expected_type = String::getElementType(registry);
     if (contained_type != expected_type)
-        throw std::runtime_error("std::string can only be built on top of '" + expected_type.getName() + "' -- found " + contained_type.getName());
+        throw std::runtime_error("std::string can only be built on top of '" +
+                                 expected_type.getName() + "' -- found " +
+                                 contained_type.getName());
 
-    String* new_type = new String(registry);
+    String *new_type = new String(registry);
     registry.add(new_type);
     return *new_type;
 }
 Container::ContainerFactory String::getFactory() const { return factory; }
-

--- a/lang/csupport/containers.hh
+++ b/lang/csupport/containers.hh
@@ -3,91 +3,97 @@
 
 #include <typelib/typemodel.hh>
 
-class Vector : public Typelib::Container
-{
+class Vector : public Typelib::Container {
     bool is_memcpy;
     using Typelib::Container::resize;
-    void resize(std::vector<uint8_t>* ptr, size_t new_size) const;
-    void copy(std::vector<uint8_t>* dst_ptr, size_t dst_idx, std::vector<uint8_t>* src_ptr, size_t src_idx, size_t count) const;
-    void erase(std::vector<uint8_t>* ptr, size_t idx) const;
-    std::string getIndirectTypeName(std::string const& element_name) const;
+    void resize(std::vector<uint8_t> *ptr, size_t new_size) const;
+    void copy(std::vector<uint8_t> *dst_ptr, size_t dst_idx,
+              std::vector<uint8_t> *src_ptr, size_t src_idx,
+              size_t count) const;
+    void erase(std::vector<uint8_t> *ptr, size_t idx) const;
+    std::string getIndirectTypeName(std::string const &element_name) const;
 
-public:
-    static std::string fullName(std::string const& element_name);
-    Vector(Typelib::Type const& on);
+  public:
+    static std::string fullName(std::string const &element_name);
+    Vector(Typelib::Type const &on);
 
     bool isRandomAccess() const;
-    void setElement(void* ptr, int idx, Typelib::Value value) const;
-    Typelib::Value getElement(void* ptr, int idx) const;
+    void setElement(void *ptr, int idx, Typelib::Value value) const;
+    Typelib::Value getElement(void *ptr, int idx) const;
 
-    size_t getElementCount(void const* ptr) const;
-    void init(void* ptr) const;
-    void destroy(void* ptr) const;
-    void clear(void*) const;
+    size_t getElementCount(void const *ptr) const;
+    void init(void *ptr) const;
+    void destroy(void *ptr) const;
+    void clear(void *) const;
     long getNaturalSize() const;
-    void push(void* ptr, Typelib::Value v) const;
-    bool erase(void* ptr, Typelib::Value v) const;
-    bool compare(void* ptr, void* other) const;
-    void copy(void* dst, void* src) const;
-    bool visit(void* ptr, Typelib::ValueVisitor& visitor) const;
-    void delete_if_impl(void* ptr, DeleteIfPredicate& pred) const;
+    void push(void *ptr, Typelib::Value v) const;
+    bool erase(void *ptr, Typelib::Value v) const;
+    bool compare(void *ptr, void *other) const;
+    void copy(void *dst, void *src) const;
+    bool visit(void *ptr, Typelib::ValueVisitor &visitor) const;
+    void delete_if_impl(void *ptr, DeleteIfPredicate &pred) const;
 
-    MarshalOps::const_iterator dump(
-            void const* container_ptr, size_t element_count, Typelib::OutputStream& stream,
-            MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const;
+    MarshalOps::const_iterator dump(void const *container_ptr,
+                                    size_t element_count,
+                                    Typelib::OutputStream &stream,
+                                    MarshalOps::const_iterator const begin,
+                                    MarshalOps::const_iterator const end) const;
 
-    MarshalOps::const_iterator load(
-            void* container_ptr, size_t element_count,
-            Typelib::InputStream& stream,
-            MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const;
+    MarshalOps::const_iterator load(void *container_ptr, size_t element_count,
+                                    Typelib::InputStream &stream,
+                                    MarshalOps::const_iterator const begin,
+                                    MarshalOps::const_iterator const end) const;
 
-    static Container const& factory(Typelib::Registry& registry, std::list<Typelib::Type const*> const& on);
+    static Container const &factory(Typelib::Registry &registry,
+                                    std::list<Typelib::Type const *> const &on);
     ContainerFactory getFactory() const;
 };
 
-class String : public Typelib::Container
-{
-public:
-    String(Typelib::Registry const& registry);
+class String : public Typelib::Container {
+  public:
+    String(Typelib::Registry const &registry);
 
-    size_t getElementCount(void const* ptr) const;
-    void init(void* ptr) const;
-    void destroy(void* ptr) const;
-    void clear(void*) const;
+    size_t getElementCount(void const *ptr) const;
+    void init(void *ptr) const;
+    void destroy(void *ptr) const;
+    void clear(void *) const;
 
     long getNaturalSize() const;
 
-    void push(void* ptr, Typelib::Value v) const;
+    void push(void *ptr, Typelib::Value v) const;
 
-    bool erase(void* ptr, Typelib::Value v) const;
+    bool erase(void *ptr, Typelib::Value v) const;
 
-    bool compare(void* ptr, void* other) const;
+    bool compare(void *ptr, void *other) const;
 
-    void copy(void* dst, void* src) const;
+    void copy(void *dst, void *src) const;
 
-    bool visit(void* ptr, Typelib::ValueVisitor& visitor) const;
+    bool visit(void *ptr, Typelib::ValueVisitor &visitor) const;
 
-    MarshalOps::const_iterator dump(
-            void const* container_ptr, size_t element_count, Typelib::OutputStream& stream,
-            MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const;
+    MarshalOps::const_iterator dump(void const *container_ptr,
+                                    size_t element_count,
+                                    Typelib::OutputStream &stream,
+                                    MarshalOps::const_iterator const begin,
+                                    MarshalOps::const_iterator const end) const;
 
-    MarshalOps::const_iterator load(
-            void* container_ptr, size_t element_count,
-            Typelib::InputStream& stream,
-            MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const;
+    MarshalOps::const_iterator load(void *container_ptr, size_t element_count,
+                                    Typelib::InputStream &stream,
+                                    MarshalOps::const_iterator const begin,
+                                    MarshalOps::const_iterator const end) const;
 
-    void delete_if_impl(void* ptr, DeleteIfPredicate& pred) const;
+    void delete_if_impl(void *ptr, DeleteIfPredicate &pred) const;
 
-    static Container const& factory(Typelib::Registry& registry, std::list<Type const*> const& on);
+    static Container const &factory(Typelib::Registry &registry,
+                                    std::list<Type const *> const &on);
     ContainerFactory getFactory() const;
 
-    static Type const& getElementType(Typelib::Registry const& registry);
+    static Type const &getElementType(Typelib::Registry const &registry);
 
     // This method is never called since we redefine modifiedDependencyAliases
-    std::string getIndirectTypeName(std::string const& element_name) const { return ""; }
-    void modifiedDependencyAliases(Typelib::Registry& registry) const {}
+    std::string getIndirectTypeName(std::string const &element_name) const {
+        return "";
+    }
+    void modifiedDependencyAliases(Typelib::Registry &registry) const {}
 };
 
-
 #endif
-

--- a/lang/csupport/plugin.cc
+++ b/lang/csupport/plugin.cc
@@ -1,9 +1,7 @@
 #include "containers.hh"
 #include <typelib/pluginmanager.hh>
 
-extern "C" void registerPlugins(Typelib::PluginManager& manager)
-{
+extern "C" void registerPlugins(Typelib::PluginManager &manager) {
     Typelib::Container::registerContainer("/std/vector", Vector::factory);
     Typelib::Container::registerContainer("/std/string", String::factory);
 }
-

--- a/lang/csupport/standard_types.cc
+++ b/lang/csupport/standard_types.cc
@@ -5,33 +5,40 @@
 
 using namespace Typelib;
 
-static void addStandardTypes(Typelib::Registry& r)
-{
+static void addStandardTypes(Typelib::Registry &r) {
     BOOST_STATIC_ASSERT((Typelib::NamespaceMark == '/'));
 
     r.add(new NullType("/nil"));
     r.alias("/nil", "/void");
-    
+
     // Add standard sized integers
-    static const int sizes[] = { 1, 2, 4, 8 };
-    for (int i = 0; i < 4; ++i)
-    {
-        std::string suffix = "int" + boost::lexical_cast<std::string>(sizes[i] * 8) + "_t";
-        r.add(new Numeric("/"  + suffix, sizes[i], Numeric::SInt));
+    static const int sizes[] = {1, 2, 4, 8};
+    for (int i = 0; i < 4; ++i) {
+        std::string suffix =
+            "int" + boost::lexical_cast<std::string>(sizes[i] * 8) + "_t";
+        r.add(new Numeric("/" + suffix, sizes[i], Numeric::SInt));
         r.add(new Numeric("/u" + suffix, sizes[i], Numeric::UInt));
     }
 
-    std::string normalized_type_name = "/int" + boost::lexical_cast<std::string>(std::numeric_limits<signed char>::digits + 1) + "_t";
+    std::string normalized_type_name =
+        "/int" + boost::lexical_cast<std::string>(
+                     std::numeric_limits<signed char>::digits + 1) +
+        "_t";
     r.alias(normalized_type_name, "/signed char");
     if (std::numeric_limits<char>::is_signed)
         r.alias(normalized_type_name, "/char");
-    normalized_type_name = "/uint" + boost::lexical_cast<std::string>(std::numeric_limits<signed char>::digits + 1) + "_t";
+    normalized_type_name = "/uint" +
+                           boost::lexical_cast<std::string>(
+                               std::numeric_limits<signed char>::digits + 1) +
+                           "_t";
     if (!std::numeric_limits<char>::is_signed)
         r.alias(normalized_type_name, "/char");
     r.alias(normalized_type_name, "/unsigned char");
 
-
-    normalized_type_name = "/int" + boost::lexical_cast<std::string>(std::numeric_limits<short int>::digits + 1) + "_t";
+    normalized_type_name = "/int" +
+                           boost::lexical_cast<std::string>(
+                               std::numeric_limits<short int>::digits + 1) +
+                           "_t";
     r.alias(normalized_type_name, "/signed short int");
     r.alias(normalized_type_name, "/signed int short");
     r.alias(normalized_type_name, "/int signed short");
@@ -41,7 +48,10 @@ static void addStandardTypes(Typelib::Registry& r)
     r.alias(normalized_type_name, "/short signed");
     r.alias(normalized_type_name, "/short");
     r.alias(normalized_type_name, "/short int");
-    normalized_type_name = "/uint" + boost::lexical_cast<std::string>(std::numeric_limits<short int>::digits + 1) + "_t";
+    normalized_type_name = "/uint" +
+                           boost::lexical_cast<std::string>(
+                               std::numeric_limits<short int>::digits + 1) +
+                           "_t";
     r.alias(normalized_type_name, "/short unsigned int");
     r.alias(normalized_type_name, "/short int unsigned");
     r.alias(normalized_type_name, "/int short unsigned");
@@ -49,17 +59,25 @@ static void addStandardTypes(Typelib::Registry& r)
     r.alias(normalized_type_name, "/short unsigned");
     r.alias(normalized_type_name, "/unsigned short");
 
-    normalized_type_name = "/int" + boost::lexical_cast<std::string>(std::numeric_limits<int>::digits + 1) + "_t";
+    normalized_type_name =
+        "/int" +
+        boost::lexical_cast<std::string>(std::numeric_limits<int>::digits + 1) +
+        "_t";
     r.alias(normalized_type_name, "/signed int");
     r.alias(normalized_type_name, "/signed");
     r.alias(normalized_type_name, "/int signed");
     r.alias(normalized_type_name, "/int");
-    normalized_type_name = "/uint" + boost::lexical_cast<std::string>(std::numeric_limits<int>::digits + 1) + "_t";
+    normalized_type_name =
+        "/uint" +
+        boost::lexical_cast<std::string>(std::numeric_limits<int>::digits + 1) +
+        "_t";
     r.alias(normalized_type_name, "/unsigned int");
     r.alias(normalized_type_name, "/unsigned");
     r.alias(normalized_type_name, "/int unsigned");
 
-    normalized_type_name = "/int" + boost::lexical_cast<std::string>(std::numeric_limits<long>::digits + 1) + "_t";
+    normalized_type_name = "/int" + boost::lexical_cast<std::string>(
+                                        std::numeric_limits<long>::digits + 1) +
+                           "_t";
     r.alias(normalized_type_name, "/signed long int");
     r.alias(normalized_type_name, "/signed int long");
     r.alias(normalized_type_name, "/int signed long");
@@ -69,7 +87,10 @@ static void addStandardTypes(Typelib::Registry& r)
     r.alias(normalized_type_name, "/long signed");
     r.alias(normalized_type_name, "/long");
     r.alias(normalized_type_name, "/long int");
-    normalized_type_name = "/uint" + boost::lexical_cast<std::string>(std::numeric_limits<long>::digits + 1) + "_t";
+    normalized_type_name = "/uint" +
+                           boost::lexical_cast<std::string>(
+                               std::numeric_limits<long>::digits + 1) +
+                           "_t";
     r.alias(normalized_type_name, "/long unsigned int");
     r.alias(normalized_type_name, "/long int unsigned");
     r.alias(normalized_type_name, "/int long unsigned");
@@ -77,7 +98,10 @@ static void addStandardTypes(Typelib::Registry& r)
     r.alias(normalized_type_name, "/long unsigned");
     r.alias(normalized_type_name, "/unsigned long");
 
-    normalized_type_name = "/int" + boost::lexical_cast<std::string>(std::numeric_limits<long long>::digits + 1) + "_t";
+    normalized_type_name = "/int" +
+                           boost::lexical_cast<std::string>(
+                               std::numeric_limits<long long>::digits + 1) +
+                           "_t";
     r.alias(normalized_type_name, "/signed long long int");
     r.alias(normalized_type_name, "/signed long int long");
     r.alias(normalized_type_name, "/signed int long long");
@@ -92,7 +116,10 @@ static void addStandardTypes(Typelib::Registry& r)
     r.alias(normalized_type_name, "/long int long");
     r.alias(normalized_type_name, "/int long long");
     r.alias(normalized_type_name, "/long long");
-    normalized_type_name = "/uint" + boost::lexical_cast<std::string>(std::numeric_limits<long long>::digits + 1) + "_t";
+    normalized_type_name = "/uint" +
+                           boost::lexical_cast<std::string>(
+                               std::numeric_limits<long long>::digits + 1) +
+                           "_t";
     r.alias(normalized_type_name, "/unsigned long long int");
     r.alias(normalized_type_name, "/unsigned long int long");
     r.alias(normalized_type_name, "/unsigned int long long");
@@ -104,21 +131,18 @@ static void addStandardTypes(Typelib::Registry& r)
     r.alias(normalized_type_name, "/long long unsigned");
     r.alias(normalized_type_name, "/long unsigned long");
 
-    BOOST_STATIC_ASSERT(( sizeof(float) == sizeof(int32_t) ));
-    BOOST_STATIC_ASSERT(( sizeof(double) == sizeof(int64_t) ));
-    r.add(new Numeric("/float",  4, Numeric::Float));
+    BOOST_STATIC_ASSERT((sizeof(float) == sizeof(int32_t)));
+    BOOST_STATIC_ASSERT((sizeof(double) == sizeof(int64_t)));
+    r.add(new Numeric("/float", 4, Numeric::Float));
     r.add(new Numeric("/double", 8, Numeric::Float));
 
     // Finally, add definition for boolean types
     r.add(new Numeric("/bool", sizeof(bool), Numeric::UInt));
 }
 
-
-void Typelib::CXX::addStandardTypes(Typelib::Registry& registry)
-{
+void Typelib::CXX::addStandardTypes(Typelib::Registry &registry) {
     if (!registry.has("/bool"))
         ::addStandardTypes(registry);
     if (!registry.has("/std/string"))
         registry.add(new String(registry));
 }
-

--- a/lang/csupport/standard_types.hh
+++ b/lang/csupport/standard_types.hh
@@ -3,14 +3,11 @@
 
 #include <typelib/registry.hh>
 
-namespace Typelib
-{
-    namespace CXX
-    {
-        /** Adds some definitions for standard C++ types that Typelib can handle */
-        void addStandardTypes(Typelib::Registry& registry);
-    }
+namespace Typelib {
+namespace CXX {
+/** Adds some definitions for standard C++ types that Typelib can handle */
+void addStandardTypes(Typelib::Registry &registry);
+}
 }
 
 #endif
-

--- a/lang/idl/export.cc
+++ b/lang/idl/export.cc
@@ -9,618 +9,588 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/replace.hpp>
 
-namespace
-{
-    using namespace std;
-    using namespace Typelib;
-    using boost::split;
-    using boost::join;
-    using boost::is_any_of;
+namespace {
+using namespace std;
+using namespace Typelib;
+using boost::split;
+using boost::join;
+using boost::is_any_of;
 
-    static list<string> nameSplit(std::string const& name)
-    {
-        list<string> separators;
-        split(separators, name, is_any_of("/"), boost::token_compress_on);
-        while(!separators.empty() && separators.front().empty())
-            separators.pop_front();
-        while(!separators.empty() && separators.back().empty())
-            separators.pop_back();
-        return separators;
+static list<string> nameSplit(std::string const &name) {
+    list<string> separators;
+    split(separators, name, is_any_of("/"), boost::token_compress_on);
+    while (!separators.empty() && separators.front().empty())
+        separators.pop_front();
+    while (!separators.empty() && separators.back().empty())
+        separators.pop_back();
+    return separators;
+}
+
+static size_t namespaceIndentLevel(std::string const &ns) {
+    return nameSplit(ns).size();
+}
+
+static string normalizeIDLName(std::string const &name) {
+    unsigned int template_mark;
+    string result = name;
+    while ((template_mark = result.find_first_of("<>/,")) < result.length())
+        result.replace(template_mark, 1, "_");
+    return result;
+}
+
+static string getIDLAbsoluteNamespace(std::string const &type_ns,
+                                      IDLExport const &exporter) {
+    string ns = type_ns;
+    string prefix = exporter.getNamespacePrefix();
+    string suffix = exporter.getNamespaceSuffix();
+    if (!prefix.empty())
+        ns = prefix + ns;
+    if (!suffix.empty())
+        ns += suffix;
+    return ns;
+}
+
+class IDLTypeIdentifierVisitor : public TypeVisitor {
+  public:
+    IDLExport const &m_exporter;
+    string m_front, m_back;
+    string m_namespace;
+
+    bool visit_(OpaqueType const &type);
+    bool visit_(NullType const &type);
+    bool visit_(Container const &type);
+    bool visit_(Compound const &type);
+
+    bool visit_(Numeric const &type);
+
+    bool visit_(Pointer const &type);
+    bool visit_(Array const &type);
+
+    bool visit_(Enum const &type);
+
+    IDLTypeIdentifierVisitor(IDLExport const &exporter)
+        : m_exporter(exporter) {}
+    string getTargetNamespace() const { return m_namespace; }
+    std::string getIDLAbsolute(Type const &type,
+                               std::string const &field_name = "");
+    std::string getIDLRelative(Type const &type,
+                               std::string const &field_name = "");
+    pair<string, string> getIDLBase(Type const &type,
+                                    std::string const &field_name = "");
+    void apply(Type const &type) {
+        m_namespace = getIDLAbsoluteNamespace(type.getNamespace(), m_exporter);
+        TypeVisitor::apply(type);
+        m_front = normalizeIDLName(m_front);
     }
+};
 
-    static size_t namespaceIndentLevel(std::string const& ns)
-    {
-        return nameSplit(ns).size();
-    }
-
-    static string normalizeIDLName(std::string const& name)
-    {
-        unsigned int template_mark;
-        string result = name;
-        while ((template_mark = result.find_first_of("<>/,")) < result.length())
-            result.replace(template_mark, 1, "_");
-        return result;
-    }
-
-    static string getIDLAbsoluteNamespace(std::string const& type_ns, IDLExport const& exporter)
-    {
-        string ns = type_ns;
-        string prefix = exporter.getNamespacePrefix();
-        string suffix = exporter.getNamespaceSuffix();
-        if (!prefix.empty())
-            ns = prefix + ns;
-        if (!suffix.empty())
-            ns += suffix;
-        return ns;
-    }
-
-    class IDLTypeIdentifierVisitor : public TypeVisitor
-    {
-    public:
-	IDLExport const& m_exporter;
-        string    m_front, m_back;
-        string    m_namespace;
-
-        bool visit_(OpaqueType const& type);
-        bool visit_(NullType const& type);
-        bool visit_(Container const& type);
-        bool visit_(Compound const& type);
-
-        bool visit_(Numeric const& type);
-
-        bool visit_(Pointer const& type);
-        bool visit_(Array const& type);
-
-        bool visit_(Enum const& type);
-
-        IDLTypeIdentifierVisitor(IDLExport const& exporter)
-            : m_exporter(exporter) {}
-        string getTargetNamespace() const { return m_namespace; }
-        std::string getIDLAbsolute(Type const& type, std::string const& field_name = "");
-        std::string getIDLRelative(Type const& type, std::string const& field_name = "");
-        pair<string, string> getIDLBase(Type const& type, std::string const& field_name = "");
-        void apply(Type const& type)
-        {
-            m_namespace = getIDLAbsoluteNamespace(type.getNamespace(), m_exporter);
-            TypeVisitor::apply(type);
-            m_front = normalizeIDLName(m_front);
-        }
-    };
-
-    static bool isIDLBuiltinType(Type const& type)
-    {
-        if (type.getCategory() == Type::Numeric || type.getName() == "/std/string")
-            return true;
-        else if (type.getCategory() == Type::Array)
-        {
-            Type const& element_type = static_cast<Array const&>(type).getIndirection();
-            return isIDLBuiltinType(element_type);
-        }
-        return false;
-    }
-
-    /** Returns the IDL identifier for the given type, without the type's own
-     * namespace prepended
-     */
-    static pair<string, string> getIDLBase(Type const& type, IDLExport const& exporter, std::string const& field_name = std::string())
-    {
-        std::string type_name;
-        IDLTypeIdentifierVisitor visitor(exporter);
-        visitor.apply(type);
-        if (field_name.empty())
-            return make_pair(visitor.getTargetNamespace(), visitor.m_front + visitor.m_back);
-        else
-            return make_pair(visitor.getTargetNamespace(), visitor.m_front + " " + field_name + visitor.m_back);
-    }
-
-    /** Returns the IDL identifier for the given type, with the minimal
-     * namespace specification to reach it from the exporter's current namespace
-     */
-    static string getIDLRelative(Type const& type, std::string const& relative_to, IDLExport const& exporter, std::string const& field_name = std::string())
-    {
-        pair<string, string> base = getIDLBase(type, exporter, field_name);
-        if (!base.first.empty())
-        {
-            std::string ns = getMinimalPathTo(base.first + type.getBasename(), relative_to);
-            boost::replace_all(ns, Typelib::NamespaceMarkString, "::");
-            return normalizeIDLName(ns) + base.second;
-        }
-        else return base.second;
-    }
-
-    /** Returns the IDL identifier for the given type, with the complete
-     * namespace specification prepended to it
-     */
-    static string getIDLAbsolute(Type const& type, IDLExport const& exporter, std::string const& field_name = std::string())
-    {
-        pair<string, string> base = getIDLBase(type, exporter, field_name);
-        if (!base.first.empty())
-        {
-            std::string ns = base.first;
-            boost::replace_all(ns, Typelib::NamespaceMarkString, "::");
-            return normalizeIDLName(ns) + base.second;
-        }
-        else return base.second;
-    }
-
-    std::string IDLTypeIdentifierVisitor::getIDLAbsolute(Type const& type, std::string const& field_name)
-    {
-        return ::getIDLAbsolute(type, m_exporter, field_name);
-    }
-    std::string IDLTypeIdentifierVisitor::getIDLRelative(Type const& type, std::string const& field_name)
-    {
-        return ::getIDLRelative(type, m_namespace, m_exporter, field_name);
-    }
-    pair<string, string> IDLTypeIdentifierVisitor::getIDLBase(Type const& type, std::string const& field_name)
-    {
-        return ::getIDLBase(type, m_exporter, field_name);
-    }
-
-    bool IDLTypeIdentifierVisitor::visit_(OpaqueType const& type)
-    {
-        if (m_exporter.marshalOpaquesAsAny())
-        {
-            m_namespace = "";
-            m_front = "any";
-        }
-        else
-            throw UnsupportedType(type, "opaque types are not allowed in IDL");
-
+static bool isIDLBuiltinType(Type const &type) {
+    if (type.getCategory() == Type::Numeric || type.getName() == "/std/string")
         return true;
+    else if (type.getCategory() == Type::Array) {
+        Type const &element_type =
+            static_cast<Array const &>(type).getIndirection();
+        return isIDLBuiltinType(element_type);
     }
-    bool IDLTypeIdentifierVisitor::visit_(NullType const& type)
-    { throw UnsupportedType(type, "null types are not supported for export in IDL, found " + type.getName()); }
-    bool IDLTypeIdentifierVisitor::visit_(Container const& type)
-    {
-        if (type.getName() == "/std/string")
-        {
-            m_namespace = "";
-            m_front = "string";
-        }
-        else
-        {
-            // Get the basename for "kind"
-            m_namespace = getIDLBase(type.getIndirection()).first;
-            // We generate all containers in orogen::Corba, even if their
-            // element type is a builtin
-            if (m_namespace.empty())
-                m_namespace = getIDLAbsoluteNamespace("/", m_exporter);
+    return false;
+}
 
-            std::string container_kind = Typelib::getTypename(type.kind());
-            std::string element_name   = type.getIndirection().getName();
-            boost::replace_all(element_name, Typelib::NamespaceMarkString, "_");
-            boost::replace_all(element_name, " ", "_");
-            m_front = container_kind + "_" + element_name + "_";
-        }
+/** Returns the IDL identifier for the given type, without the type's own
+ * namespace prepended
+ */
+static pair<string, string>
+getIDLBase(Type const &type, IDLExport const &exporter,
+           std::string const &field_name = std::string()) {
+    std::string type_name;
+    IDLTypeIdentifierVisitor visitor(exporter);
+    visitor.apply(type);
+    if (field_name.empty())
+        return make_pair(visitor.getTargetNamespace(),
+                         visitor.m_front + visitor.m_back);
+    else
+        return make_pair(visitor.getTargetNamespace(),
+                         visitor.m_front + " " + field_name + visitor.m_back);
+}
 
-        return true;
-    }
-    bool IDLTypeIdentifierVisitor::visit_(Compound const& type)
-    { m_front = type.getBasename();
-        return true; }
-    bool IDLTypeIdentifierVisitor::visit_(Numeric const& type)
-    {
+/** Returns the IDL identifier for the given type, with the minimal
+ * namespace specification to reach it from the exporter's current namespace
+ */
+static string getIDLRelative(Type const &type, std::string const &relative_to,
+                             IDLExport const &exporter,
+                             std::string const &field_name = std::string()) {
+    pair<string, string> base = getIDLBase(type, exporter, field_name);
+    if (!base.first.empty()) {
+        std::string ns =
+            getMinimalPathTo(base.first + type.getBasename(), relative_to);
+        boost::replace_all(ns, Typelib::NamespaceMarkString, "::");
+        return normalizeIDLName(ns) + base.second;
+    } else
+        return base.second;
+}
+
+/** Returns the IDL identifier for the given type, with the complete
+ * namespace specification prepended to it
+ */
+static string getIDLAbsolute(Type const &type, IDLExport const &exporter,
+                             std::string const &field_name = std::string()) {
+    pair<string, string> base = getIDLBase(type, exporter, field_name);
+    if (!base.first.empty()) {
+        std::string ns = base.first;
+        boost::replace_all(ns, Typelib::NamespaceMarkString, "::");
+        return normalizeIDLName(ns) + base.second;
+    } else
+        return base.second;
+}
+
+std::string
+IDLTypeIdentifierVisitor::getIDLAbsolute(Type const &type,
+                                         std::string const &field_name) {
+    return ::getIDLAbsolute(type, m_exporter, field_name);
+}
+std::string
+IDLTypeIdentifierVisitor::getIDLRelative(Type const &type,
+                                         std::string const &field_name) {
+    return ::getIDLRelative(type, m_namespace, m_exporter, field_name);
+}
+pair<string, string>
+IDLTypeIdentifierVisitor::getIDLBase(Type const &type,
+                                     std::string const &field_name) {
+    return ::getIDLBase(type, m_exporter, field_name);
+}
+
+bool IDLTypeIdentifierVisitor::visit_(OpaqueType const &type) {
+    if (m_exporter.marshalOpaquesAsAny()) {
         m_namespace = "";
-        if (type.getName() == "/bool")
-        {
-            m_front = "boolean";
+        m_front = "any";
+    } else
+        throw UnsupportedType(type, "opaque types are not allowed in IDL");
+
+    return true;
+}
+bool IDLTypeIdentifierVisitor::visit_(NullType const &type) {
+    throw UnsupportedType(
+        type, "null types are not supported for export in IDL, found " +
+                  type.getName());
+}
+bool IDLTypeIdentifierVisitor::visit_(Container const &type) {
+    if (type.getName() == "/std/string") {
+        m_namespace = "";
+        m_front = "string";
+    } else {
+        // Get the basename for "kind"
+        m_namespace = getIDLBase(type.getIndirection()).first;
+        // We generate all containers in orogen::Corba, even if their
+        // element type is a builtin
+        if (m_namespace.empty())
+            m_namespace = getIDLAbsoluteNamespace("/", m_exporter);
+
+        std::string container_kind = Typelib::getTypename(type.kind());
+        std::string element_name = type.getIndirection().getName();
+        boost::replace_all(element_name, Typelib::NamespaceMarkString, "_");
+        boost::replace_all(element_name, " ", "_");
+        m_front = container_kind + "_" + element_name + "_";
+    }
+
+    return true;
+}
+bool IDLTypeIdentifierVisitor::visit_(Compound const &type) {
+    m_front = type.getBasename();
+    return true;
+}
+bool IDLTypeIdentifierVisitor::visit_(Numeric const &type) {
+    m_namespace = "";
+    if (type.getName() == "/bool") {
+        m_front = "boolean";
+    } else if (type.getNumericCategory() != Numeric::Float) {
+        if (type.getNumericCategory() == Numeric::UInt && type.getSize() != 1)
+            m_front = "unsigned ";
+        switch (type.getSize()) {
+        case 1:
+            m_front += "octet";
+            break;
+        case 2:
+            m_front += "short";
+            break;
+        case 4:
+            m_front += "long";
+            break;
+        case 8:
+            m_front += "long long";
+            break;
         }
-        else if (type.getNumericCategory() != Numeric::Float)
-        {
-            if (type.getNumericCategory() == Numeric::UInt && type.getSize() != 1)
-                m_front = "unsigned ";
-            switch (type.getSize())
-            {
-                case 1: m_front += "octet"; break;
-                case 2: m_front += "short"; break;
-                case 4: m_front += "long"; break;
-                case 8: m_front += "long long"; break;
-            }
-        }
+    } else {
+        if (type.getSize() == 4)
+            m_front = "float";
         else
-        {
-            if (type.getSize() == 4)
-                m_front = "float";
-            else
-                m_front = "double";
-        }
+            m_front = "double";
+    }
+    return true;
+}
+bool IDLTypeIdentifierVisitor::visit_(Pointer const &type) {
+    throw UnsupportedType(type,
+                          "pointer types are not supported for export in IDL");
+}
+bool IDLTypeIdentifierVisitor::visit_(Array const &type) {
+    if (type.getIndirection().getCategory() == Type::Array)
+        throw UnsupportedType(
+            type, "multi-dimensional arrays are not supported in IDL");
+
+    pair<string, string> element_t = getIDLBase(type.getIndirection());
+    m_namespace = element_t.first;
+    m_front = element_t.second;
+    m_back = "[" + boost::lexical_cast<string>(type.getDimension()) + "]";
+    return true;
+}
+bool IDLTypeIdentifierVisitor::visit_(Enum const &type) {
+    m_front = type.getBasename();
+    return true;
+}
+
+class IDLExportVisitor : public TypeVisitor {
+  public:
+    IDLExport const &m_exporter;
+    ostringstream m_stream;
+    string m_indent;
+    string m_namespace;
+    std::map<std::string, Type const *> &m_exported_typedefs;
+
+    bool visit_(OpaqueType const &type);
+    bool visit_(Container const &type);
+    bool visit_(Compound const &type);
+    bool visit_(Compound const &type, Field const &field);
+
+    bool visit_(Numeric const &type);
+
+    bool visit_(Pointer const &type);
+    bool visit_(Array const &type);
+
+    bool visit_(Enum const &type);
+
+    IDLExportVisitor(Registry const &registry, IDLExport const &exporter,
+                     std::map<std::string, Type const *> &exported_typedefs);
+    std::string getResult() const { return m_stream.str(); }
+    std::string getTargetNamespace() const { return m_namespace; }
+    void setTargetNamespace(std::string const &target_namespace) {
+        size_t ns_size = namespaceIndentLevel(target_namespace);
+        m_indent = string(ns_size * 4, ' ');
+        m_namespace = target_namespace;
+    }
+    std::string getIDLAbsolute(Type const &type,
+                               std::string const &field_name = "");
+    std::string getIDLRelative(Type const &type,
+                               std::string const &field_name = "");
+    pair<string, string> getIDLBase(Type const &type,
+                                    std::string const &field_name = "");
+    void apply(Type const &type) {
+        setTargetNamespace(
+            getIDLAbsoluteNamespace(type.getNamespace(), m_exporter));
+        TypeVisitor::apply(type);
+    }
+};
+
+std::string IDLExportVisitor::getIDLAbsolute(Type const &type,
+                                             std::string const &field_name) {
+    return ::getIDLAbsolute(type, m_exporter, field_name);
+}
+std::string IDLExportVisitor::getIDLRelative(Type const &type,
+                                             std::string const &field_name) {
+    return ::getIDLRelative(type, m_namespace, m_exporter, field_name);
+}
+pair<string, string>
+IDLExportVisitor::getIDLBase(Type const &type, std::string const &field_name) {
+    return ::getIDLBase(type, m_exporter, field_name);
+}
+
+struct Indent {
+    string &m_indent;
+    string m_save;
+    Indent(string &current) : m_indent(current), m_save(current) {
+        m_indent += "    ";
+    }
+    ~Indent() { m_indent = m_save; }
+};
+
+IDLExportVisitor::IDLExportVisitor(
+    Registry const &registry, IDLExport const &exporter,
+    std::map<std::string, Type const *> &exported_typedefs)
+    : m_exporter(exporter), m_exported_typedefs(exported_typedefs) {}
+
+bool IDLExportVisitor::visit_(Compound const &type) {
+    m_stream << m_indent << "struct " << normalizeIDLName(type.getBasename())
+             << " {\n";
+
+    {
+        Indent indenter(m_indent);
+        TypeVisitor::visit_(type);
+    }
+
+    m_stream << m_indent << "};\n";
+
+    return true;
+}
+bool IDLExportVisitor::visit_(Compound const &type, Field const &field) {
+    m_stream << m_indent << getIDLAbsolute(field.getType(), field.getName())
+             << ";\n";
+
+    return true;
+}
+
+bool IDLExportVisitor::visit_(Numeric const &type) {
+    // no need to export Numeric types, they are already defined by IDL
+    // itself
+    return true;
+}
+
+bool IDLExportVisitor::visit_(Pointer const &type) {
+    throw UnsupportedType(type, "pointers are not allowed in IDL");
+    return true;
+}
+bool IDLExportVisitor::visit_(Array const &type) {
+    throw UnsupportedType(
+        type, "top-level arrays are not handled by the IDLExportVisitor");
+    return true;
+}
+
+bool IDLExportVisitor::visit_(Enum const &type) {
+    m_stream << m_indent << "enum " << type.getBasename() << " { ";
+
+    list<string> symbols;
+    Enum::ValueMap const &values = type.values();
+    Enum::ValueMap::const_iterator it, end = values.end();
+    for (it = values.begin(); it != end; ++it)
+        symbols.push_back(it->first);
+    m_stream << join(symbols, ", ") << " };\n";
+
+    return true;
+}
+
+bool IDLExportVisitor::visit_(Container const &type) {
+    if (type.getName() == "/std/string")
         return true;
-    }
-    bool IDLTypeIdentifierVisitor::visit_(Pointer const& type)
-    { throw UnsupportedType(type, "pointer types are not supported for export in IDL"); }
-    bool IDLTypeIdentifierVisitor::visit_(Array const& type)
-    {
-        if (type.getIndirection().getCategory() == Type::Array)
-            throw UnsupportedType(type, "multi-dimensional arrays are not supported in IDL");
 
-        pair<string, string> element_t = getIDLBase(type.getIndirection());
-        m_namespace = element_t.first;
-        m_front = element_t.second;
-        m_back = "[" + boost::lexical_cast<string>(type.getDimension()) + "]";
+    // sequence<> can be used as-is, but in order to be as cross-ORB
+    // compatible as possible we generate sequence typedefs and use them in
+    // the compounds. Emit the sequence right now.
+    string target_namespace = getIDLBase(type.getIndirection()).first;
+    // We never emit sequences into the main namespace, even if their
+    // element is a builtin
+    if (target_namespace.empty())
+        target_namespace = getIDLAbsoluteNamespace("/", m_exporter);
+    setTargetNamespace(target_namespace);
+
+    std::string element_name = getIDLAbsolute(type.getIndirection());
+    std::string typedef_name = getIDLBase(type).second;
+    boost::replace_all(typedef_name, "::", "_");
+    m_stream << m_indent << "typedef sequence<" << element_name << "> "
+             << typedef_name << ";\n";
+    m_exported_typedefs.insert(
+        make_pair(type.getIndirection().getNamespace() + typedef_name, &type));
+
+    return true;
+}
+bool IDLExportVisitor::visit_(OpaqueType const &type) {
+    if (m_exporter.marshalOpaquesAsAny())
         return true;
-    }
-    bool IDLTypeIdentifierVisitor::visit_(Enum const& type)
-    { m_front = type.getBasename();
-        return true; }
 
-    class IDLExportVisitor : public TypeVisitor
-    {
-    public:
-	IDLExport const& m_exporter;
-        ostringstream  m_stream;
-        string    m_indent;
-        string    m_namespace;
-        std::map<std::string, Type const*>& m_exported_typedefs;
-
-        bool visit_(OpaqueType const& type);
-        bool visit_(Container const& type);
-        bool visit_(Compound const& type);
-        bool visit_(Compound const& type, Field const& field);
-
-        bool visit_(Numeric const& type);
-
-        bool visit_(Pointer const& type);
-        bool visit_(Array const& type);
-
-        bool visit_(Enum const& type);
-
-        IDLExportVisitor(Registry const& registry, IDLExport const& exporter, std::map<std::string, Type const*>& exported_typedefs);
-        std::string getResult() const { return m_stream.str(); }
-        std::string getTargetNamespace() const { return m_namespace; }
-        void setTargetNamespace(std::string const& target_namespace)
-        {
-            size_t ns_size = namespaceIndentLevel(target_namespace);
-            m_indent = string(ns_size * 4, ' ');
-            m_namespace = target_namespace;
-        }
-        std::string getIDLAbsolute(Type const& type, std::string const& field_name = "");
-        std::string getIDLRelative(Type const& type, std::string const& field_name = "");
-        pair<string, string> getIDLBase(Type const& type, std::string const& field_name = "");
-        void apply(Type const& type)
-        {
-            setTargetNamespace(getIDLAbsoluteNamespace(type.getNamespace(), m_exporter));
-            TypeVisitor::apply(type);
-        }
-    };
-
-    std::string IDLExportVisitor::getIDLAbsolute(Type const& type,
-            std::string const& field_name)
-    {
-        return ::getIDLAbsolute(type, m_exporter, field_name);
-    }
-    std::string IDLExportVisitor::getIDLRelative(Type const& type,
-            std::string const& field_name)
-    {
-        return ::getIDLRelative(type, m_namespace, m_exporter, field_name);
-    }
-    pair<string, string> IDLExportVisitor::getIDLBase(Type const& type,
-            std::string const& field_name)
-    {
-        return ::getIDLBase(type, m_exporter, field_name);
-    }
-
-    struct Indent
-    {
-        string& m_indent;
-        string  m_save;
-        Indent(string& current)
-            : m_indent(current), m_save(current)
-        { m_indent += "    "; }
-        ~Indent() { m_indent = m_save; }
-    };
-
-    IDLExportVisitor::IDLExportVisitor(Registry const& registry, IDLExport const& exporter,
-	    std::map<std::string, Type const*>& exported_typedefs)
-        : m_exporter(exporter)
-        , m_exported_typedefs(exported_typedefs) {}
-
-    bool IDLExportVisitor::visit_(Compound const& type)
-    { 
-        m_stream << m_indent << "struct " << normalizeIDLName(type.getBasename()) << " {\n";
-        
-        { Indent indenter(m_indent);
-            TypeVisitor::visit_(type);
-        }
-
-        m_stream << m_indent
-            << "};\n";
-
-        return true;
-    }
-    bool IDLExportVisitor::visit_(Compound const& type, Field const& field)
-    { 
-        m_stream
-            << m_indent
-            << getIDLAbsolute(field.getType(), field.getName())
-            << ";\n";
-
-        return true;
-    }
-
-    bool IDLExportVisitor::visit_(Numeric const& type)
-    {
-	// no need to export Numeric types, they are already defined by IDL
-	// itself
-	return true;
-    }
-
-    bool IDLExportVisitor::visit_ (Pointer const& type)
-    {
-	throw UnsupportedType(type, "pointers are not allowed in IDL");
-        return true;
-    }
-    bool IDLExportVisitor::visit_ (Array const& type)
-    {
-	throw UnsupportedType(type, "top-level arrays are not handled by the IDLExportVisitor");
-        return true;
-    }
-
-    bool IDLExportVisitor::visit_ (Enum const& type)
-    {
-	m_stream << m_indent << "enum " << type.getBasename() << " { ";
-
-        list<string> symbols;
-        Enum::ValueMap const& values = type.values();
-	Enum::ValueMap::const_iterator it, end = values.end();
-	for (it = values.begin(); it != end; ++it)
-	    symbols.push_back(it->first);
-	m_stream << join(symbols, ", ") << " };\n";
-
-        return true;
-    }
-
-    bool IDLExportVisitor::visit_(Container const& type)
-    {
-        if (type.getName() == "/std/string")
-            return true;
-                
-        // sequence<> can be used as-is, but in order to be as cross-ORB
-        // compatible as possible we generate sequence typedefs and use them in
-        // the compounds. Emit the sequence right now.
-	string target_namespace  = getIDLBase(type.getIndirection()).first;
-        // We never emit sequences into the main namespace, even if their
-        // element is a builtin
-        if (target_namespace.empty())
-            target_namespace = getIDLAbsoluteNamespace("/", m_exporter);
-        setTargetNamespace(target_namespace);
-
-        std::string element_name = getIDLAbsolute(type.getIndirection());
-        std::string typedef_name = getIDLBase(type).second;
-        boost::replace_all(typedef_name, "::", "_");
-        m_stream << m_indent << "typedef sequence<" << element_name << "> " << typedef_name << ";\n";
-        m_exported_typedefs.insert(make_pair(type.getIndirection().getNamespace() + typedef_name, &type));
-
-        return true;
-    }
-    bool IDLExportVisitor::visit_(OpaqueType const& type)
-    {
-        if (m_exporter.marshalOpaquesAsAny())
-            return true;
-
-        throw UnsupportedType(type, "opaque types are not supported for export in IDL");
-    }
+    throw UnsupportedType(type,
+                          "opaque types are not supported for export in IDL");
+}
 }
 
 using namespace std;
-IDLExport::IDLExport() 
-    : m_namespace("/"), m_opaque_as_any(false) {}
+IDLExport::IDLExport() : m_namespace("/"), m_opaque_as_any(false) {}
 
 bool IDLExport::marshalOpaquesAsAny() const { return m_opaque_as_any; }
 
-void IDLExport::end
-    ( ostream& stream
-    , Typelib::Registry const& /*registry*/ )
-{
+void IDLExport::end(ostream &stream, Typelib::Registry const & /*registry*/) {
     generateTypedefs(stream);
 
     // Close the remaining namespaces
     closeNamespaces(stream, namespaceIndentLevel(m_namespace));
 }
 
-void IDLExport::closeNamespaces(ostream& stream, int levels)
-{
-    for (int i = 0; i < levels; ++i)
-    {
-	m_indent = std::string(m_indent, 0, m_indent.size() - 4);
-	stream << "\n" << m_indent << "};\n";
+void IDLExport::closeNamespaces(ostream &stream, int levels) {
+    for (int i = 0; i < levels; ++i) {
+        m_indent = std::string(m_indent, 0, m_indent.size() - 4);
+        stream << "\n" << m_indent << "};\n";
     }
 }
 
-void IDLExport::checkType(Type const& type)
-{
+void IDLExport::checkType(Type const &type) {
     if (type.getCategory() == Type::Pointer)
-	throw UnsupportedType(type, "pointers are not allowed in IDL");
-    if (type.getCategory() == Type::Array)
-    {
-	Type::Category pointed_to = static_cast<Indirect const&>(type).getIndirection().getCategory();
-	if (pointed_to == Type::Array || pointed_to == Type::Pointer)
-	    throw UnsupportedType(type, "multi-dimensional arrays are not supported yet");
+        throw UnsupportedType(type, "pointers are not allowed in IDL");
+    if (type.getCategory() == Type::Array) {
+        Type::Category pointed_to =
+            static_cast<Indirect const &>(type).getIndirection().getCategory();
+        if (pointed_to == Type::Array || pointed_to == Type::Pointer)
+            throw UnsupportedType(
+                type, "multi-dimensional arrays are not supported yet");
     }
-
 }
 
-void IDLExport::adaptNamespace(ostream& stream, string const& ns)
-{
-    if (m_namespace != ns)
-    {
-        list<string>
-            old_namespace = nameSplit(m_namespace),
-            new_namespace = nameSplit(ns);
+void IDLExport::adaptNamespace(ostream &stream, string const &ns) {
+    if (m_namespace != ns) {
+        list<string> old_namespace = nameSplit(m_namespace),
+                     new_namespace = nameSplit(ns);
 
-	while(!old_namespace.empty() && !new_namespace.empty() && old_namespace.front() == new_namespace.front())
-	{
-	    old_namespace.pop_front();
-	    new_namespace.pop_front();
-	}
+        while (!old_namespace.empty() && !new_namespace.empty() &&
+               old_namespace.front() == new_namespace.front()) {
+            old_namespace.pop_front();
+            new_namespace.pop_front();
+        }
 
-	closeNamespaces(stream, old_namespace.size());
+        closeNamespaces(stream, old_namespace.size());
 
-	while (!new_namespace.empty())
-	{
-	    stream << m_indent << "module " << normalizeIDLName(new_namespace.front()) << " {\n";
-	    m_indent += "    ";
-	    new_namespace.pop_front();
-	}
+        while (!new_namespace.empty()) {
+            stream << m_indent << "module "
+                   << normalizeIDLName(new_namespace.front()) << " {\n";
+            m_indent += "    ";
+            new_namespace.pop_front();
+        }
     }
     m_namespace = ns;
 }
 
-std::string IDLExport::getIDLAbsolute(Type const& type) const
-{
+std::string IDLExport::getIDLAbsolute(Type const &type) const {
     return ::getIDLAbsolute(type, *this);
 }
 
-std::string IDLExport::getIDLRelative(Type const& type, std::string const& relative_to) const
-{
+std::string IDLExport::getIDLRelative(Type const &type,
+                                      std::string const &relative_to) const {
     return ::getIDLRelative(type, relative_to, *this);
 }
 
-void IDLExport::save
-    ( ostream& stream
-    , utilmm::config_set const& config
-    , Typelib::Registry const& type )
-{
+void IDLExport::save(ostream &stream, utilmm::config_set const &config,
+                     Typelib::Registry const &type) {
     m_ns_prefix = config.get<std::string>("namespace_prefix", "");
-    if (!m_ns_prefix.empty() && string(m_ns_prefix, 0, 1) != Typelib::NamespaceMarkString)
+    if (!m_ns_prefix.empty() &&
+        string(m_ns_prefix, 0, 1) != Typelib::NamespaceMarkString)
         m_ns_prefix = Typelib::NamespaceMarkString + m_ns_prefix;
     m_ns_suffix = config.get<std::string>("namespace_suffix", "");
-    if (!m_ns_suffix.empty() && string(m_ns_suffix, m_ns_suffix.length() - 1, 1) != Typelib::NamespaceMarkString)
+    if (!m_ns_suffix.empty() &&
+        string(m_ns_suffix, m_ns_suffix.length() - 1, 1) !=
+            Typelib::NamespaceMarkString)
         m_ns_suffix += Typelib::NamespaceMarkString;
     m_blob_threshold = config.get<int>("blob_threshold", 0);
-    m_opaque_as_any  = config.get<bool>("opaque_as_any", false);
-    list<string> selection = config.get< list<string> >("selected");
+    m_opaque_as_any = config.get<bool>("opaque_as_any", false);
+    list<string> selection = config.get<list<string> >("selected");
     m_selected_types = set<string>(selection.begin(), selection.end());
     return Exporter::save(stream, config, type);
 }
 
-void IDLExport::generateTypedefs(ostream& stream)
-{
+void IDLExport::generateTypedefs(ostream &stream) {
     for (TypedefMap::const_iterator it = m_typedefs.begin();
-            it != m_typedefs.end(); ++it)
-    {
+         it != m_typedefs.end(); ++it) {
         adaptNamespace(stream, it->first);
 
-        list<string> const& lines = it->second;
-        for (list<string>::const_iterator str_it = lines.begin(); str_it != lines.end(); ++str_it)
+        list<string> const &lines = it->second;
+        for (list<string>::const_iterator str_it = lines.begin();
+             str_it != lines.end(); ++str_it)
             stream << m_indent << "typedef " << *str_it << std::endl;
     }
 }
 
-std::string IDLExport::getNamespacePrefix() const
-{
-    return m_ns_prefix;
-}
-std::string IDLExport::getNamespaceSuffix() const
-{
-    return m_ns_suffix;
-}
+std::string IDLExport::getNamespacePrefix() const { return m_ns_prefix; }
+std::string IDLExport::getNamespaceSuffix() const { return m_ns_suffix; }
 
-bool IDLExport::save
-    ( ostream& stream
-    , Typelib::RegistryIterator const& type )
-{
-    if (! m_selected_types.empty())
-    {
-        if (m_selected_types.count(type->getName()) == 0)
-        {
+bool IDLExport::save(ostream &stream, Typelib::RegistryIterator const &type) {
+    if (!m_selected_types.empty()) {
+        if (m_selected_types.count(type->getName()) == 0) {
             return false;
         }
     }
 
-    if (type.isAlias())
-    {
-	// IDL has C++-like rules for struct and enums. Do not alias a "struct A" to "A";
-	if (type->getNamespace() != type.getNamespace()
-		|| (type->getBasename() != "struct " + type.getBasename()
-		    && type->getBasename() != "enum " + type.getBasename()
-		    && type.getBasename() != "struct " + type->getBasename()
-		    && type.getBasename() != "enum " + type->getBasename()))
-	{
-	    IDLExport::checkType(*type);
+    if (type.isAlias()) {
+        // IDL has C++-like rules for struct and enums. Do not alias a "struct
+        // A" to "A";
+        if (type->getNamespace() != type.getNamespace() ||
+            (type->getBasename() != "struct " + type.getBasename() &&
+             type->getBasename() != "enum " + type.getBasename() &&
+             type.getBasename() != "struct " + type->getBasename() &&
+             type.getBasename() != "enum " + type->getBasename())) {
+            IDLExport::checkType(*type);
             ostringstream stream;
 
-            std::string type_namespace = getIDLAbsoluteNamespace(type.getNamespace(), *this);
+            std::string type_namespace =
+                getIDLAbsoluteNamespace(type.getNamespace(), *this);
 
-            map<string, Type const*>::const_iterator already_exported =
+            map<string, Type const *>::const_iterator already_exported =
                 m_exported_typedefs.find(type.getName());
-            if (already_exported != m_exported_typedefs.end())
-            {
+            if (already_exported != m_exported_typedefs.end()) {
                 if (*already_exported->second != *type)
-                    throw UnsupportedType(*type, "the typedef name " + type.getName() + " is reserved by the IDL exporter");
+                    throw UnsupportedType(
+                        *type, "the typedef name " + type.getName() +
+                                   " is reserved by the IDL exporter");
                 return false;
-            }
-            else if (type.getBasename().find_first_of("/<>") != std::string::npos)
-            {
+            } else if (type.getBasename().find_first_of("/<>") !=
+                       std::string::npos) {
                 return false;
             }
 
-	    // Alias types using typedef, taking into account that the aliased type
-	    // may not be in the same module than the new alias.
-	    if (type->getCategory() == Type::Array)
-	    {
-		Array const& array_t = dynamic_cast<Array const&>(*type);
-		stream 
-		    << getIDLAbsolute(array_t.getIndirection())
-		    << " " << type.getBasename() << "[" << array_t.getDimension() << "];";
-	    }
-            else if (type->getCategory() == Type::Container && type->getName() != "/std/string")
-            {
+            // Alias types using typedef, taking into account that the aliased
+            // type
+            // may not be in the same module than the new alias.
+            if (type->getCategory() == Type::Array) {
+                Array const &array_t = dynamic_cast<Array const &>(*type);
+                stream << getIDLAbsolute(array_t.getIndirection()) << " "
+                       << type.getBasename() << "[" << array_t.getDimension()
+                       << "];";
+            } else if (type->getCategory() == Type::Container &&
+                       type->getName() != "/std/string") {
                 // Generate a sequence, regardless of the actual container type
-                Container const& container_t = dynamic_cast<Container const&>(*type);
-                stream << "sequence<" << getIDLAbsolute(container_t.getIndirection()) << "> " << type.getBasename() << ";";
-            }
-            else if (type->getCategory() == Type::Opaque)
-            {
+                Container const &container_t =
+                    dynamic_cast<Container const &>(*type);
+                stream << "sequence<"
+                       << getIDLAbsolute(container_t.getIndirection()) << "> "
+                       << type.getBasename() << ";";
+            } else if (type->getCategory() == Type::Opaque) {
                 if (marshalOpaquesAsAny())
                     stream << "any " << type.getBasename() << ";";
-            }
-            else if (type.getBasename().find_first_of(" ") == string::npos)
-		stream << getIDLAbsolute(*type) << " " << type.getBasename() << ";";
+            } else if (type.getBasename().find_first_of(" ") == string::npos)
+                stream << getIDLAbsolute(*type) << " " << type.getBasename()
+                       << ";";
 
             std::string def = stream.str();
             if (!def.empty())
                 m_typedefs[type_namespace].push_back(def);
             return true;
-	}
-        else return false;
-    }
-    else
-    {
-	// Don't call adaptNamespace right now, since some types can be simply
-	// ignored by the IDLExportVisitor -- resulting in an empty module,
-	// which is not accepted in IDL
-	//
-	// Instead, act "as if" the namespace was changed, capturing the output
-	// in a temporary ostringstream and change namespace only if some output
-	// has actually been generated
-	
-	if (m_blob_threshold && static_cast<int>(type->getSize()) > m_blob_threshold)
-	{
-            string target_namespace = getIDLAbsoluteNamespace(type.getNamespace(), *this);
+        } else
+            return false;
+    } else {
+        // Don't call adaptNamespace right now, since some types can be simply
+        // ignored by the IDLExportVisitor -- resulting in an empty module,
+        // which is not accepted in IDL
+        //
+        // Instead, act "as if" the namespace was changed, capturing the output
+        // in a temporary ostringstream and change namespace only if some output
+        // has actually been generated
+
+        if (m_blob_threshold &&
+            static_cast<int>(type->getSize()) > m_blob_threshold) {
+            string target_namespace =
+                getIDLAbsoluteNamespace(type.getNamespace(), *this);
             size_t ns_size = namespaceIndentLevel(target_namespace);
             string indent_string = string(ns_size * 4, ' ');
 
-	    adaptNamespace(stream, target_namespace);
-	    stream << indent_string << "typedef sequence<octet> " << type->getBasename() << ";\n";
+            adaptNamespace(stream, target_namespace);
+            stream << indent_string << "typedef sequence<octet> "
+                   << type->getBasename() << ";\n";
             return true;
-	}
-	else
-	{
-	    IDLExportVisitor exporter(type.getRegistry(), *this, m_exported_typedefs);
-	    exporter.apply(*type);
+        } else {
+            IDLExportVisitor exporter(type.getRegistry(), *this,
+                                      m_exported_typedefs);
+            exporter.apply(*type);
 
-	    string result = exporter.getResult();
-	    if (result.empty())
+            string result = exporter.getResult();
+            if (result.empty())
                 return false;
-            else
-	    {
-		adaptNamespace(stream, exporter.getTargetNamespace());
-		stream << result;
+            else {
+                adaptNamespace(stream, exporter.getTargetNamespace());
+                stream << result;
                 return true;
-	    }
-	}
+            }
+        }
     }
 }
 
 TYPELIB_REGISTER_IO1(idl, IDLExport)
-

--- a/lang/idl/export.hh
+++ b/lang/idl/export.hh
@@ -3,7 +3,8 @@
 
 #include <typelib/exporter.hh>
 
-/* Exports types or a whole registry in the CORBA Interface Definition Language (IDL).
+/* Exports types or a whole registry in the CORBA Interface Definition Language
+ * (IDL).
  * This exporter accepts the following options:
  * * \c namespace_prefix: a namespace to prepend to the type namespace. Useful
  *      to have the normal C types coexist with the CORBA-generated types.
@@ -15,8 +16,7 @@
  *      instance if the software using CORBA implements its own type safety
  *      mechanisms)
  */
-class IDLExport : public Typelib::Exporter
-{
+class IDLExport : public Typelib::Exporter {
     std::string m_namespace;
     std::string m_ns_prefix;
     std::string m_ns_suffix;
@@ -26,8 +26,7 @@ class IDLExport : public Typelib::Exporter
 
     std::set<std::string> m_selected_types;
 
-    struct TypedefSpec
-    {
+    struct TypedefSpec {
         std::string name_space;
         std::string declaration;
     };
@@ -37,18 +36,17 @@ class IDLExport : public Typelib::Exporter
     /** The set of typedefs that have been exported during the generation
      * process, -- i.e. before the end of generation
      */
-    std::map<std::string, Typelib::Type const*> m_exported_typedefs;
+    std::map<std::string, Typelib::Type const *> m_exported_typedefs;
 
+    void closeNamespaces(std::ostream &stream, int levels);
+    void adaptNamespace(std::ostream &stream, std::string const &ns);
+    void generateTypedefs(std::ostream &stream);
 
-    void closeNamespaces(std::ostream& stream, int levels);
-    void adaptNamespace(std::ostream& stream, std::string const& ns);
-    void generateTypedefs(std::ostream& stream);
-
-protected:
+  protected:
     /** Called by save to add data after saving all registry types */
-    virtual void end  (std::ostream& stream, Typelib::Registry const& registry);
+    virtual void end(std::ostream &stream, Typelib::Registry const &registry);
 
-public:
+  public:
     IDLExport();
 
     bool marshalOpaquesAsAny() const;
@@ -56,20 +54,17 @@ public:
     std::string getNamespacePrefix() const;
     std::string getNamespaceSuffix() const;
 
-    std::string getIDLAbsolute(Typelib::Type const& type) const;
-    std::string getIDLRelative(Typelib::Type const& type, std::string const& relative_to) const;
+    std::string getIDLAbsolute(Typelib::Type const &type) const;
+    std::string getIDLRelative(Typelib::Type const &type,
+                               std::string const &relative_to) const;
 
-    virtual void save
-        ( std::ostream& stream
-	, utilmm::config_set const& config
-        , Typelib::Registry const& type);
+    virtual void save(std::ostream &stream, utilmm::config_set const &config,
+                      Typelib::Registry const &type);
 
-    virtual bool save
-        ( std::ostream& stream
-        , Typelib::RegistryIterator const& type);
+    virtual bool save(std::ostream &stream,
+                      Typelib::RegistryIterator const &type);
 
-    static void checkType(Typelib::Type const& type);
+    static void checkType(Typelib::Type const &type);
 };
 
 #endif
-

--- a/lang/tlb/export.cc
+++ b/lang/tlb/export.cc
@@ -3,246 +3,220 @@
 
 #include <typelib/typevisitor.hh>
 
-namespace
-{
-    using namespace std;
-    using namespace Typelib;
-    class TlbExportVisitor : public TypeVisitor
+namespace {
+using namespace std;
+using namespace Typelib;
+class TlbExportVisitor : public TypeVisitor {
+    ostream &m_stream;
+    string m_indent;
+    string m_source_id;
+    string emitSourceID() const;
+    string emitMetaData(Type const &type) const;
+    string emitMetaData(MetaData const &metadata) const;
+
+  protected:
+    bool visit_(Compound const &type);
+    bool visit_(Compound const &type, Field const &field);
+
+    bool visit_(Numeric const &type);
+
+    bool visit_(Pointer const &type);
+    bool visit_(Array const &type);
+
+    bool visit_(Enum const &type);
+
+    bool visit_(NullType const &type);
+    bool visit_(OpaqueType const &type);
+    bool visit_(Container const &type);
+
+  public:
+    TlbExportVisitor(ostream &stream, string const &base_indent,
+                     std::string const &source_id);
+};
+
+struct Indent {
+    string &m_indent;
+    string m_save;
+    Indent(string &current) : m_indent(current), m_save(current) {
+        m_indent += "  ";
+    }
+    ~Indent() { m_indent = m_save; }
+};
+
+TlbExportVisitor::TlbExportVisitor(ostream &stream, string const &base_indent,
+                                   std::string const &source_id)
+    : m_stream(stream), m_indent(base_indent), m_source_id(source_id) {}
+
+std::string xmlEscape(std::string const &source) {
+    string result = source;
+    size_t pos = result.find_first_of("<>");
+    while (pos != string::npos) {
+        if (result[pos] == '<')
+            result.replace(pos, 1, "&lt;");
+        else if (result[pos] == '>')
+            result.replace(pos, 1, "&gt;");
+        pos = result.find_first_of("<>");
+    }
+
+    return result;
+}
+
+std::string TlbExportVisitor::emitMetaData(Type const &type) const {
+    return emitMetaData(type.getMetaData());
+}
+std::string TlbExportVisitor::emitMetaData(MetaData const &metadata) const {
+    std::ostringstream stream;
+    MetaData::Map const &map = metadata.get();
+    for (MetaData::Map::const_iterator it = map.begin(); it != map.end();
+         ++it) {
+        std::string key = it->first;
+        MetaData::Values values = it->second;
+        for (MetaData::Values::const_iterator it_value = values.begin();
+             it_value != values.end(); ++it_value)
+            stream << "<metadata key=\"" << key << "\"><![CDATA[" << *it_value
+                   << "]]></metadata>\n";
+    }
+    return stream.str();
+}
+
+std::string TlbExportVisitor::emitSourceID() const {
+    if (!m_source_id.empty())
+        return "source_id=\"" + xmlEscape(m_source_id) + "\"";
+    else
+        return std::string();
+}
+
+bool TlbExportVisitor::visit_(OpaqueType const &type) {
+    m_stream << "<opaque name=\"" << xmlEscape(type.getName()) << "\" size=\""
+             << type.getSize() << "\" " << emitSourceID() << ">\n";
+    m_stream << m_indent << emitMetaData(type) << "\n";
+    m_stream << m_indent << "</opaque>";
+    return true;
+}
+
+bool TlbExportVisitor::visit_(Compound const &type) {
+    m_stream << "<compound name=\"" << xmlEscape(type.getName()) << "\" size=\""
+             << type.getSize() << "\" " << emitSourceID() << ">\n";
+
     {
-        ostream&  m_stream;
-        string    m_indent;
-        string    m_source_id;
-        string emitSourceID() const;
-        string emitMetaData(Type const& type) const;
-        string emitMetaData(MetaData const& metadata) const;
+        Indent indenter(m_indent);
+        TypeVisitor::visit_(type);
+    }
 
-    protected:
-        bool visit_(Compound const& type);
-        bool visit_(Compound const& type, Field const& field);
+    m_stream << m_indent << emitMetaData(type) << "\n";
+    m_stream << m_indent << "</compound>";
 
-        bool visit_(Numeric const& type);
+    return true;
+}
+bool TlbExportVisitor::visit_(Compound const &type, Field const &field) {
+    m_stream << m_indent << "<field name=\"" << field.getName() << "\""
+             << " type=\"" << xmlEscape(field.getType().getName()) << "\""
+             << " offset=\"" << field.getOffset() << "\">\n";
+    m_stream << m_indent << emitMetaData(field.getMetaData()) << "\n";
+    m_stream << m_indent << "</field>\n";
+    return true;
+}
 
-        bool visit_(Pointer const& type);
-        bool visit_(Array const& type);
+namespace {
+char const *getStringCategory(Numeric::NumericCategory category) {
+    switch (category) {
+    case Numeric::SInt:
+        return "sint";
+    case Numeric::UInt:
+        return "uint";
+    case Numeric::Float:
+        return "float";
+    }
+    // never reached
+    return 0;
+}
+}
 
-        bool visit_(Enum const& type);
+bool TlbExportVisitor::visit_(Numeric const &type) {
+    m_stream << "<numeric name=\"" << type.getName() << "\" "
+             << "category=\"" << getStringCategory(type.getNumericCategory())
+             << "\" "
+             << "size=\"" << type.getSize() << "\" " << emitSourceID() << ">";
+    m_stream << m_indent << emitMetaData(type) << "\n";
+    m_stream << m_indent << "</numeric>";
 
-	bool visit_(NullType const& type);
-        bool visit_(OpaqueType const& type);
-        bool visit_(Container const& type);
+    return true;
+}
+bool TlbExportVisitor::visit_(NullType const &type) {
+    m_stream << "<null "
+             << " name=\"" << type.getName() << "\" " << emitSourceID() << ">";
+    m_stream << m_indent << emitMetaData(type) << "\n";
+    m_stream << m_indent << "</null>";
+    return true;
+}
 
-    public:
-        TlbExportVisitor(ostream& stream, string const& base_indent, std::string const& source_id);
-    };
+void indirect(ostream &stream, Indirect const &type) {
+    stream << " name=\"" << xmlEscape(type.getName()) << "\" of=\""
+           << xmlEscape(type.getIndirection().getName()) << "\"";
+}
 
-    struct Indent
+bool TlbExportVisitor::visit_(Pointer const &type) {
+    m_stream << "<pointer ";
+    indirect(m_stream, type);
+    m_stream << " " << emitSourceID() << ">\n";
+    m_stream << m_indent << emitMetaData(type) << "\n";
+    m_stream << m_indent << "</pointer>";
+    return true;
+}
+bool TlbExportVisitor::visit_(Array const &type) {
+    m_stream << "<array ";
+    indirect(m_stream, type);
+    m_stream << " dimension=\"" << type.getDimension() << "\" "
+             << emitSourceID() << ">\n";
+    m_stream << m_indent << emitMetaData(type) << "\n";
+    m_stream << m_indent << "</array>";
+    return true;
+}
+bool TlbExportVisitor::visit_(Container const &type) {
+    m_stream << "<container ";
+    indirect(m_stream, type);
+    m_stream << " size=\"" << type.getSize() << "\""
+             << " kind=\"" << xmlEscape(type.kind()) << "\""
+             << " " << emitSourceID() << ">\n";
+    m_stream << m_indent << emitMetaData(type) << "\n";
+    m_stream << m_indent << "</container>";
+    return true;
+}
+
+bool TlbExportVisitor::visit_(Enum const &type) {
+    Enum::ValueMap const &values = type.values();
+    m_stream << "<enum name=\"" << type.getName() << "\" " << emitSourceID()
+             << ">\n";
     {
-        string& m_indent;
-        string  m_save;
-        Indent(string& current)
-            : m_indent(current), m_save(current)
-        { m_indent += "  "; }
-        ~Indent() { m_indent = m_save; }
-    };
-
-    TlbExportVisitor::TlbExportVisitor(ostream& stream, string const& base_indent, std::string const& source_id)
-        : m_stream(stream), m_indent(base_indent), m_source_id(source_id) {}
-                
-    std::string xmlEscape(std::string const& source)
-    {
-        string result = source;
-        size_t pos = result.find_first_of("<>");
-        while (pos != string::npos)
-        {
-            if (result[pos] == '<')
-                result.replace(pos, 1, "&lt;");
-            else if (result[pos] == '>')
-                result.replace(pos, 1, "&gt;");
-            pos = result.find_first_of("<>");
-        }
-
-        return result;
+        Indent indenter(m_indent);
+        Enum::ValueMap::const_iterator it;
+        for (it = values.begin(); it != values.end(); ++it)
+            m_stream << m_indent << "<value symbol=\"" << it->first
+                     << "\" value=\"" << it->second << "\"/>\n";
     }
+    m_stream << m_indent << emitMetaData(type) << "\n";
+    m_stream << m_indent << "</enum>";
 
-    std::string TlbExportVisitor::emitMetaData(Type const& type) const
-    {
-        return emitMetaData(type.getMetaData());
-    }
-    std::string TlbExportVisitor::emitMetaData(MetaData const& metadata) const
-    {
-        std::ostringstream stream;
-        MetaData::Map const& map = metadata.get();
-        for (MetaData::Map::const_iterator it = map.begin(); it != map.end(); ++it)
-        {
-            std::string key = it->first;
-            MetaData::Values values = it->second;
-            for (MetaData::Values::const_iterator it_value = values.begin(); it_value != values.end(); ++it_value)
-                stream << "<metadata key=\"" << key << "\"><![CDATA[" << *it_value << "]]></metadata>\n";
-        }
-        return stream.str();
-    }
-
-    std::string TlbExportVisitor::emitSourceID() const
-    {
-        if (!m_source_id.empty())
-            return "source_id=\"" + xmlEscape(m_source_id) + "\"";
-        else return std::string();
-    }
-
-    bool TlbExportVisitor::visit_(OpaqueType const& type)
-    {
-        m_stream << "<opaque name=\"" << xmlEscape(type.getName()) << "\" size=\"" << type.getSize() << "\" " << emitSourceID() << ">\n";
-        m_stream << m_indent << emitMetaData(type) << "\n";
-        m_stream << m_indent << "</opaque>";
-        return true;
-    }
-
-    bool TlbExportVisitor::visit_(Compound const& type)
-    { 
-        m_stream << "<compound name=\"" << xmlEscape(type.getName()) << "\" size=\"" << type.getSize() << "\" " << emitSourceID() << ">\n";
-        
-        { Indent indenter(m_indent);
-            TypeVisitor::visit_(type);
-        }
-
-        m_stream << m_indent << emitMetaData(type) << "\n";
-        m_stream << m_indent << "</compound>";
-
-        return true;
-    }
-    bool TlbExportVisitor::visit_(Compound const& type, Field const& field)
-    { 
-        m_stream 
-            << m_indent
-            << "<field name=\"" << field.getName() << "\""
-            << " type=\""   << xmlEscape(field.getType().getName())  << "\""
-            << " offset=\"" << field.getOffset() << "\">\n";
-        m_stream << m_indent << emitMetaData(field.getMetaData()) << "\n";
-        m_stream << m_indent << "</field>\n";
-        return true;
-    }
-
-    namespace
-    {
-        char const* getStringCategory(Numeric::NumericCategory category)
-        {
-            switch(category)
-            {
-                case Numeric::SInt:
-                    return "sint";
-                case Numeric::UInt:
-                    return "uint";
-                case Numeric::Float:
-                    return "float";
-            }
-            // never reached
-            return 0;
-        }
-    }
-
-    bool TlbExportVisitor::visit_(Numeric const& type)
-    {
-        m_stream 
-            << "<numeric name=\"" << type.getName() << "\" " 
-            << "category=\"" << getStringCategory(type.getNumericCategory()) << "\" "
-            << "size=\"" << type.getSize() << "\" " << emitSourceID() << ">";
-        m_stream << m_indent << emitMetaData(type) << "\n";
-        m_stream << m_indent << "</numeric>";
-
-        return true;
-    }
-    bool TlbExportVisitor::visit_ (NullType const& type)
-    {
-        m_stream << "<null " << " name=\"" << type.getName() << "\" " << emitSourceID() << ">";
-        m_stream << m_indent << emitMetaData(type) << "\n";
-        m_stream << m_indent << "</null>";
-	return true;
-    }
-
-    void indirect(ostream& stream, Indirect const& type)
-    {
-        stream 
-            << " name=\"" << xmlEscape(type.getName())
-            << "\" of=\"" << xmlEscape(type.getIndirection().getName()) << "\"";
-    }
-
-    bool TlbExportVisitor::visit_ (Pointer const& type)
-    {
-        m_stream << "<pointer ";
-        indirect(m_stream, type);
-        m_stream << " " << emitSourceID() << ">\n";
-        m_stream << m_indent << emitMetaData(type) << "\n";
-        m_stream << m_indent << "</pointer>";
-        return true;
-    }
-    bool TlbExportVisitor::visit_ (Array const& type)
-    {
-        m_stream << "<array ";
-        indirect(m_stream, type);
-        m_stream << " dimension=\"" << type.getDimension() << "\" " << emitSourceID() << ">\n";
-        m_stream << m_indent << emitMetaData(type) << "\n";
-        m_stream << m_indent << "</array>";
-        return true;
-    }
-    bool TlbExportVisitor::visit_(Container const& type)
-    { 
-        m_stream << "<container ";
-        indirect(m_stream, type);
-        m_stream
-            << " size=\"" << type.getSize() << "\""
-            << " kind=\"" << xmlEscape(type.kind()) << "\""
-            << " " << emitSourceID() << ">\n";
-        m_stream << m_indent << emitMetaData(type) << "\n";
-        m_stream << m_indent << "</container>";
-        return true;
-    }
-
-    bool TlbExportVisitor::visit_ (Enum const& type)
-    {
-        Enum::ValueMap const& values = type.values();
-        m_stream << "<enum name=\"" << type.getName() << "\" " << emitSourceID() << ">\n";
-        { Indent indenter(m_indent);
-            Enum::ValueMap::const_iterator it;
-            for (it = values.begin(); it != values.end(); ++it)
-                m_stream << m_indent << "<value symbol=\"" << it->first << "\" value=\"" << it->second << "\"/>\n";
-        }
-        m_stream << m_indent << emitMetaData(type) << "\n";
-        m_stream << m_indent << "</enum>";
-
-        return true;
-    }
-
+    return true;
+}
 }
 
 using namespace std;
-void TlbExport::begin
-    ( ostream& stream
-    , Typelib::Registry const& /*registry*/ )
-{
-    stream << 
-        "<?xml version=\"1.0\"?>\n"
-        "<typelib>\n";
+void TlbExport::begin(ostream &stream, Typelib::Registry const & /*registry*/) {
+    stream << "<?xml version=\"1.0\"?>\n"
+              "<typelib>\n";
 }
-void TlbExport::end
-    ( ostream& stream
-    , Typelib::Registry const& /*registry*/ )
-{
-    stream << 
-        "</typelib>\n";
+void TlbExport::end(ostream &stream, Typelib::Registry const & /*registry*/) {
+    stream << "</typelib>\n";
 }
 
-bool TlbExport::save
-    ( ostream& stream
-    , Typelib::RegistryIterator const& type )
-{
-    if (type.isAlias())
-    {
+bool TlbExport::save(ostream &stream, Typelib::RegistryIterator const &type) {
+    if (type.isAlias()) {
         stream << "  <alias "
-            "name=\"" << xmlEscape(type.getName()) << "\" "
-            "source=\"" << xmlEscape(type->getName()) << "\"/>\n";
-    }
-    else
-    {
+                  "name=\"" << xmlEscape(type.getName()) << "\" "
+                                                            "source=\""
+               << xmlEscape(type->getName()) << "\"/>\n";
+    } else {
         stream << "  ";
         TlbExportVisitor exporter(stream, "  ", type.getSource());
         exporter.apply(*type);
@@ -250,4 +224,3 @@ bool TlbExport::save
     }
     return true;
 }
-

--- a/lang/tlb/export.hh
+++ b/lang/tlb/export.hh
@@ -3,19 +3,16 @@
 
 #include <typelib/exporter.hh>
 
-class TlbExport : public Typelib::Exporter
-{
-protected:
+class TlbExport : public Typelib::Exporter {
+  protected:
     /** Called by save to add a prelude before saving all registry types */
-    virtual void begin(std::ostream& stream, Typelib::Registry const& registry);
+    virtual void begin(std::ostream &stream, Typelib::Registry const &registry);
     /** Called by save to add data after saving all registry types */
-    virtual void end  (std::ostream& stream, Typelib::Registry const& registry);
+    virtual void end(std::ostream &stream, Typelib::Registry const &registry);
 
-public:
-    virtual bool save
-        ( std::ostream& stream
-        , Typelib::RegistryIterator const& type);
+  public:
+    virtual bool save(std::ostream &stream,
+                      Typelib::RegistryIterator const &type);
 };
 
 #endif
-

--- a/lang/tlb/import.cc
+++ b/lang/tlb/import.cc
@@ -10,378 +10,335 @@
 #include <fstream>
 
 // Helpers
-namespace 
-{
-    using namespace std;
-    using namespace Typelib;
-    
-    template<typename Cat>
-    Cat getCategoryFromNode(Cat* categories, xmlChar const* name )
-    {
-        for(const Cat* cur_cat = categories; cur_cat->name; ++cur_cat)
-        {
-            if (!xmlStrcmp(name, cur_cat->name)) 
-                return *cur_cat;
-        }
-        throw std::runtime_error(string("unrecognized XML node '") + reinterpret_cast<char const*>(name) + "'");
+namespace {
+using namespace std;
+using namespace Typelib;
+
+template <typename Cat>
+Cat getCategoryFromNode(Cat *categories, xmlChar const *name) {
+    for (const Cat *cur_cat = categories; cur_cat->name; ++cur_cat) {
+        if (!xmlStrcmp(name, cur_cat->name))
+            return *cur_cat;
     }
+    throw std::runtime_error(string("unrecognized XML node '") +
+                             reinterpret_cast<char const *>(name) + "'");
+}
 }
 
 // Core function for loading
 // Loading is done in two passes:
-//  - first, we register all type names present and the associated xml nodes and loading functions
+//  - first, we register all type names present and the associated xml nodes and
+//  loading functions
 //    by calling readNodes
 //  - second, we load the Type objects in dependency order by calling load
-namespace
-{
-    // A factory function that builds a type object from a node description
-    struct TypeNode;
-    class Factory;
-    typedef Type const* (*NodeLoader) (TypeNode const& type, Factory& factory);
+namespace {
+// A factory function that builds a type object from a node description
+struct TypeNode;
+class Factory;
+typedef Type const *(*NodeLoader)(TypeNode const &type, Factory &factory);
 
-    struct TypeNode
-    {
-        xmlNodePtr xml;
-        string name;
-        string file;
-        NodeLoader  loader;
+struct TypeNode {
+    xmlNodePtr xml;
+    string name;
+    string file;
+    NodeLoader loader;
 
-        TypeNode
-            ( xmlNodePtr node = 0
-            , string const& name_ = string()
-            , string const& file_ = string()
-            , NodeLoader loader_ = 0 )
-            : xml(node), name(name_), file(file_), loader(loader_) {}
-    };
-    typedef std::map<string, TypeNode> TypeMap;
+    TypeNode(xmlNodePtr node = 0, string const &name_ = string(),
+             string const &file_ = string(), NodeLoader loader_ = 0)
+        : xml(node), name(name_), file(file_), loader(loader_) {}
+};
+typedef std::map<string, TypeNode> TypeMap;
 }
 
-// load loads the \c name type using the type nodes in \c remaining, which holds 
+// load loads the \c name type using the type nodes in \c remaining, which holds
 // types defined in the tlb file that aren't loaded yet
-namespace
-{
-    void loadMetaData(xmlNodePtr node, MetaData& metadata)
-    {
-        for(xmlNodePtr xml = xmlFirstElementChild(node); xml; xml=xmlNextElementSibling(xml))
-        {
-            if (xmlStrcmp(xml->name, reinterpret_cast<const xmlChar*>("metadata")))
-                continue;
-            string key = getAttribute<string>(xml, "key");
-            string value;
-            // Look at a child CDATA block
-            xmlNodePtr cdata = xml->children;
-            for(; cdata; cdata=cdata->next)
-            {
-                if (cdata->type == XML_CDATA_SECTION_NODE)
-                {
-                    value = reinterpret_cast<char const*>(cdata->content);
-                    break;
-                }
+namespace {
+void loadMetaData(xmlNodePtr node, MetaData &metadata) {
+    for (xmlNodePtr xml = xmlFirstElementChild(node); xml;
+         xml = xmlNextElementSibling(xml)) {
+        if (xmlStrcmp(xml->name, reinterpret_cast<const xmlChar *>("metadata")))
+            continue;
+        string key = getAttribute<string>(xml, "key");
+        string value;
+        // Look at a child CDATA block
+        xmlNodePtr cdata = xml->children;
+        for (; cdata; cdata = cdata->next) {
+            if (cdata->type == XML_CDATA_SECTION_NODE) {
+                value = reinterpret_cast<char const *>(cdata->content);
+                break;
             }
-
-            metadata.add(key, value);
         }
+
+        metadata.add(key, value);
+    }
+}
+
+void loadMetaData(TypeNode const &node, MetaData &metadata) {
+    loadMetaData(node.xml, metadata);
+}
+
+class Factory {
+    TypeMap m_map;
+    Registry &m_registry;
+
+  public:
+    Factory(Registry &registry) : m_registry(registry) {}
+
+    Registry &getRegistry() { return m_registry; }
+
+    void insert(TypeNode const &type, Type *object) {
+        loadMetaData(type, object->getMetaData());
+        m_registry.add(object, type.file);
     }
 
-    void loadMetaData(TypeNode const& node, MetaData& metadata)
-    {
-        loadMetaData(node.xml, metadata);
+    void alias(TypeNode const &type, string const &new_name) {
+        m_registry.alias(new_name, type.name);
     }
 
-    class Factory
-    {
-        TypeMap   m_map;
-        Registry& m_registry;
+    void build(TypeMap const &map) {
+        m_map = map;
+        while (!m_map.empty())
+            build(m_map.begin()->first);
+    }
 
-    public:
-        Factory(Registry& registry)
-            : m_registry(registry) {}
+    // Do NOT pass name by reference. It could be destroyed by the
+    // m_map.erase(it)
+    Type const *build(string const name) {
+        string basename = TypeBuilder::getBaseTypename(name);
 
-        Registry& getRegistry() { return m_registry; }
+        Type const *base = m_registry.get(basename);
+        TypeMap::iterator it = m_map.find(basename);
 
-        void insert(TypeNode const& type, Type* object)
-        {
-            loadMetaData(type, object->getMetaData());
-            m_registry.add(object, type.file);
+        if (!base) {
+            if (it == m_map.end())
+                throw Undefined(basename);
+
+            TypeNode type(it->second);
+            m_map.erase(it);
+
+            base = type.loader(type, *this);
+
+            if (base->getName() != basename && !m_registry.has(basename, false))
+                m_registry.alias(base->getName(), basename);
+        } else if (it != m_map.end()) {
+            // TODO check that the definition in the file
+            // TODO and the definition in the registry
+            // TODO match
+            m_map.erase(it);
         }
 
-        void alias (TypeNode const& type, string const& new_name)
-        { m_registry.alias(new_name, type.name); }
+        if (basename == name)
+            return base;
 
-        void build(TypeMap const& map)
-        {
-            m_map = map;
-            while(! m_map.empty())
-                build(m_map.begin()->first);
-        }
+        Type const *derived = m_registry.build(name);
+        if (derived->getName() != name && !m_registry.has(name, false))
+            m_registry.alias(derived->getName(), name);
 
-        // Do NOT pass name by reference. It could be destroyed by the
-        // m_map.erase(it)
-        Type const* build(string const name)
-        {
-            string basename = TypeBuilder::getBaseTypename(name);
-
-            Type const* base = m_registry.get(basename);
-            TypeMap::iterator it = m_map.find(basename);
-
-            if (! base)
-            {
-                if (it == m_map.end())
-                    throw Undefined(basename);
-
-                TypeNode    type(it->second);
-                m_map.erase(it);
-
-                base = type.loader(type, *this);
-
-                if (base->getName() != basename && !m_registry.has(basename, false))
-                    m_registry.alias(base->getName(), basename);
-            }
-            else if (it != m_map.end())
-            {
-                // TODO check that the definition in the file
-                // TODO and the definition in the registry 
-                // TODO match
-                m_map.erase(it);
-            }
-
-            if (basename == name)
-                return base;
-
-            Type const* derived = m_registry.build(name);
-            if (derived->getName() != name && !m_registry.has(name, false))
-                m_registry.alias(derived->getName(), name);
-
-            it = m_map.find(name);
-            if (it != m_map.end())
-                m_map.erase(it);
-            return derived;
-        }
-    };
+        it = m_map.find(name);
+        if (it != m_map.end())
+            m_map.erase(it);
+        return derived;
+    }
+};
 }
 
 // Loading nodes
-namespace
-{
-    struct NumericCategory
-    {
-        const xmlChar* name;
-        Numeric::NumericCategory  type;
-    };
-    NumericCategory numeric_categories[] = {
-        { reinterpret_cast<const xmlChar*>("sint"),  Numeric::SInt },
-        { reinterpret_cast<const xmlChar*>("uint"),  Numeric::UInt },
-        { reinterpret_cast<const xmlChar*>("float"), Numeric::Float },
-        { 0, Numeric::SInt }
-    };
-    Type const* load_numeric(TypeNode const& node, Factory& factory)
-    {
-        NumericCategory category = getCategoryFromNode
-            ( numeric_categories
-            , reinterpret_cast<xmlChar const*>(getAttribute<string>(node.xml, "category").c_str()) );
-        size_t      size = getAttribute<size_t>(node.xml, "size");
+namespace {
+struct NumericCategory {
+    const xmlChar *name;
+    Numeric::NumericCategory type;
+};
+NumericCategory numeric_categories[] = {
+    {reinterpret_cast<const xmlChar *>("sint"), Numeric::SInt},
+    {reinterpret_cast<const xmlChar *>("uint"), Numeric::UInt},
+    {reinterpret_cast<const xmlChar *>("float"), Numeric::Float},
+    {0, Numeric::SInt}};
+Type const *load_numeric(TypeNode const &node, Factory &factory) {
+    NumericCategory category = getCategoryFromNode(
+        numeric_categories,
+        reinterpret_cast<xmlChar const *>(
+            getAttribute<string>(node.xml, "category").c_str()));
+    size_t size = getAttribute<size_t>(node.xml, "size");
 
-        Type* type = new Numeric(node.name, size, category.type);
-        factory.insert(node, type);
-        return type;
+    Type *type = new Numeric(node.name, size, category.type);
+    factory.insert(node, type);
+    return type;
+}
+Type const *load_null(TypeNode const &node, Factory &factory) {
+    Type *type = new NullType(node.name);
+    factory.insert(node, type);
+    return type;
+}
+Type const *load_opaque(TypeNode const &node, Factory &factory) {
+    size_t size = getAttribute<size_t>(node.xml, "size");
+    Type *type = new OpaqueType(node.name, size);
+    factory.insert(node, type);
+    return type;
+}
+Type const *load_container(TypeNode const &node, Factory &factory) {
+    string indirect_name = getAttribute<string>(node.xml, "of");
+    Type const *indirect = factory.build(indirect_name);
+    string kind = getAttribute<string>(node.xml, "kind");
+    bool has_size = false;
+    int size = 0;
+    try {
+        size = getAttribute<int>(node.xml, "size");
+        has_size = true;
+    } catch (Parsing::MissingAttribute) {
     }
-    Type const* load_null(TypeNode const& node, Factory& factory)
-    {
-        Type* type = new NullType(node.name);
-        factory.insert(node, type);
-        return type;
+
+    Type const *container =
+        &Container::createContainer(factory.getRegistry(), kind, *indirect);
+    // We use zero size to indicate that the natural platform size should be
+    // used
+    if (has_size && size != 0) {
+        // Update the size to match the one saved in the registry. This is to
+        // allow a proper call to resize() later if needed.
+        factory.getRegistry().get_(*container).setSize(size);
     }
-    Type const* load_opaque(TypeNode const& node, Factory& factory)
-    {
-        size_t size = getAttribute<size_t>(node.xml, "size");
-        Type* type = new OpaqueType(node.name, size);
-        factory.insert(node, type);
-        return type;
+    loadMetaData(node, container->getMetaData());
+    return container;
+}
+Type const *load_enum(TypeNode const &node, Factory &factory) {
+    Enum *type = new Enum(node.name);
+    for (xmlNodePtr xml = xmlFirstElementChild(node.xml); xml;
+         xml = xmlNextElementSibling(xml)) {
+        if (xmlStrcmp(xml->name, reinterpret_cast<const xmlChar *>("value")))
+            continue;
+
+        string symbol = getAttribute<string>(xml, "symbol");
+        Enum::integral_type value =
+            getAttribute<Enum::integral_type>(xml, "value");
+        type->add(symbol, value);
     }
-    Type const* load_container(TypeNode const& node, Factory& factory)
-    {
-        string indirect_name = getAttribute<string>(node.xml, "of");
-        Type const* indirect = factory.build(indirect_name);
-        string kind          = getAttribute<string>(node.xml, "kind");
-        bool has_size = false;
-        int size = 0;
-        try { 
-            size = getAttribute<int>(node.xml, "size");
-            has_size = true;
+
+    factory.insert(node, type);
+    return type;
+}
+Type const *load_alias(TypeNode const &node, Factory &factory) {
+    string source = getAttribute<string>(node.xml, "source");
+    Type const *type = factory.build(source);
+    factory.alias(node, source);
+    return type;
+}
+
+Type const *load_compound(TypeNode const &node, Factory &factory) {
+    Compound *compound = new Compound(node.name);
+    size_t size = getAttribute<size_t>(node.xml, "size");
+
+    for (xmlNodePtr xml = xmlFirstElementChild(node.xml); xml;
+         xml = xmlNextElementSibling(xml)) {
+        if (xmlStrcmp(xml->name, reinterpret_cast<const xmlChar *>("field")))
+            continue;
+
+        // checkNodeName<UnexpectedElement>    (xml, "field");
+        string name = getAttribute<string>(xml, "name");
+        string tname = getAttribute<string>(xml, "type");
+        size_t offset = getAttribute<size_t>(xml, "offset");
+
+        Type const *type = factory.build(tname);
+        Field const &field = compound->addField(name, *type, offset);
+        loadMetaData(xml, field.getMetaData());
+    }
+
+    compound->setSize(size);
+    factory.insert(node, compound);
+    return compound;
+}
+}
+
+namespace {
+struct NodeCategories {
+    const xmlChar *name;
+    NodeLoader loader;
+};
+
+NodeCategories node_categories[] = {
+    {reinterpret_cast<const xmlChar *>("alias"), load_alias},
+    {reinterpret_cast<const xmlChar *>("numeric"), load_numeric},
+    {reinterpret_cast<const xmlChar *>("null"), load_null},
+    {reinterpret_cast<const xmlChar *>("opaque"), load_opaque},
+    {reinterpret_cast<const xmlChar *>("enum"), load_enum},
+    {reinterpret_cast<const xmlChar *>("compound"), load_compound},
+    {reinterpret_cast<const xmlChar *>("container"), load_container},
+    {0, 0}};
+
+void load(string const &file, TypeMap &map, xmlNodePtr type_node) {
+    string name = getStringAttribute(type_node, "name");
+    NodeCategories cat = getCategoryFromNode(node_categories, type_node->name);
+
+    TypeMap::iterator it = map.find(name);
+    if (it != map.end()) {
+        string old_file = it->second.file;
+        std::clog << "Type " << name << " has already been defined in "
+                  << old_file << endl;
+        std::clog << "\tThe definition found in " << file << " will be ignored"
+                  << endl;
+    } else {
+        string type_file = file;
+        try {
+            type_file = getStringAttribute(type_node, "source_id");
+        } catch (Parsing::MissingAttribute) {
         }
-        catch(Parsing::MissingAttribute) {}
-
-        Type const* container = &Container::createContainer(factory.getRegistry(), kind, *indirect);
-        // We use zero size to indicate that the natural platform size should be
-        // used
-        if (has_size && size != 0)
-        {
-            // Update the size to match the one saved in the registry. This is to
-            // allow a proper call to resize() later if needed.
-            factory.getRegistry().get_(*container).setSize(size);
-        }
-        loadMetaData(node, container->getMetaData());
-        return container;
-    }
-    Type const* load_enum(TypeNode const& node, Factory& factory)
-    { 
-        Enum* type = new Enum(node.name);
-        for(xmlNodePtr xml = xmlFirstElementChild(node.xml); xml; xml=xmlNextElementSibling(xml))
-        {
-            if (xmlStrcmp(xml->name, reinterpret_cast<const xmlChar*>("value")))
-                continue;
-
-            string symbol = getAttribute<string>(xml, "symbol");
-            Enum::integral_type value  = getAttribute<Enum::integral_type>(xml, "value");
-            type->add(symbol, value);
-        }
-
-        factory.insert(node, type); 
-        return type;
-    }
-    Type const* load_alias(TypeNode const& node, Factory& factory)
-    {
-        string source = getAttribute<string>(node.xml, "source");
-        Type const* type = factory.build(source);
-        factory.alias(node, source);
-        return type;
-    }
-
-    
-    Type const* load_compound(TypeNode const& node, Factory& factory)
-    {
-        Compound* compound = new Compound(node.name);
-        size_t size = getAttribute<size_t>(node.xml, "size");
-
-        for(xmlNodePtr xml = xmlFirstElementChild(node.xml); xml; xml=xmlNextElementSibling(xml))
-        {
-            if (xmlStrcmp(xml->name, reinterpret_cast<const xmlChar*>("field")))
-                continue;
-
-            //checkNodeName<UnexpectedElement>    (xml, "field");
-            string name   = getAttribute<string>(xml, "name");
-            string tname  = getAttribute<string>(xml, "type");
-            size_t offset = getAttribute<size_t>(xml, "offset");
-
-            Type const* type = factory.build(tname);
-            Field const& field = compound->addField(name, *type, offset);
-            loadMetaData(xml, field.getMetaData());
-        }
-
-        compound->setSize(size);
-        factory.insert(node, compound);
-        return compound;
+        map[name] = TypeNode(type_node, name, type_file, cat.loader);
     }
 }
 
+void parse(std::string const &source_id, xmlDocPtr doc, Registry &registry) {
+    if (!doc)
+        throw Parsing::MalformedXML();
 
-namespace
-{
-    struct NodeCategories
-    {
-        const xmlChar* name;
-        NodeLoader  loader;
-    };
+    xmlNodePtr root_node = xmlDocGetRootElement(doc);
+    if (!root_node)
+        return;
 
-    NodeCategories node_categories[] = {
-        { reinterpret_cast<const xmlChar*>("alias"),     load_alias },
-        { reinterpret_cast<const xmlChar*>("numeric"),   load_numeric },
-        { reinterpret_cast<const xmlChar*>("null"),      load_null },
-        { reinterpret_cast<const xmlChar*>("opaque"),    load_opaque },
-        { reinterpret_cast<const xmlChar*>("enum"),      load_enum },
-        { reinterpret_cast<const xmlChar*>("compound"),  load_compound },
-        { reinterpret_cast<const xmlChar*>("container"),  load_container },
-        { 0, 0 }
-    };
+    checkNodeName<Parsing::BadRootElement>(root_node, "typelib");
 
-    void load(string const& file, TypeMap& map, xmlNodePtr type_node)
-    {
-        string name   = getStringAttribute(type_node, "name");
-        NodeCategories cat = getCategoryFromNode(node_categories, type_node->name);
+    TypeMap all_types;
+    for (xmlNodePtr node = root_node->xmlChildrenNode; node;
+         node = node->next) {
+        if (!xmlStrcmp(node->name,
+                       reinterpret_cast<const xmlChar *>("comment")))
+            continue;
+        if (!xmlStrcmp(node->name, reinterpret_cast<const xmlChar *>("text")))
+            continue;
 
-        TypeMap::iterator it = map.find(name);
-        if (it != map.end())
-        {
-            string old_file = it->second.file;
-            std::clog << "Type " << name << " has already been defined in " << old_file << endl;
-            std::clog << "\tThe definition found in " << file << " will be ignored" << endl;
-        }
-        else
-        {
-            string type_file = file;
-            try { type_file = getStringAttribute(type_node, "source_id"); }
-            catch(Parsing::MissingAttribute) {}
-            map[name] = TypeNode(type_node, name, type_file, cat.loader);
-        }
+        ::load(source_id, all_types, node);
     }
 
-    void parse(std::string const& source_id, xmlDocPtr doc, Registry& registry)
-    {
-	if (!doc) 
-	    throw Parsing::MalformedXML();
-
-        xmlNodePtr root_node = xmlDocGetRootElement(doc);
-        if (!root_node) 
-            return;
-
-        checkNodeName<Parsing::BadRootElement>(root_node, "typelib");
-
-        TypeMap all_types;
-        for(xmlNodePtr node = root_node -> xmlChildrenNode; node; node=node->next)
-        {
-            if (!xmlStrcmp(node->name, reinterpret_cast<const xmlChar*>("comment")))
-                continue;
-            if (!xmlStrcmp(node->name, reinterpret_cast<const xmlChar*>("text")))
-                continue;
-
-            ::load(source_id, all_types, node);
-        }
-
-        Factory factory(registry);
-        factory.build(all_types);
-    }
+    Factory factory(registry);
+    factory.build(all_types);
+}
 }
 
-void TlbImport::load
-    ( std::istream& stream
-    , utilmm::config_set const& config
-    , Typelib::Registry& registry)
-{
+void TlbImport::load(std::istream &stream, utilmm::config_set const &config,
+                     Typelib::Registry &registry) {
     // libXML is not really iostream-compatible :(
     // Get the whole document
     std::string document;
 
-    while (stream.good())
-    {
+    while (stream.good()) {
         std::stringbuf buffer;
         stream >> &buffer;
         document += buffer.str();
     }
     xmlDocPtr doc = xmlParseMemory(document.c_str(), document.length());
-    if (!doc) 
+    if (!doc)
         throw Parsing::MalformedXML();
 
-    try
-    {
+    try {
         parse("", doc, registry);
         xmlFreeDoc(doc);
-    }
-    catch(...)
-    { 
-        xmlFreeDoc(doc); 
+    } catch (...) {
+        xmlFreeDoc(doc);
         throw;
     }
 }
 
-
-void TlbImport::load
-    ( std::string const& path
-    , utilmm::config_set const& config
-    , Typelib::Registry& registry)
-{
-    // Loading from files seams to be broken on some distro's libxml2-packages, 
+void TlbImport::load(std::string const &path, utilmm::config_set const &config,
+                     Typelib::Registry &registry) {
+    // Loading from files seams to be broken on some distro's libxml2-packages,
     // so we load the whole file into memory before parsing
     std::ifstream stream(path.c_str());
     load(stream, config, registry);
 }
-

--- a/lang/tlb/import.hh
+++ b/lang/tlb/import.hh
@@ -3,19 +3,13 @@
 
 #include <typelib/importer.hh>
 
-class TlbImport : public Typelib::Importer
-{
-public:
-    virtual void load
-        ( std::istream& stream
-        , utilmm::config_set const& config
-        , Typelib::Registry& registry);
+class TlbImport : public Typelib::Importer {
+  public:
+    virtual void load(std::istream &stream, utilmm::config_set const &config,
+                      Typelib::Registry &registry);
 
-    virtual void load
-        ( std::string const& file
-        , utilmm::config_set const& config
-        , Typelib::Registry& registry);
+    virtual void load(std::string const &file, utilmm::config_set const &config,
+                      Typelib::Registry &registry);
 };
 
 #endif
-

--- a/lang/tlb/parsing.hh
+++ b/lang/tlb/parsing.hh
@@ -4,51 +4,54 @@
 #include <sstream>
 #include <string>
 
-namespace Parsing
-{
-    using Typelib::ImportError;
-    class MalformedXML : public ImportError
-    {
-    public:
-        MalformedXML(const std::string& file = "") 
-            : ImportError(file, "malformed XML") {}
-    };
+namespace Parsing {
+using Typelib::ImportError;
+class MalformedXML : public ImportError {
+  public:
+    MalformedXML(const std::string &file = "")
+        : ImportError(file, "malformed XML") {}
+};
 
-    class UnexpectedElement : public ImportError
-    {
-        std::string m_found, m_expected;
-    public:
-        UnexpectedElement(const std::string& found_, const std::string expected_, const std::string& file = "")
-            : ImportError(file, "unexpected element " + found_ + ", was expecting " + expected_)
-            , m_found(found_), m_expected(expected_) { }
-        ~UnexpectedElement() throw() {}
+class UnexpectedElement : public ImportError {
+    std::string m_found, m_expected;
 
-        std::string found() const    { return m_found; }
-        std::string expected() const { return m_expected; }
-    };
+  public:
+    UnexpectedElement(const std::string &found_, const std::string expected_,
+                      const std::string &file = "")
+        : ImportError(file, "unexpected element " + found_ +
+                                ", was expecting " + expected_),
+          m_found(found_), m_expected(expected_) {}
+    ~UnexpectedElement() throw() {}
 
-    class BadRootElement : public ImportError
-    {
-        std::string m_found, m_expected;
-    public:
-        BadRootElement(const std::string& found_, const std::string expected_, const std::string& file = "")
-            : ImportError(file, "this document is not a Typelib type library: found " + found_ + " instead of " + expected_)
-            , m_found(found_), m_expected(expected_) {}
-        ~BadRootElement() throw() {}
+    std::string found() const { return m_found; }
+    std::string expected() const { return m_expected; }
+};
 
-        std::string found() const    { return m_found; }
-        std::string expected() const { return m_expected; }
-    };
+class BadRootElement : public ImportError {
+    std::string m_found, m_expected;
 
-    class MissingAttribute : public ImportError
-    {
-        std::string m_attribute;
-    public:
-        MissingAttribute(const std::string& attribute, const std::string& file = "")
-            : ImportError(file, "missing attribute " + attribute), m_attribute(attribute) {}
-        ~MissingAttribute() throw() {}
-    };
+  public:
+    BadRootElement(const std::string &found_, const std::string expected_,
+                   const std::string &file = "")
+        : ImportError(file,
+                      "this document is not a Typelib type library: found " +
+                          found_ + " instead of " + expected_),
+          m_found(found_), m_expected(expected_) {}
+    ~BadRootElement() throw() {}
+
+    std::string found() const { return m_found; }
+    std::string expected() const { return m_expected; }
+};
+
+class MissingAttribute : public ImportError {
+    std::string m_attribute;
+
+  public:
+    MissingAttribute(const std::string &attribute, const std::string &file = "")
+        : ImportError(file, "missing attribute " + attribute),
+          m_attribute(attribute) {}
+    ~MissingAttribute() throw() {}
+};
 };
 
 #endif
-

--- a/lang/tlb/register.cc
+++ b/lang/tlb/register.cc
@@ -3,4 +3,3 @@
 #include <typelib/plugins.hh>
 
 TYPELIB_REGISTER_IO2(tlb, TlbExport, TlbImport)
-

--- a/lang/tlb/xmltools.hh
+++ b/lang/tlb/xmltools.hh
@@ -5,34 +5,33 @@
 #include "parsing.hh"
 #include <boost/lexical_cast.hpp>
 
-namespace 
-{
-    using std::string;
+namespace {
+using std::string;
 
-    template<typename Exception>
-    void checkNodeName(xmlNodePtr node, const char* expected)
-    {
-        if (xmlStrcmp(node->name, reinterpret_cast<const xmlChar*>(expected)))
-            throw Exception(reinterpret_cast<const char*>(node->name), expected, "");
-    }
+template <typename Exception>
+void checkNodeName(xmlNodePtr node, const char *expected) {
+    if (xmlStrcmp(node->name, reinterpret_cast<const xmlChar *>(expected)))
+        throw Exception(reinterpret_cast<const char *>(node->name), expected,
+                        "");
+}
 
-    std::string getStringAttribute(xmlNodePtr type, const char* att_name)
-    {
-        xmlChar* att = xmlGetProp(type, reinterpret_cast<const xmlChar*>(att_name) );
-        if (! att)
-            throw Parsing::MissingAttribute(att_name, "");
-        std::string ret( reinterpret_cast<const char*>(att));
-        xmlFree(att);
-        return ret;
-    }
+std::string getStringAttribute(xmlNodePtr type, const char *att_name) {
+    xmlChar *att =
+        xmlGetProp(type, reinterpret_cast<const xmlChar *>(att_name));
+    if (!att)
+        throw Parsing::MissingAttribute(att_name, "");
+    std::string ret(reinterpret_cast<const char *>(att));
+    xmlFree(att);
+    return ret;
+}
 
-    template<typename T>
-    T getAttribute(xmlNodePtr type, char const* att_name)
-    { return boost::lexical_cast<T>(getStringAttribute(type, att_name)); }
-    template<>
-    std::string getAttribute<std::string>(xmlNodePtr type, const char* att_name)
-    { return getStringAttribute(type, att_name); }
+template <typename T> T getAttribute(xmlNodePtr type, char const *att_name) {
+    return boost::lexical_cast<T>(getStringAttribute(type, att_name));
+}
+template <>
+std::string getAttribute<std::string>(xmlNodePtr type, const char *att_name) {
+    return getStringAttribute(type, att_name);
+}
 }
 
 #endif
-

--- a/test/data/laser.h
+++ b/test/data/laser.h
@@ -1,12 +1,9 @@
-namespace Laser
-{
-    typedef int array_typedef[256];
-    struct Data
-    {
-	int sec;
-	unsigned int usec;
+namespace Laser {
+typedef int array_typedef[256];
+struct Data {
+    int sec;
+    unsigned int usec;
 
-	double ranges[256];
-    };
+    double ranges[256];
+};
 }
-

--- a/test/data/nested_types/enum_in_struct.h
+++ b/test/data/nested_types/enum_in_struct.h
@@ -1,6 +1,3 @@
 struct Root {
-    enum Bla {
-        VALUE = 5
-    };
+    enum Bla { VALUE = 5 };
 };
-

--- a/test/data/nested_types/struct_in_struct.h
+++ b/test/data/nested_types/struct_in_struct.h
@@ -1,20 +1,15 @@
-typedef union
-{
-  struct __pthread_mutex_s
-  {
-    int __lock;
-    unsigned int __count;
-    int __owner;
+typedef union {
+    struct __pthread_mutex_s {
+        int __lock;
+        unsigned int __count;
+        int __owner;
 
-    unsigned int __nusers;
+        unsigned int __nusers;
 
+        int __kind;
 
-
-    int __kind;
-
-    int __spins;
-  } __data;
-  char __size[40];
-  long int __align;
+        int __spins;
+    } __data;
+    char __size[40];
+    long int __align;
 } pthread_mutex_t;
-

--- a/test/data/posterLib.h
+++ b/test/data/posterLib.h
@@ -1,19 +1,11 @@
 
 #define STATUS int
 
-typedef enum H2_ENDIANNESS {
-  H2_BIG_ENDIAN,
-  H2_LITTLE_ENDIAN
-} H2_ENDIANNESS;
+typedef enum H2_ENDIANNESS { H2_BIG_ENDIAN, H2_LITTLE_ENDIAN } H2_ENDIANNESS;
 
 /* -- STRUCTURES ------------------------------------------ */
-extern STATUS	logInit(int fd, int maxMsgs);
-extern int logMsg ( const char *fmt, ... );
+extern STATUS logInit(int fd, int maxMsgs);
+extern int logMsg(const char *fmt, ...);
 
 /* type of operation in posterTake() */
-typedef enum {
-	POSTER_READ,
-	POSTER_WRITE,
-	POSTER_IOCTL
-} POSTER_OP;
-
+typedef enum { POSTER_READ, POSTER_WRITE, POSTER_IOCTL } POSTER_OP;

--- a/test/data/stdheaders.h
+++ b/test/data/stdheaders.h
@@ -7,4 +7,3 @@
 
 // Cannot import stdlib.h: nested type definitions
 // #include <stdlib.h>
-

--- a/test/data/test_idl.h
+++ b/test/data/test_idl.h
@@ -1,5 +1,4 @@
-typedef struct Compound
-{
+typedef struct Compound {
     int a;
     short b;
     char c;
@@ -15,35 +14,32 @@ typedef enum TestEnum { A, B, C } EnumAlias;
 typedef TestEnum OtherEnum;
 
 namespace NS1 {
-    namespace NS1_1 {
-	struct Test {
-	    int a;
-	    short b;
-	};
-    }
+namespace NS1_1 {
+struct Test {
+    int a;
+    short b;
+};
+}
 
-    namespace NS1_2 {
-	typedef NS1_1::Test Test;
-    }
+namespace NS1_2 {
+typedef NS1_1::Test Test;
+}
 
-    struct Test {
-	NS1_1::Test test2;
-    };
+struct Test {
+    NS1_1::Test test2;
+};
 }
 
 #ifdef IDL_POINTER_ALIAS
-typedef int* Pointer;
+typedef int *Pointer;
 #endif
 #ifdef IDL_POINTER_IN_STRUCT
-struct InvalidStruct
-{
-    int* value;
+struct InvalidStruct {
+    int *value;
 };
 #endif
 #ifdef IDL_MULTI_ARRAY
-struct MultiArrayStruct
-{
+struct MultiArrayStruct {
     int array[10][20];
 };
 #endif
-

--- a/test/ruby/cxx_import_tests/documentation_utf8.h
+++ b/test/ruby/cxx_import_tests/documentation_utf8.h
@@ -1,6 +1,5 @@
 /* this is a 香 multiline with ነ unicode characters
  */
-struct DocumentedType
-{
+struct DocumentedType {
     int field; // otherwise the type is ignored
 };

--- a/test/ruby/cxx_import_tests/documentation_with_space_between_struct_and_opening_bracket.h
+++ b/test/ruby/cxx_import_tests/documentation_with_space_between_struct_and_opening_bracket.h
@@ -2,7 +2,6 @@
  * documentation block
  */
 
-struct DocumentedType
-{
+struct DocumentedType {
     int field; // otherwise the type is ignored
 };

--- a/test/ruby/cxx_import_tests/documentation_with_struct_and_opening_bracket_on_different_lines.h
+++ b/test/ruby/cxx_import_tests/documentation_with_struct_and_opening_bracket_on_different_lines.h
@@ -1,7 +1,6 @@
 /* this is a multiline
  * documentation block
  */
-struct DocumentedType
-{
+struct DocumentedType {
     int field; // otherwise the type is ignored
 };

--- a/test/ruby/cxx_import_tests/ignored_base_class.h
+++ b/test/ruby/cxx_import_tests/ignored_base_class.h
@@ -1,11 +1,8 @@
-struct Base
-{
-private:
+struct Base {
+  private:
     double first;
 };
 
-struct Derived : public Base
-{
+struct Derived : public Base {
     double second;
 };
-

--- a/test/ruby/cxx_import_tests/non_virtual_inheritance.h
+++ b/test/ruby/cxx_import_tests/non_virtual_inheritance.h
@@ -1,14 +1,10 @@
 #include <stdint.h>
-struct FirstBase
-{
+struct FirstBase {
     uint64_t first;
 };
-struct SecondBase
-{
+struct SecondBase {
     uint64_t second;
 };
-struct Derived : public FirstBase, public SecondBase
-{
+struct Derived : public FirstBase, public SecondBase {
     uint64_t third;
 };
-

--- a/test/ruby/cxx_import_tests/private_base_class.h
+++ b/test/ruby/cxx_import_tests/private_base_class.h
@@ -1,9 +1,7 @@
-struct Base
-{
+struct Base {
     double first;
 };
 
-struct Derived : private Base
-{
+struct Derived : private Base {
     double second;
 };

--- a/test/ruby/cxx_import_tests/template_of_container.h
+++ b/test/ruby/cxx_import_tests/template_of_container.h
@@ -1,13 +1,7 @@
 #include <vector>
 
-template<typename T>
-struct BaseTemplate
-{
-    T field;
-};
+template <typename T> struct BaseTemplate { T field; };
 
-struct Subclass : BaseTemplate< std::vector<double> >
-{
+struct Subclass : BaseTemplate<std::vector<double> > {
     std::vector<double> another_field;
 };
-

--- a/test/ruby/cxx_import_tests/virtual_inheritance.h
+++ b/test/ruby/cxx_import_tests/virtual_inheritance.h
@@ -1,9 +1,7 @@
-struct Base
-{
+struct Base {
     double field;
 };
 
-struct Derived : virtual public Base
-{
+struct Derived : virtual public Base {
     double other_field;
 };

--- a/test/ruby/cxx_import_tests/virtual_methods.h
+++ b/test/ruby/cxx_import_tests/virtual_methods.h
@@ -1,5 +1,4 @@
-struct Class
-{
+struct Class {
     virtual int method();
     double field;
 };

--- a/test/ruby/test_rb_value.cc
+++ b/test/ruby/test_rb_value.cc
@@ -7,17 +7,15 @@
 
 using namespace Typelib;
 
-static bool do_check_struct_A_value(A const& a)
-{ 
+static bool do_check_struct_A_value(A const &a) {
     if (a.a == 10 && a.b == 20 && a.c == 30 && a.d == 40)
         return true;
-    printf("do_check_struct_A_value failed: a=%i, b=%i, c=%i, d=%i\n",
-            (int)a.a, (int)a.b, (int)a.c, (int)a.d);
+    printf("do_check_struct_A_value failed: a=%i, b=%i, c=%i, d=%i\n", (int)a.a,
+           (int)a.b, (int)a.c, (int)a.d);
     return false;
 }
 
-static void do_set_struct_A_value(A& a)
-{
+static void do_set_struct_A_value(A &a) {
     a.a = 10;
     a.b = 20;
     a.c = 30;
@@ -27,189 +25,168 @@ static void do_set_struct_A_value(A& a)
  * This file provides the C-side of the test_rb_value testsuite
  */
 
-static VALUE check_struct_A_value(VALUE self, VALUE ra)
-{
-    Value* value = 0;
+static VALUE check_struct_A_value(VALUE self, VALUE ra) {
+    Value *value = 0;
     Data_Get_Struct(ra, Value, value);
 
-    A& a(*reinterpret_cast<A*>(value->getData()));
+    A &a(*reinterpret_cast<A *>(value->getData()));
     if (do_check_struct_A_value(a))
         return Qtrue;
     return Qfalse;
 }
 
-static VALUE set_struct_A_value(VALUE self, VALUE ra)
-{
-    Value* value = 0;
+static VALUE set_struct_A_value(VALUE self, VALUE ra) {
+    Value *value = 0;
     Data_Get_Struct(ra, Value, value);
 
-    A& a(*reinterpret_cast<A*>(value->getData()));
+    A &a(*reinterpret_cast<A *>(value->getData()));
     do_set_struct_A_value(a);
     return ra;
 }
 
-static VALUE check_B_c_value(VALUE self, VALUE rb)
-{
-    Value* value = 0;
+static VALUE check_B_c_value(VALUE self, VALUE rb) {
+    Value *value = 0;
     Data_Get_Struct(rb, Value, value);
 
-    B& b(*reinterpret_cast<B*>(value->getData()));
+    B &b(*reinterpret_cast<B *>(value->getData()));
     for (int i = 0; i < 100; ++i)
         if (fabs(b.c[i] - float(i) / 10.0f) > 0.001)
             return Qfalse;
     return Qtrue;
 }
 
-static void do_set_B_c_value(B& b)
-{
+static void do_set_B_c_value(B &b) {
     for (int i = 0; i < 100; ++i)
         b.c[i] = float(i) / 10.0f;
 }
 
-static VALUE set_B_c_value(VALUE self, VALUE rb)
-{
-    Value* value = 0;
+static VALUE set_B_c_value(VALUE self, VALUE rb) {
+    Value *value = 0;
     Data_Get_Struct(rb, Value, value);
 
-    B& b(*reinterpret_cast<B*>(value->getData()));
+    B &b(*reinterpret_cast<B *>(value->getData()));
     do_set_B_c_value(b);
     return Qnil;
 }
 
-static VALUE fill_multi_dim_array(VALUE self, VALUE rb)
-{
-    Value* value = 0;
+static VALUE fill_multi_dim_array(VALUE self, VALUE rb) {
+    Value *value = 0;
     Data_Get_Struct(rb, Value, value);
 
-    TestMultiDimArray& b(*reinterpret_cast<TestMultiDimArray*>(value->getData()));
+    TestMultiDimArray &b(
+        *reinterpret_cast<TestMultiDimArray *>(value->getData()));
     for (int y = 0; y < 10; ++y)
-	for (int x = 0; x < 10; ++x)
-	    b.fields[y][x] = x + y * 10;
+        for (int x = 0; x < 10; ++x)
+            b.fields[y][x] = x + y * 10;
 
     return Qnil;
 }
 
 extern "C" {
 
-    void Init_libtest_ruby()
-    {
-        rb_define_method(rb_mKernel, "check_B_c_value",         RUBY_METHOD_FUNC(check_B_c_value), 1);
-        rb_define_method(rb_mKernel, "set_B_c_value",           RUBY_METHOD_FUNC(set_B_c_value), 1);
-        rb_define_method(rb_mKernel, "check_struct_A_value",    RUBY_METHOD_FUNC(check_struct_A_value), 1);
-        rb_define_method(rb_mKernel, "set_struct_A_value",      RUBY_METHOD_FUNC(set_struct_A_value), 1);
-        rb_define_method(rb_mKernel, "fill_multi_dim_array",      RUBY_METHOD_FUNC(fill_multi_dim_array), 1);
-    }
-
-    void test_simple_function_call() { }
-
-    void generate_nand(double* value)
-    { *value = 1.0/0.0; }
-    void generate_nanf(float* value)
-    { *value = 1.0f/0.0f; }
-    void test_numeric_argument_passing(char a, short b, int c, long d, long long e, float f, double g)
-    {
-	if (a != 1 || b != 2 || c != 3 || d != 4 || e != 5 || f != 6 || g != 7)
-	    rb_raise(rb_eArgError, "failed to pass numeric arguments");
-    }
-    char test_returns_numeric_argument_char(char value) { return value; }
-    short test_returns_numeric_argument_short(short value) { return value; }
-    int test_returns_numeric_argument_int(int value) { return value; }
-    long test_returns_numeric_argument_long(long value) { return value; }
-    int64_t test_returns_numeric_argument_int64_t(int64_t value) { return value; }
-    float test_returns_numeric_argument_float(float value) { return value; }
-    double test_returns_numeric_argument_double(double value) { return value; }
-    void test_returns_argument(int* holder) { *holder = 42; }
-
-
-    void test_pointer_argument(A* a)
-    {
-        if (!do_check_struct_A_value(*a))
-            rb_raise(rb_eArgError, "error in passing structure as pointer");
-    }
-
-    struct A* test_returns_pointer()
-    {
-        static A a;
-        do_set_struct_A_value(a);
-        return &a;
-    }
-
-    void test_modifies_argument(int* value) 
-    { 
-	if (*value != 0)
-	    rb_raise(rb_eArgError, "invalid argument value");
-	*value = 42; 
-    }
-
-
-    int test_immediate_to_pointer(double* value) { return *value == 0.5; }
-
-    void test_ptr_argument_changes(struct B* b)
-    { do_set_B_c_value(*b); }
-
-    void test_arg_input_output(int* value, INPUT_OUTPUT_MODE mode) 
-    { 
-        if (mode == BOTH && *value != 10)
-        {
-            *value = 0;
-            return;
-        }
-        *value = 5; 
-    }
-
-    void test_enum_io_handling(INPUT_OUTPUT_MODE* mode)
-    {
-        switch(*mode)
-        {
-            case BOTH:
-                *mode = OUTPUT;
-                break;
-            case OUTPUT:
-                *mode = BOTH;
-                break;
-        }
-    }
-
-    static int opaque_handler;
-    OPAQUE_TYPE test_opaque_handling()
-    { return &opaque_handler; }
-
-    int check_opaque_value(OPAQUE_TYPE handler, int check)
-    { return (handler == test_opaque_handling()) ? check : 0; }
-
-    void test_string_argument(char const* value)
-    {
-        if (strcmp(value, "test"))
-            rb_raise(rb_eArgError, "bad string argument");
-    }
-
-    static const char* static_string = "string_return";
-    const char* test_string_return()
-    { return static_string; }
-    void test_string_argument_modification(char* str, int buffer_length)
-    { strcpy(str, static_string); }
-    void test_string_as_array(char str[256])
-    { strcpy(str, static_string); }
-
-    DEFINE_STR id;
-    int test_id_handling(DEFINE_ID* new_id, int check)
-    {
-        *new_id = &id;
-        return check;
-    }
-    int check_id_value(DEFINE_ID test_id, int check)
-    { 
-        printf("check_id_value, test_id=%p, &id=%p\n", test_id, &id);
-        return (test_id == &id) ? check : 0; 
-    }
-
-    void test_null_return_value(DEFINE_ID* test_id, int check)
-    {
-	*test_id = 0;
-    }
-
-    void test_void_argument(void* value, int check)
-    { *static_cast<int*>(value) = check; }
+void Init_libtest_ruby() {
+    rb_define_method(rb_mKernel, "check_B_c_value",
+                     RUBY_METHOD_FUNC(check_B_c_value), 1);
+    rb_define_method(rb_mKernel, "set_B_c_value",
+                     RUBY_METHOD_FUNC(set_B_c_value), 1);
+    rb_define_method(rb_mKernel, "check_struct_A_value",
+                     RUBY_METHOD_FUNC(check_struct_A_value), 1);
+    rb_define_method(rb_mKernel, "set_struct_A_value",
+                     RUBY_METHOD_FUNC(set_struct_A_value), 1);
+    rb_define_method(rb_mKernel, "fill_multi_dim_array",
+                     RUBY_METHOD_FUNC(fill_multi_dim_array), 1);
 }
 
+void test_simple_function_call() {}
 
+void generate_nand(double *value) { *value = 1.0 / 0.0; }
+void generate_nanf(float *value) { *value = 1.0f / 0.0f; }
+void test_numeric_argument_passing(char a, short b, int c, long d, long long e,
+                                   float f, double g) {
+    if (a != 1 || b != 2 || c != 3 || d != 4 || e != 5 || f != 6 || g != 7)
+        rb_raise(rb_eArgError, "failed to pass numeric arguments");
+}
+char test_returns_numeric_argument_char(char value) { return value; }
+short test_returns_numeric_argument_short(short value) { return value; }
+int test_returns_numeric_argument_int(int value) { return value; }
+long test_returns_numeric_argument_long(long value) { return value; }
+int64_t test_returns_numeric_argument_int64_t(int64_t value) { return value; }
+float test_returns_numeric_argument_float(float value) { return value; }
+double test_returns_numeric_argument_double(double value) { return value; }
+void test_returns_argument(int *holder) { *holder = 42; }
+
+void test_pointer_argument(A *a) {
+    if (!do_check_struct_A_value(*a))
+        rb_raise(rb_eArgError, "error in passing structure as pointer");
+}
+
+struct A *test_returns_pointer() {
+    static A a;
+    do_set_struct_A_value(a);
+    return &a;
+}
+
+void test_modifies_argument(int *value) {
+    if (*value != 0)
+        rb_raise(rb_eArgError, "invalid argument value");
+    *value = 42;
+}
+
+int test_immediate_to_pointer(double *value) { return *value == 0.5; }
+
+void test_ptr_argument_changes(struct B *b) { do_set_B_c_value(*b); }
+
+void test_arg_input_output(int *value, INPUT_OUTPUT_MODE mode) {
+    if (mode == BOTH && *value != 10) {
+        *value = 0;
+        return;
+    }
+    *value = 5;
+}
+
+void test_enum_io_handling(INPUT_OUTPUT_MODE *mode) {
+    switch (*mode) {
+    case BOTH:
+        *mode = OUTPUT;
+        break;
+    case OUTPUT:
+        *mode = BOTH;
+        break;
+    }
+}
+
+static int opaque_handler;
+OPAQUE_TYPE test_opaque_handling() { return &opaque_handler; }
+
+int check_opaque_value(OPAQUE_TYPE handler, int check) {
+    return (handler == test_opaque_handling()) ? check : 0;
+}
+
+void test_string_argument(char const *value) {
+    if (strcmp(value, "test"))
+        rb_raise(rb_eArgError, "bad string argument");
+}
+
+static const char *static_string = "string_return";
+const char *test_string_return() { return static_string; }
+void test_string_argument_modification(char *str, int buffer_length) {
+    strcpy(str, static_string);
+}
+void test_string_as_array(char str[256]) { strcpy(str, static_string); }
+
+DEFINE_STR id;
+int test_id_handling(DEFINE_ID *new_id, int check) {
+    *new_id = &id;
+    return check;
+}
+int check_id_value(DEFINE_ID test_id, int check) {
+    printf("check_id_value, test_id=%p, &id=%p\n", test_id, &id);
+    return (test_id == &id) ? check : 0;
+}
+
+void test_null_return_value(DEFINE_ID *test_id, int check) { *test_id = 0; }
+
+void test_void_argument(void *value, int check) {
+    *static_cast<int *>(value) = check;
+}
+}

--- a/test/test_cimport.h
+++ b/test/test_cimport.h
@@ -6,4 +6,3 @@
 #else
 #error "GOOD is not defined"
 #endif
-

--- a/test/test_containers.cc
+++ b/test/test_containers.cc
@@ -14,119 +14,116 @@
 using namespace Typelib;
 using namespace std;
 
-template<int ptrsize> struct ptr_value_getter { };
-template<> struct ptr_value_getter<4> { typedef uint32_t result; };
-template<> struct ptr_value_getter<8> { typedef uint64_t result; };
+template <int ptrsize> struct ptr_value_getter {};
+template <> struct ptr_value_getter<4> { typedef uint32_t result; };
+template <> struct ptr_value_getter<8> { typedef uint64_t result; };
 
-typedef ptr_value_getter<sizeof(void*)>::result ptr_value_t;
-ptr_value_t ptr_value(void* ptr) { return reinterpret_cast<ptr_value_t>(ptr); };
+typedef ptr_value_getter<sizeof(void *)>::result ptr_value_t;
+ptr_value_t ptr_value(void *ptr) { return reinterpret_cast<ptr_value_t>(ptr); };
 
-BOOST_AUTO_TEST_CASE( test_vector_assumptions )
-{
+BOOST_AUTO_TEST_CASE(test_vector_assumptions) {
     // It is expected that ->size() depends on the type of the vector elements,
     // but that the size can be offset by using the ratio of sizeof()
     {
         vector<int32_t> values;
         values.resize(10);
         BOOST_REQUIRE_EQUAL(10, values.size());
-        BOOST_REQUIRE_EQUAL(5, reinterpret_cast< vector<int64_t>& >(values).size());
+        BOOST_REQUIRE_EQUAL(5,
+                            reinterpret_cast<vector<int64_t> &>(values).size());
     }
     {
-        vector< vector<double> > values;
+        vector<vector<double> > values;
         values.resize(10);
         BOOST_REQUIRE_EQUAL(10, values.size());
-        BOOST_REQUIRE_EQUAL(10 * sizeof(vector<double>), reinterpret_cast< vector<int8_t>& >(values).size());
+        BOOST_REQUIRE_EQUAL(10 * sizeof(vector<double>),
+                            reinterpret_cast<vector<int8_t> &>(values).size());
     }
 
     // To resize the containers efficiently, we assume that moving the bytes
     // around is fine. This is a valid assumption only if the std::vector's
     // internal structure does not store any pointer to the memory location
-    // 
+    //
     // This tests that this assumption is valid
     {
-        vector< vector<double> > values;
+        vector<vector<double> > values;
         values.resize(10);
 
-        uint8_t* values_p = reinterpret_cast<uint8_t*>(&values);
-        uint8_t* it_p     = reinterpret_cast<uint8_t*>(&values);
+        uint8_t *values_p = reinterpret_cast<uint8_t *>(&values);
+        uint8_t *it_p = reinterpret_cast<uint8_t *>(&values);
         ptr_value_t vector_min = ptr_value(&values);
         ptr_value_t vector_max = ptr_value(&values) + sizeof(values);
 
-        while ((it_p + sizeof(void*)) - values_p < static_cast<int>(sizeof(values)))
-        {
-            ptr_value_t p = *reinterpret_cast<ptr_value_t*>(it_p);
+        while ((it_p + sizeof(void *)) - values_p <
+               static_cast<int>(sizeof(values))) {
+            ptr_value_t p = *reinterpret_cast<ptr_value_t *>(it_p);
             BOOST_REQUIRE(!(p >= vector_min && p < vector_max));
             ++it_p;
         }
     }
 }
 
-static void import_test_types(Registry& registry)
-{
-    static const char* test_file = TEST_DATA_PATH("test_cimport.tlb");
+static void import_test_types(Registry &registry) {
+    static const char *test_file = TEST_DATA_PATH("test_cimport.tlb");
 
     utilmm::config_set config;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
-    BOOST_REQUIRE_NO_THROW( importer->load(test_file, config, registry) );
+    BOOST_REQUIRE_NO_THROW(importer->load(test_file, config, registry));
 }
 
-struct AssertValueVisit : public ValueVisitor
-{
+struct AssertValueVisit : public ValueVisitor {
     vector<int32_t> values;
-    bool visit_(int32_t& v)
-    {
+    bool visit_(int32_t &v) {
         values.push_back(v);
         return true;
     }
 };
 
-BOOST_AUTO_TEST_CASE( test_vector_defines_aliases )
-{
+BOOST_AUTO_TEST_CASE(test_vector_defines_aliases) {
     Registry registry;
     import_test_types(registry);
     registry.alias("/B", "/BAlias");
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("B"));
+    Container const &container =
+        Container::createContainer(registry, "/std/vector", *registry.get("B"));
 
-    Type const* aliased = registry.get("/std/vector</BAlias>");
+    Type const *aliased = registry.get("/std/vector</BAlias>");
     BOOST_REQUIRE(aliased);
     BOOST_REQUIRE(*aliased == container);
 }
 
-BOOST_AUTO_TEST_CASE( test_vector_getElementCount )
-{
+BOOST_AUTO_TEST_CASE(test_vector_getElementCount) {
     Registry registry;
     import_test_types(registry);
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("B"));
+    Container const &container =
+        Container::createContainer(registry, "/std/vector", *registry.get("B"));
 
     std::vector<B> vector;
     vector.resize(10);
     BOOST_REQUIRE_EQUAL(10, container.getElementCount(&vector));
 }
 
-BOOST_AUTO_TEST_CASE( test_vector_init_destroy )
-{
+BOOST_AUTO_TEST_CASE(test_vector_init_destroy) {
     Registry registry;
     import_test_types(registry);
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("B"));
+    Container const &container =
+        Container::createContainer(registry, "/std/vector", *registry.get("B"));
     BOOST_REQUIRE_EQUAL(Type::Container, container.getCategory());
 
-    void* v_memory = malloc(sizeof(std::vector<B>));
+    void *v_memory = malloc(sizeof(std::vector<B>));
     container.init(v_memory);
     BOOST_REQUIRE_EQUAL(0, container.getElementCount(v_memory));
     container.destroy(v_memory);
     free(v_memory);
 }
 
-BOOST_AUTO_TEST_CASE( test_vector_push )
-{
+BOOST_AUTO_TEST_CASE(test_vector_push) {
     Registry registry;
     import_test_types(registry);
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("int"));
+    Container const &container = Container::createContainer(
+        registry, "/std/vector", *registry.get("int"));
 
     std::vector<int> vector;
-    for (int value = 0; value < 10; ++value)
-    {
+    for (int value = 0; value < 10; ++value) {
         container.push(&vector, Value(&value, container.getIndirection()));
         BOOST_REQUIRE_EQUAL(value + 1, vector.size());
 
@@ -135,20 +132,22 @@ BOOST_AUTO_TEST_CASE( test_vector_push )
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_vector_erase )
-{
+BOOST_AUTO_TEST_CASE(test_vector_erase) {
     Registry registry;
     import_test_types(registry);
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("int"));
+    Container const &container = Container::createContainer(
+        registry, "/std/vector", *registry.get("int"));
 
     std::vector<int> vector;
     for (int value = 0; value < 10; ++value)
         vector.push_back(value);
 
     int value = 20;
-    BOOST_REQUIRE(!container.erase(&vector, Value(&value, container.getIndirection())));
+    BOOST_REQUIRE(
+        !container.erase(&vector, Value(&value, container.getIndirection())));
     value = 5;
-    BOOST_REQUIRE(container.erase(&vector, Value(&value, container.getIndirection())));
+    BOOST_REQUIRE(
+        container.erase(&vector, Value(&value, container.getIndirection())));
 
     BOOST_REQUIRE_EQUAL(9, vector.size());
     for (int i = 0; i < 5; ++i)
@@ -157,16 +156,15 @@ BOOST_AUTO_TEST_CASE( test_vector_erase )
         BOOST_REQUIRE_EQUAL(i + 1, vector[i]);
 }
 
-bool test_delete_if_pred(Value v)
-{
-    int* value = reinterpret_cast<int*>(v.getData());
+bool test_delete_if_pred(Value v) {
+    int *value = reinterpret_cast<int *>(v.getData());
     return (*value > 3) && (*value < 6);
 }
-BOOST_AUTO_TEST_CASE( test_vector_delete_if )
-{
+BOOST_AUTO_TEST_CASE(test_vector_delete_if) {
     Registry registry;
     import_test_types(registry);
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("int"));
+    Container const &container = Container::createContainer(
+        registry, "/std/vector", *registry.get("int"));
 
     std::vector<int> vector;
     for (int value = 0; value < 10; ++value)
@@ -181,12 +179,12 @@ BOOST_AUTO_TEST_CASE( test_vector_delete_if )
         BOOST_REQUIRE_EQUAL(i + 2, vector[i]);
 }
 
-BOOST_AUTO_TEST_CASE( test_vector_getElement )
-{ 
+BOOST_AUTO_TEST_CASE(test_vector_getElement) {
     Registry registry;
     import_test_types(registry);
 
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("int32_t"));
+    Container const &container = Container::createContainer(
+        registry, "/std/vector", *registry.get("int32_t"));
 
     std::vector<int32_t> v;
     v.resize(10);
@@ -194,32 +192,34 @@ BOOST_AUTO_TEST_CASE( test_vector_getElement )
         v[i] = i;
 
     for (int i = 0; i < 10; ++i)
-        BOOST_REQUIRE_EQUAL(i, *reinterpret_cast<int*>(container.getElement(&v, i).getData()));
+        BOOST_REQUIRE_EQUAL(
+            i, *reinterpret_cast<int *>(container.getElement(&v, i).getData()));
 }
 
-BOOST_AUTO_TEST_CASE( test_vector_setElement )
-{ 
+BOOST_AUTO_TEST_CASE(test_vector_setElement) {
     Registry registry;
     import_test_types(registry);
 
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("int32_t"));
+    Container const &container = Container::createContainer(
+        registry, "/std/vector", *registry.get("int32_t"));
 
     std::vector<int32_t> v;
     v.resize(10);
 
     for (int i = 0; i < 10; ++i)
-        container.setElement(&v, i, Typelib::Value(&i, container.getIndirection()));
+        container.setElement(&v, i,
+                             Typelib::Value(&i, container.getIndirection()));
 
     for (int i = 0; i < 10; ++i)
         BOOST_REQUIRE_EQUAL(i, v[i]);
 }
 
-BOOST_AUTO_TEST_CASE( test_vector_visit )
-{ 
+BOOST_AUTO_TEST_CASE(test_vector_visit) {
     Registry registry;
     import_test_types(registry);
 
-    Container const& container = Container::createContainer(registry, "/std/vector", *registry.get("int32_t"));
+    Container const &container = Container::createContainer(
+        registry, "/std/vector", *registry.get("int32_t"));
 
     std::vector<int32_t> v;
     v.resize(10);
@@ -237,17 +237,17 @@ BOOST_AUTO_TEST_CASE( test_vector_visit )
         BOOST_REQUIRE_EQUAL(i, visitor.values[i]);
 }
 
-BOOST_AUTO_TEST_CASE( test_erase_collection_of_collections )
-{
+BOOST_AUTO_TEST_CASE(test_erase_collection_of_collections) {
     Registry registry;
     import_test_types(registry);
-    Container const& inside = Container::createContainer(registry, "/std/vector", *registry.get("int32_t"));
-    Container const& container = Container::createContainer(registry, "/std/vector", inside);
+    Container const &inside = Container::createContainer(
+        registry, "/std/vector", *registry.get("int32_t"));
+    Container const &container =
+        Container::createContainer(registry, "/std/vector", inside);
 
-    std::vector< std::vector<int32_t> > v;
+    std::vector<std::vector<int32_t> > v;
     v.resize(10);
-    for (int i = 0; i < 10; ++i)
-    {
+    for (int i = 0; i < 10; ++i) {
         v[i].resize(10);
         for (int j = 0; j < 10; ++j)
             v[i][j] = i * 100 + j;
@@ -260,40 +260,38 @@ BOOST_AUTO_TEST_CASE( test_erase_collection_of_collections )
 
     BOOST_REQUIRE_EQUAL(10, v.size());
 
-    for (int i = 0; i < 10; ++i)
-    {
+    for (int i = 0; i < 10; ++i) {
         BOOST_REQUIRE_EQUAL(10, v[i].size());
         for (int j = 0; j < 10; ++j)
             BOOST_REQUIRE_EQUAL(i * 100 + j, v[i][j]);
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_copy_collection_of_collections )
-{
+BOOST_AUTO_TEST_CASE(test_copy_collection_of_collections) {
     Registry registry;
     import_test_types(registry);
-    Container const& inside = Container::createContainer(registry, "/std/vector", *registry.get("int32_t"));
-    Container const& container = Container::createContainer(registry, "/std/vector", inside);
+    Container const &inside = Container::createContainer(
+        registry, "/std/vector", *registry.get("int32_t"));
+    Container const &container =
+        Container::createContainer(registry, "/std/vector", inside);
 
-    std::vector< std::vector<int32_t> > v;
+    std::vector<std::vector<int32_t> > v;
     v.resize(10);
-    for (int i = 0; i < 10; ++i)
-    {
+    for (int i = 0; i < 10; ++i) {
         v[i].resize(10);
         for (int j = 0; j < 10; ++j)
             v[i][j] = i * 100 + j;
     }
 
-    std::vector< std::vector<int32_t> > copy;
+    std::vector<std::vector<int32_t> > copy;
     Typelib::copy(Value(&copy, container), Value(&v, container));
 
-    for (int i = 0; i < 10; ++i)
-    {
+    for (int i = 0; i < 10; ++i) {
         BOOST_REQUIRE_EQUAL(10, v[i].size());
         for (int j = 0; j < 10; ++j)
             BOOST_REQUIRE_EQUAL(i * 100 + j, v[i][j]);
     }
 
-    BOOST_REQUIRE( Typelib::compare(Value(&copy, container), Value(&v, container)) );
+    BOOST_REQUIRE(
+        Typelib::compare(Value(&copy, container), Value(&v, container)));
 }
-

--- a/test/test_display.cc
+++ b/test/test_display.cc
@@ -14,36 +14,37 @@ using namespace std;
 
 #include "test_cimport.1"
 
-
-BOOST_AUTO_TEST_CASE(test_csv)
-{
+BOOST_AUTO_TEST_CASE(test_csv) {
     {
-	Registry registry;
+        Registry registry;
         Typelib::CXX::addStandardTypes(registry);
 
-	float    f32  = 0.52;
-	Type const& type = *registry.get("float");
-	
-	ostringstream stream;
-	stream << csv_header(type, "base");
-	BOOST_CHECK_EQUAL("base", stream.str());
+        float f32 = 0.52;
+        Type const &type = *registry.get("float");
 
-	stream.str("");
-	stream << csv(type, &f32);
-	BOOST_CHECK_CLOSE(0.52f, boost::lexical_cast<float>(stream.str()), 0.00001);
+        ostringstream stream;
+        stream << csv_header(type, "base");
+        BOOST_CHECK_EQUAL("base", stream.str());
+
+        stream.str("");
+        stream << csv(type, &f32);
+        BOOST_CHECK_CLOSE(0.52f, boost::lexical_cast<float>(stream.str()),
+                          0.00001);
     }
-    
-    {
-	// Get the test file into repository
-	utilmm::config_set config;
-	auto_ptr<Registry> registry(PluginManager::self()->load("tlb", TEST_DATA_PATH("test_cimport.tlb"), config));
 
-	{
-	    ostringstream stream;
-	    Type const& display_type = *registry->get("/DisplayTest");
-	    stream << csv_header(display_type, "t");
-	    BOOST_CHECK_EQUAL("t.fields[0] t.fields[1] t.fields[2] t.fields[3] t.f t.d t.a.a t.a.b t.a.c t.a.d t.mode", stream.str());
-	}
+    {
+        // Get the test file into repository
+        utilmm::config_set config;
+        auto_ptr<Registry> registry(PluginManager::self()->load(
+            "tlb", TEST_DATA_PATH("test_cimport.tlb"), config));
+
+        {
+            ostringstream stream;
+            Type const &display_type = *registry->get("/DisplayTest");
+            stream << csv_header(display_type, "t");
+            BOOST_CHECK_EQUAL("t.fields[0] t.fields[1] t.fields[2] t.fields[3] "
+                              "t.f t.d t.a.a t.a.b t.a.c t.a.d t.mode",
+                              stream.str());
+        }
     }
 }
-

--- a/test/test_lang_tlb.cc
+++ b/test/test_lang_tlb.cc
@@ -17,12 +17,11 @@ using namespace Typelib;
 using namespace std;
 
 #ifdef HAS_INTERNAL_CPARSER
-BOOST_AUTO_TEST_CASE( test_tlb_rejects_recursive_types )
-{
+BOOST_AUTO_TEST_CASE(test_tlb_rejects_recursive_types) {
     PluginManager::self manager;
     Registry registry;
 
-    static const char* test_file = TEST_DATA_PATH("test_cimport.1");
+    static const char *test_file = TEST_DATA_PATH("test_cimport.1");
     utilmm::config_set config;
     manager->load("c", test_file, config, registry);
 
@@ -30,12 +29,11 @@ BOOST_AUTO_TEST_CASE( test_tlb_rejects_recursive_types )
 }
 #endif
 
-BOOST_AUTO_TEST_CASE( test_tlb_idempotent )
-{
+BOOST_AUTO_TEST_CASE(test_tlb_idempotent) {
     PluginManager::self manager;
     Registry registry;
 
-    static const char* test_file = TEST_DATA_PATH("test_cimport.tlb");
+    static const char *test_file = TEST_DATA_PATH("test_cimport.tlb");
     {
         utilmm::config_set config;
         manager->load("tlb", test_file, config, registry);
@@ -45,20 +43,18 @@ BOOST_AUTO_TEST_CASE( test_tlb_idempotent )
     result = manager->save("tlb", registry);
     istringstream io(result);
     utilmm::config_set config;
-    Registry* reloaded = NULL;
+    Registry *reloaded = NULL;
     reloaded = manager->load("tlb", io, config);
 
-    if (!registry.isSame(*reloaded))
-    {
-        RegistryIterator it = registry.begin(),
-                         end = registry.end();
-        for (; it != end; ++it)
-        {
+    if (!registry.isSame(*reloaded)) {
+        RegistryIterator it = registry.begin(), end = registry.end();
+        for (; it != end; ++it) {
             if (!reloaded->has(it->getName(), true))
-                std::cerr << "reloaded does not have " << it->getName() << std::endl;
-            else if (!(*it).isSame(*reloaded->build(it->getName())))
-            {
-                std::cerr << "versions of " << it->getName() << " differ" << std::endl;
+                std::cerr << "reloaded does not have " << it->getName()
+                          << std::endl;
+            else if (!(*it).isSame(*reloaded->build(it->getName()))) {
+                std::cerr << "versions of " << it->getName() << " differ"
+                          << std::endl;
                 std::cerr << *it << std::endl << std::endl;
                 std::cerr << *reloaded->get(it->getName()) << std::endl;
             }
@@ -66,41 +62,43 @@ BOOST_AUTO_TEST_CASE( test_tlb_idempotent )
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_tlb_import )
-{
+BOOST_AUTO_TEST_CASE(test_tlb_import) {
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
 
     {
-	string empty_tlb = "<?xml version=\"1.0\"?>\n<typelib>\n</typelib>";
-	istringstream stream(empty_tlb);
-	Registry registry;
-	importer->load(stream, config, registry);
+        string empty_tlb = "<?xml version=\"1.0\"?>\n<typelib>\n</typelib>";
+        istringstream stream(empty_tlb);
+        Registry registry;
+        importer->load(stream, config, registry);
     }
 
     {
-	string invalid_element_type = "<?xml version=\"1.0\"?>\n<typelib>\n<invalid_thing name=\"fake\"/></typelib>";
-	istringstream stream(invalid_element_type);
-	Registry registry;
-	BOOST_CHECK_THROW(importer->load(stream, config, registry), std::runtime_error);
+        string invalid_element_type = "<?xml "
+                                      "version=\"1.0\"?>\n<typelib>\n<invalid_"
+                                      "thing name=\"fake\"/></typelib>";
+        istringstream stream(invalid_element_type);
+        Registry registry;
+        BOOST_CHECK_THROW(importer->load(stream, config, registry),
+                          std::runtime_error);
     }
     {
-	string missing_arg = "<?xml version=\"1.0\"?>\n<typelib>\n<invalid_thing /></typelib>";
-	istringstream stream(missing_arg);
-	Registry registry;
-	BOOST_CHECK_THROW(importer->load(stream, config, registry), std::runtime_error);
+        string missing_arg =
+            "<?xml version=\"1.0\"?>\n<typelib>\n<invalid_thing /></typelib>";
+        istringstream stream(missing_arg);
+        Registry registry;
+        BOOST_CHECK_THROW(importer->load(stream, config, registry),
+                          std::runtime_error);
     }
 
-
-    { 
-	ifstream file(TEST_DATA_PATH("rflex.tlb"));
-	Registry registry;
+    {
+        ifstream file(TEST_DATA_PATH("rflex.tlb"));
+        Registry registry;
         Typelib::CXX::addStandardTypes(registry);
-	importer->load(file, config, registry);
+        importer->load(file, config, registry);
 
-	BOOST_CHECK( registry.get("/custom_null") );
-	BOOST_CHECK( registry.get("/custom_null")->isNull() );
+        BOOST_CHECK(registry.get("/custom_null"));
+        BOOST_CHECK(registry.get("/custom_null")->isNull());
     }
 }
-

--- a/test/test_marshalling.cc
+++ b/test/test_marshalling.cc
@@ -15,18 +15,18 @@
 using namespace Typelib;
 using namespace std;
 
-BOOST_AUTO_TEST_CASE( test_marshalling_simple )
-{
+BOOST_AUTO_TEST_CASE(test_marshalling_simple) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
     /* Check a simple structure which translates into MEMCPY */
     {
-        Type const& type = *registry.get("/A");
+        Type const &type = *registry.get("/A");
         A a;
         memset(&a, 1, sizeof(A));
         a.a = 10000;
@@ -36,24 +36,30 @@ BOOST_AUTO_TEST_CASE( test_marshalling_simple )
         vector<uint8_t> buffer = dump(Value(&a, type));
 
         size_t expected_dump_size = offsetof(A, d) + sizeof(a.d);
-        BOOST_REQUIRE_EQUAL( buffer.size(), expected_dump_size);
-        BOOST_REQUIRE( !memcmp(&buffer[0], &a, expected_dump_size) );
+        BOOST_REQUIRE_EQUAL(buffer.size(), expected_dump_size);
+        BOOST_REQUIRE(!memcmp(&buffer[0], &a, expected_dump_size));
 
         A reloaded;
         load(Value(&reloaded, type), buffer);
-        BOOST_REQUIRE( !memcmp(&reloaded, &a, expected_dump_size) );
+        BOOST_REQUIRE(!memcmp(&reloaded, &a, expected_dump_size));
 
         // Try (in order)
         //  - smaller type
         //  - bigger type
         //  - bigger buffer
         //  - smaller buffer
-        BOOST_REQUIRE_THROW(load(Value(&reloaded, *registry.build("/int[200]")), buffer), std::runtime_error);
-        BOOST_REQUIRE_THROW(load(Value(&reloaded, *registry.get("/int")), buffer), std::runtime_error);
+        BOOST_REQUIRE_THROW(
+            load(Value(&reloaded, *registry.build("/int[200]")), buffer),
+            std::runtime_error);
+        BOOST_REQUIRE_THROW(
+            load(Value(&reloaded, *registry.get("/int")), buffer),
+            std::runtime_error);
         buffer.resize(buffer.size() + 2);
-        BOOST_REQUIRE_THROW(load(Value(&reloaded, type), buffer), std::runtime_error);
+        BOOST_REQUIRE_THROW(load(Value(&reloaded, type), buffer),
+                            std::runtime_error);
         buffer.resize(buffer.size() - 4);
-        BOOST_REQUIRE_THROW(load(Value(&reloaded, type), buffer), std::runtime_error);
+        BOOST_REQUIRE_THROW(load(Value(&reloaded, type), buffer),
+                            std::runtime_error);
     }
 
     /* Now, insert SKIPS into it */
@@ -62,21 +68,19 @@ BOOST_AUTO_TEST_CASE( test_marshalling_simple )
         size_t align1 = offsetof(A, b) - sizeof(a.a);
         size_t align2 = offsetof(A, c) - sizeof(a.b) - offsetof(A, b);
         size_t align3 = offsetof(A, d) - sizeof(a.c) - offsetof(A, c);
-        size_t align4 = sizeof(A)      - sizeof(a.d) - offsetof(A, d);
-        size_t raw_ops[] = {
-            MemLayout::FLAG_MEMCPY, sizeof(long long),
-            MemLayout::FLAG_SKIP, align1,
-            MemLayout::FLAG_MEMCPY, sizeof(int),
-            MemLayout::FLAG_SKIP, align2,
-            MemLayout::FLAG_MEMCPY, sizeof(char),
-            MemLayout::FLAG_SKIP, align3,
-            MemLayout::FLAG_MEMCPY, sizeof(short)
-        };
+        size_t align4 = sizeof(A) - sizeof(a.d) - offsetof(A, d);
+        size_t raw_ops[] = {MemLayout::FLAG_MEMCPY, sizeof(long long),
+                            MemLayout::FLAG_SKIP,   align1,
+                            MemLayout::FLAG_MEMCPY, sizeof(int),
+                            MemLayout::FLAG_SKIP,   align2,
+                            MemLayout::FLAG_MEMCPY, sizeof(char),
+                            MemLayout::FLAG_SKIP,   align3,
+                            MemLayout::FLAG_MEMCPY, sizeof(short)};
 
         MemoryLayout ops;
         ops.insert(ops.end(), raw_ops, raw_ops + 14);
 
-        Type const& type = *registry.get("/A");
+        Type const &type = *registry.get("/A");
         memset(&a, 1, sizeof(A));
         a.a = 10000;
         a.b = 1000;
@@ -84,8 +88,9 @@ BOOST_AUTO_TEST_CASE( test_marshalling_simple )
         a.d = 10;
         vector<uint8_t> buffer;
         dump(Value(&a, type), buffer, ops);
-        BOOST_REQUIRE_EQUAL( sizeof(A) - align1 - align2 - align3 - align4, buffer.size());
-        BOOST_REQUIRE_EQUAL( *reinterpret_cast<long long*>(&buffer[0]), a.a );
+        BOOST_REQUIRE_EQUAL(sizeof(A) - align1 - align2 - align3 - align4,
+                            buffer.size());
+        BOOST_REQUIRE_EQUAL(*reinterpret_cast<long long *>(&buffer[0]), a.a);
 
         A reloaded;
         memset(&reloaded, 2, sizeof(A));
@@ -101,23 +106,21 @@ BOOST_AUTO_TEST_CASE( test_marshalling_simple )
     {
         B b;
         for (unsigned int i = 0; i < sizeof(b); ++i)
-            reinterpret_cast<uint8_t*>(&b)[i] = rand();
+            reinterpret_cast<uint8_t *>(&b)[i] = rand();
 
-        size_t raw_ops[] = {
-            MemLayout::FLAG_MEMCPY, offsetof(B, c),
-            MemLayout::FLAG_ARRAY, 100,
-                MemLayout::FLAG_MEMCPY, sizeof(b.c[0]),
-            MemLayout::FLAG_END,
-            MemLayout::FLAG_MEMCPY, sizeof(B) - offsetof(B, d)
-        };
+        size_t raw_ops[] = {MemLayout::FLAG_MEMCPY,    offsetof(B, c),
+                            MemLayout::FLAG_ARRAY,     100,
+                            MemLayout::FLAG_MEMCPY,    sizeof(b.c[0]),
+                            MemLayout::FLAG_END,       MemLayout::FLAG_MEMCPY,
+                            sizeof(B) - offsetof(B, d)};
 
         MemoryLayout ops;
         ops.insert(ops.end(), raw_ops, raw_ops + 9);
 
-        Type const& type = *registry.get("/B");
+        Type const &type = *registry.get("/B");
         vector<uint8_t> buffer;
         dump(Value(&b, type), buffer, ops);
-        BOOST_REQUIRE_EQUAL( sizeof(B), buffer.size());
+        BOOST_REQUIRE_EQUAL(sizeof(B), buffer.size());
         BOOST_REQUIRE(!memcmp(&buffer[0], &b, sizeof(B)));
 
         B reloaded;
@@ -126,38 +129,42 @@ BOOST_AUTO_TEST_CASE( test_marshalling_simple )
     }
 }
 
-template<typename T>
-size_t CHECK_SIMPLE_VALUE(vector<uint8_t> const& buffer, size_t offset, T value)
-{
-    BOOST_REQUIRE_EQUAL(value, *reinterpret_cast<T const*>(&buffer[offset]));
+template <typename T>
+size_t CHECK_SIMPLE_VALUE(vector<uint8_t> const &buffer, size_t offset,
+                          T value) {
+    BOOST_REQUIRE_EQUAL(value, *reinterpret_cast<T const *>(&buffer[offset]));
     return offset + sizeof(T);
 }
 
-template<typename T>
-size_t CHECK_VECTOR_VALUE(vector<uint8_t> const& buffer, size_t offset, vector<T> const& value)
-{
+template <typename T>
+size_t CHECK_VECTOR_VALUE(vector<uint8_t> const &buffer, size_t offset,
+                          vector<T> const &value) {
     // First, check for the size
-    offset = CHECK_SIMPLE_VALUE(buffer, offset, static_cast<uint64_t>(value.size()));
+    offset =
+        CHECK_SIMPLE_VALUE(buffer, offset, static_cast<uint64_t>(value.size()));
     // Then for the elements
     for (size_t i = 0; i < value.size(); ++i)
         offset = CHECK_SIMPLE_VALUE(buffer, offset, value[i]);
     return offset;
 }
 
-BOOST_AUTO_TEST_CASE(test_marshalapply_containers)
-{
+BOOST_AUTO_TEST_CASE(test_marshalapply_containers) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
     StdCollections offset_discovery;
-    uint8_t* base_ptr     = reinterpret_cast<uint8_t*>(&offset_discovery);
-    size_t off_dbl_vector = reinterpret_cast<uint8_t*>(&offset_discovery.dbl_vector) - base_ptr;
-    size_t off_v8         = reinterpret_cast<uint8_t*>(&offset_discovery.v8) - base_ptr;
-    size_t off_v_of_v     = reinterpret_cast<uint8_t*>(&offset_discovery.v_of_v) - base_ptr;
+    uint8_t *base_ptr = reinterpret_cast<uint8_t *>(&offset_discovery);
+    size_t off_dbl_vector =
+        reinterpret_cast<uint8_t *>(&offset_discovery.dbl_vector) - base_ptr;
+    size_t off_v8 =
+        reinterpret_cast<uint8_t *>(&offset_discovery.v8) - base_ptr;
+    size_t off_v_of_v =
+        reinterpret_cast<uint8_t *>(&offset_discovery.v_of_v) - base_ptr;
 
     {
         StdCollections data;
@@ -165,10 +172,9 @@ BOOST_AUTO_TEST_CASE(test_marshalapply_containers)
         data.dbl_vector.resize(5);
         for (int i = 0; i < 5; ++i)
             data.dbl_vector[i] = 0.01 * i;
-        data.v8  = -106;
+        data.v8 = -106;
         data.v_of_v.resize(5);
-        for (int i = 0; i < 5; ++i)
-        {
+        for (int i = 0; i < 5; ++i) {
             data.v_of_v[i].resize(3);
             for (int j = 0; j < 3; ++j)
                 data.v_of_v[i][j] = i * 10 + j;
@@ -176,79 +182,89 @@ BOOST_AUTO_TEST_CASE(test_marshalapply_containers)
         data.v16 = 5235;
         data.v64 = 5230971546LL;
 
-        Type const& type       = *registry.get("/StdCollections");
+        Type const &type = *registry.get("/StdCollections");
         vector<uint8_t> buffer = dump(Value(&data, type));
 
-        size_t size_without_trailing_padding = 
-            reinterpret_cast<uint8_t const*>(&data.padding) + sizeof(data.padding) - reinterpret_cast<uint8_t const*>(&data)
-                - sizeof(std::vector<double>) - sizeof (std::vector< std::vector<double> >)
-                + sizeof(double) * 20 // elements
-                + 7 * sizeof(uint64_t);
+        size_t size_without_trailing_padding =
+            reinterpret_cast<uint8_t const *>(&data.padding) +
+            sizeof(data.padding) - reinterpret_cast<uint8_t const *>(&data) -
+            sizeof(std::vector<double>) -
+            sizeof(std::vector<std::vector<double> >) +
+            sizeof(double) * 20 // elements
+            + 7 * sizeof(uint64_t);
 
-        BOOST_REQUIRE_EQUAL( buffer.size(), size_without_trailing_padding );
+        BOOST_REQUIRE_EQUAL(buffer.size(), size_without_trailing_padding);
 
         CHECK_SIMPLE_VALUE(buffer, 0, data.iv);
-        size_t pos = CHECK_VECTOR_VALUE(buffer, off_dbl_vector, data.dbl_vector);
+        size_t pos =
+            CHECK_VECTOR_VALUE(buffer, off_dbl_vector, data.dbl_vector);
         CHECK_SIMPLE_VALUE(buffer, pos, data.v8);
 
-        pos = CHECK_SIMPLE_VALUE(buffer, pos + off_v_of_v - off_v8, static_cast<uint64_t>(data.v_of_v.size()));
+        pos = CHECK_SIMPLE_VALUE(buffer, pos + off_v_of_v - off_v8,
+                                 static_cast<uint64_t>(data.v_of_v.size()));
         for (int i = 0; i < 5; ++i)
             pos = CHECK_VECTOR_VALUE(buffer, pos, data.v_of_v[i]);
 
         StdCollections reloaded;
         load(Value(&reloaded, type), buffer);
-        BOOST_REQUIRE( data.iv         == reloaded.iv );
-        BOOST_REQUIRE( data.dbl_vector == reloaded.dbl_vector );
-        BOOST_REQUIRE( data.v8         == reloaded.v8 );
-        BOOST_REQUIRE( data.v16        == reloaded.v16 );
-        BOOST_REQUIRE( data.v64        == reloaded.v64 );
-        BOOST_REQUIRE( data.padding        == reloaded.padding );
+        BOOST_REQUIRE(data.iv == reloaded.iv);
+        BOOST_REQUIRE(data.dbl_vector == reloaded.dbl_vector);
+        BOOST_REQUIRE(data.v8 == reloaded.v8);
+        BOOST_REQUIRE(data.v16 == reloaded.v16);
+        BOOST_REQUIRE(data.v64 == reloaded.v64);
+        BOOST_REQUIRE(data.padding == reloaded.padding);
 
         // Now, add the trailing bytes back. The load method should be OK with
         // it
         size_t size_with_trailing_padding =
-            sizeof(StdCollections)
-                - sizeof(std::vector<double>) - sizeof (std::vector< std::vector<double> >)
-                + sizeof(double) * 20 // elements
-                + 7 * sizeof(uint64_t); // element counts
+            sizeof(StdCollections) - sizeof(std::vector<double>) -
+            sizeof(std::vector<std::vector<double> >) +
+            sizeof(double) * 20     // elements
+            + 7 * sizeof(uint64_t); // element counts
 
-        buffer.insert(buffer.end(), size_with_trailing_padding - size_without_trailing_padding, 0);
+        buffer.insert(buffer.end(), size_with_trailing_padding -
+                                        size_without_trailing_padding,
+                      0);
         {
             StdCollections reloaded;
             load(Value(&reloaded, type), buffer);
-            BOOST_REQUIRE( data.iv         == reloaded.iv );
-            BOOST_REQUIRE( data.dbl_vector == reloaded.dbl_vector );
-            BOOST_REQUIRE( data.v8         == reloaded.v8 );
-            BOOST_REQUIRE( data.v16        == reloaded.v16 );
-            BOOST_REQUIRE( data.v64        == reloaded.v64 );
-            BOOST_REQUIRE( data.padding        == reloaded.padding );
+            BOOST_REQUIRE(data.iv == reloaded.iv);
+            BOOST_REQUIRE(data.dbl_vector == reloaded.dbl_vector);
+            BOOST_REQUIRE(data.v8 == reloaded.v8);
+            BOOST_REQUIRE(data.v16 == reloaded.v16);
+            BOOST_REQUIRE(data.v64 == reloaded.v64);
+            BOOST_REQUIRE(data.padding == reloaded.padding);
         }
     }
 
     {
         StdCollections data;
-        
+
         data.iv = 0;
         data.v8 = 1;
         data.v_of_v.resize(5);
         data.v16 = 2;
         data.v64 = 3;
 
-        Type const& type       = *registry.get("/StdCollections");
+        Type const &type = *registry.get("/StdCollections");
         vector<uint8_t> buffer = dump(Value(&data, type));
-        size_t size_without_trailing_padding = 
-            reinterpret_cast<uint8_t const*>(&data.padding) + sizeof(data.padding) - reinterpret_cast<uint8_t const*>(&data);
-        BOOST_REQUIRE_EQUAL( buffer.size(),
-                size_without_trailing_padding - sizeof(std::vector<double>) - sizeof (std::vector< std::vector<double> >)
-                + 7 * sizeof(uint64_t)); // element counts
+        size_t size_without_trailing_padding =
+            reinterpret_cast<uint8_t const *>(&data.padding) +
+            sizeof(data.padding) - reinterpret_cast<uint8_t const *>(&data);
+        BOOST_REQUIRE_EQUAL(buffer.size(),
+                            size_without_trailing_padding -
+                                sizeof(std::vector<double>) -
+                                sizeof(std::vector<std::vector<double> >) +
+                                7 * sizeof(uint64_t)); // element counts
 
         CHECK_SIMPLE_VALUE(buffer, 0, data.iv);
-        size_t pos = CHECK_VECTOR_VALUE(buffer, off_dbl_vector, data.dbl_vector);
+        size_t pos =
+            CHECK_VECTOR_VALUE(buffer, off_dbl_vector, data.dbl_vector);
         CHECK_SIMPLE_VALUE(buffer, pos, data.v8);
 
-        pos = CHECK_SIMPLE_VALUE(buffer, pos + off_v_of_v - off_v8, static_cast<uint64_t>(data.v_of_v.size()));
+        pos = CHECK_SIMPLE_VALUE(buffer, pos + off_v_of_v - off_v8,
+                                 static_cast<uint64_t>(data.v_of_v.size()));
         for (int i = 0; i < 5; ++i)
             pos = CHECK_VECTOR_VALUE(buffer, pos, data.v_of_v[i]);
     }
 }
-

--- a/test/test_memory_layout.cc
+++ b/test/test_memory_layout.cc
@@ -9,7 +9,6 @@
 #include <typelib/value.hh>
 #include <typelib/memory_layout.hh>
 
-
 #include <typelib/value_ops.hh>
 #include <test/test_cimport.1>
 #include <string.h>
@@ -17,18 +16,18 @@
 using namespace Typelib;
 using namespace std;
 
-BOOST_AUTO_TEST_CASE( test_layout_simple )
-{
+BOOST_AUTO_TEST_CASE(test_layout_simple) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
     /* Check a simple structure with alignment issues */
     {
-        Type const& type = *registry.get("/A");
+        Type const &type = *registry.get("/A");
         MemoryLayout ops = Typelib::layout_of(type);
 
         BOOST_REQUIRE_EQUAL(2U, ops.size());
@@ -39,7 +38,7 @@ BOOST_AUTO_TEST_CASE( test_layout_simple )
 
     /* Check handling of simple arrays */
     {
-        Type const& type = *registry.build("/char[100]");
+        Type const &type = *registry.build("/char[100]");
         MemoryLayout ops = Typelib::layout_of(type);
 
         BOOST_REQUIRE_EQUAL(2U, ops.size());
@@ -49,7 +48,7 @@ BOOST_AUTO_TEST_CASE( test_layout_simple )
 
     /* Check a structure with arrays */
     {
-        Type const& type = *registry.get("/B");
+        Type const &type = *registry.get("/B");
         MemoryLayout ops = Typelib::layout_of(type);
 
         BOOST_REQUIRE_EQUAL(2U, ops.size());
@@ -60,7 +59,7 @@ BOOST_AUTO_TEST_CASE( test_layout_simple )
 
     /* Check a multidimensional array */
     {
-        Type const& type = *registry.get("TestMultiDimArray");
+        Type const &type = *registry.get("TestMultiDimArray");
         MemoryLayout ops = Typelib::layout_of(type);
 
         BOOST_REQUIRE_EQUAL(2U, ops.size());
@@ -71,7 +70,7 @@ BOOST_AUTO_TEST_CASE( test_layout_simple )
     // Check a structure with pointer. Must throw by default, but accept if the
     // accept_pointers flag is set, in which case FLAG_MEMCPY is used for it.
     {
-        Type const& type = *registry.get("/C");
+        Type const &type = *registry.get("/C");
         BOOST_CHECK_THROW(Typelib::layout_of(type), Typelib::NoLayout);
 
         MemoryLayout ops = Typelib::layout_of(type, true);
@@ -80,7 +79,7 @@ BOOST_AUTO_TEST_CASE( test_layout_simple )
         C data;
         BOOST_REQUIRE_EQUAL(offsetof(C, z) + sizeof(data.z), ops[1]);
     }
- 
+
     // Check an opaque type
     {
         OpaqueType type("test_opaque", 10);
@@ -88,22 +87,25 @@ BOOST_AUTO_TEST_CASE( test_layout_simple )
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_layout_arrays)
-{
+BOOST_AUTO_TEST_CASE(test_layout_arrays) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
     {
-        Type const& type      = *registry.get("/Arrays");
-        Compound const& str       = static_cast<Compound const&>(*registry.get("/NS1/Test"));
-        BOOST_REQUIRE(str.getSize() != str.getField("b")->getOffset() + str.getField("b")->getType().getSize());
+        Type const &type = *registry.get("/Arrays");
+        Compound const &str =
+            static_cast<Compound const &>(*registry.get("/NS1/Test"));
+        BOOST_REQUIRE(str.getSize() !=
+                      str.getField("b")->getOffset() +
+                          str.getField("b")->getType().getSize());
 
-        Type const& v_str   = *registry.get("/std/vector</NS1/Test>");
-        Type const& v_double  = *registry.get("/std/vector</double>");
+        Type const &v_str = *registry.get("/std/vector</NS1/Test>");
+        Type const &v_double = *registry.get("/std/vector</double>");
         MemoryLayout ops = Typelib::layout_of(type);
 
         StdCollections test;
@@ -111,32 +113,21 @@ BOOST_AUTO_TEST_CASE(test_layout_arrays)
         Arrays arrays_v;
         size_t expected[] = {
             MemLayout::FLAG_MEMCPY,
-               reinterpret_cast<uint8_t*>(&arrays_v.a_v_numeric) - reinterpret_cast<uint8_t*>(&arrays_v),
-            MemLayout::FLAG_ARRAY,
-                10,
-                MemLayout::FLAG_CONTAINER,
-                    reinterpret_cast<size_t>(&v_double),
-                    MemLayout::FLAG_MEMCPY,
-                    sizeof(double),
-                MemLayout::FLAG_END,
-            MemLayout::FLAG_END,
+            reinterpret_cast<uint8_t *>(&arrays_v.a_v_numeric) -
+                reinterpret_cast<uint8_t *>(&arrays_v),
+            MemLayout::FLAG_ARRAY, 10, MemLayout::FLAG_CONTAINER,
+            reinterpret_cast<size_t>(&v_double), MemLayout::FLAG_MEMCPY,
+            sizeof(double), MemLayout::FLAG_END, MemLayout::FLAG_END,
             MemLayout::FLAG_MEMCPY,
-               reinterpret_cast<uint8_t*>(&arrays_v.a_v_struct[0]) - reinterpret_cast<uint8_t*>(&arrays_v.padding3),
-            MemLayout::FLAG_ARRAY,
-                10,
-                MemLayout::FLAG_CONTAINER,
-                    reinterpret_cast<size_t>(&v_str),
-                    MemLayout::FLAG_MEMCPY,
-                    sizeof(NS1::Test),
-                MemLayout::FLAG_END,
-            MemLayout::FLAG_END,
-            MemLayout::FLAG_MEMCPY,
-            sizeof(char)
-        };
+            reinterpret_cast<uint8_t *>(&arrays_v.a_v_struct[0]) -
+                reinterpret_cast<uint8_t *>(&arrays_v.padding3),
+            MemLayout::FLAG_ARRAY, 10, MemLayout::FLAG_CONTAINER,
+            reinterpret_cast<size_t>(&v_str), MemLayout::FLAG_MEMCPY,
+            sizeof(NS1::Test), MemLayout::FLAG_END, MemLayout::FLAG_END,
+            MemLayout::FLAG_MEMCPY, sizeof(char)};
 
         for (size_t i = 0; i < ops.size(); ++i)
-            if (expected[i] != ops[i])
-            {
+            if (expected[i] != ops[i]) {
                 Typelib::display(cerr, ops.begin(), ops.end());
                 std::cerr << "error at index " << i << std::endl;
                 BOOST_REQUIRE_EQUAL(expected[i], ops[i]);
@@ -148,68 +139,57 @@ BOOST_AUTO_TEST_CASE(test_layout_arrays)
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_layout_containers)
-{
+BOOST_AUTO_TEST_CASE(test_layout_containers) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
     {
-        Type const& type      = *registry.get("/Collections");
-        Compound const& str       = static_cast<Compound const&>(*registry.get("/NS1/Test"));
-        BOOST_REQUIRE(str.getSize() != str.getField("b")->getOffset() + str.getField("b")->getType().getSize());
+        Type const &type = *registry.get("/Collections");
+        Compound const &str =
+            static_cast<Compound const &>(*registry.get("/NS1/Test"));
+        BOOST_REQUIRE(str.getSize() !=
+                      str.getField("b")->getOffset() +
+                          str.getField("b")->getType().getSize());
 
-        Type const& v_str     = *registry.get("/std/vector</NS1/Test>");
-        Type const& v_v_str   = *registry.get("/std/vector</std/vector</NS1/Test>>");
-        Type const& v_double  = *registry.get("/std/vector</double>");
-        Type const& v_v_double  = *registry.get("/std/vector</std/vector</double>>");
+        Type const &v_str = *registry.get("/std/vector</NS1/Test>");
+        Type const &v_v_str =
+            *registry.get("/std/vector</std/vector</NS1/Test>>");
+        Type const &v_double = *registry.get("/std/vector</double>");
+        Type const &v_v_double =
+            *registry.get("/std/vector</std/vector</double>>");
         MemoryLayout ops = Typelib::layout_of(type);
 
         Collections value;
 
         size_t expected[] = {
-            MemLayout::FLAG_CONTAINER,
-                reinterpret_cast<size_t>(&v_double),
-                MemLayout::FLAG_MEMCPY,
-                sizeof(double),
-            MemLayout::FLAG_END,
+            MemLayout::FLAG_CONTAINER, reinterpret_cast<size_t>(&v_double),
+            MemLayout::FLAG_MEMCPY, sizeof(double), MemLayout::FLAG_END,
             MemLayout::FLAG_MEMCPY,
-               reinterpret_cast<uint8_t*>(&value.v_struct) - reinterpret_cast<uint8_t*>(&value.padding1),
-            MemLayout::FLAG_CONTAINER,
-                reinterpret_cast<size_t>(&v_str),
-                MemLayout::FLAG_MEMCPY,
-                sizeof(NS1::Test),
-            MemLayout::FLAG_END,
+            reinterpret_cast<uint8_t *>(&value.v_struct) -
+                reinterpret_cast<uint8_t *>(&value.padding1),
+            MemLayout::FLAG_CONTAINER, reinterpret_cast<size_t>(&v_str),
+            MemLayout::FLAG_MEMCPY, sizeof(NS1::Test), MemLayout::FLAG_END,
             MemLayout::FLAG_MEMCPY,
-               reinterpret_cast<uint8_t*>(&value.v_v_numeric) - reinterpret_cast<uint8_t*>(&value.padding2),
-            MemLayout::FLAG_CONTAINER,
-                reinterpret_cast<size_t>(&v_v_double),
-                MemLayout::FLAG_CONTAINER,
-                    reinterpret_cast<size_t>(&v_double),
-                    MemLayout::FLAG_MEMCPY,
-                    sizeof(double),
-                MemLayout::FLAG_END,
-            MemLayout::FLAG_END,
-            MemLayout::FLAG_MEMCPY,
-               reinterpret_cast<uint8_t*>(&value.v_v_struct) - reinterpret_cast<uint8_t*>(&value.padding3),
-            MemLayout::FLAG_CONTAINER,
-                reinterpret_cast<size_t>(&v_v_str),
-                MemLayout::FLAG_CONTAINER,
-                    reinterpret_cast<size_t>(&v_str),
-                    MemLayout::FLAG_MEMCPY,
-                    sizeof(NS1::Test),
-                MemLayout::FLAG_END,
-            MemLayout::FLAG_END,
-            MemLayout::FLAG_MEMCPY,
-            sizeof(char)
-        };
+            reinterpret_cast<uint8_t *>(&value.v_v_numeric) -
+                reinterpret_cast<uint8_t *>(&value.padding2),
+            MemLayout::FLAG_CONTAINER, reinterpret_cast<size_t>(&v_v_double),
+            MemLayout::FLAG_CONTAINER, reinterpret_cast<size_t>(&v_double),
+            MemLayout::FLAG_MEMCPY, sizeof(double), MemLayout::FLAG_END,
+            MemLayout::FLAG_END, MemLayout::FLAG_MEMCPY,
+            reinterpret_cast<uint8_t *>(&value.v_v_struct) -
+                reinterpret_cast<uint8_t *>(&value.padding3),
+            MemLayout::FLAG_CONTAINER, reinterpret_cast<size_t>(&v_v_str),
+            MemLayout::FLAG_CONTAINER, reinterpret_cast<size_t>(&v_str),
+            MemLayout::FLAG_MEMCPY, sizeof(NS1::Test), MemLayout::FLAG_END,
+            MemLayout::FLAG_END, MemLayout::FLAG_MEMCPY, sizeof(char)};
 
         for (size_t i = 0; i < ops.size(); ++i)
-            if (expected[i] != ops[i])
-            {
+            if (expected[i] != ops[i]) {
                 Typelib::display(cerr, ops.begin(), ops.end());
                 std::cerr << "error at index " << i << std::endl;
                 BOOST_REQUIRE_EQUAL(expected[i], ops[i]);
@@ -220,4 +200,3 @@ BOOST_AUTO_TEST_CASE(test_layout_containers)
         BOOST_REQUIRE_EQUAL(expected_size, ops.size());
     }
 }
-

--- a/test/test_model.cc
+++ b/test/test_model.cc
@@ -14,14 +14,13 @@ using namespace Typelib;
 using namespace std;
 using boost::tie;
 
-static pair<Compound*, Compound*> recursive_types(Registry& reg)
-{
-    Compound* direct = new Compound("/R");
+static pair<Compound *, Compound *> recursive_types(Registry &reg) {
+    Compound *direct = new Compound("/R");
     reg.add(direct);
     direct->addField("recursive", *reg.build("/R*"), 0);
 
-    Compound* indirect  = new Compound("/R_indirect");
-    Compound* indirect_temp = new Compound("/R_temp");
+    Compound *indirect = new Compound("/R_indirect");
+    Compound *indirect_temp = new Compound("/R_temp");
     reg.add(indirect);
     reg.add(indirect_temp);
     indirect_temp->addField("recursive", *reg.build("/R_indirect*"), 0);
@@ -30,8 +29,7 @@ static pair<Compound*, Compound*> recursive_types(Registry& reg)
     return make_pair(direct, indirect);
 }
 
-BOOST_AUTO_TEST_CASE( test_compound_size )
-{
+BOOST_AUTO_TEST_CASE(test_compound_size) {
     Registry r;
     Typelib::CXX::addStandardTypes(r);
 
@@ -47,12 +45,11 @@ BOOST_AUTO_TEST_CASE( test_compound_size )
 
     Compound *direct, *indirect;
     tie(direct, indirect) = recursive_types(r);
-    BOOST_REQUIRE_EQUAL(direct->getSize(), sizeof(int*));
-    BOOST_REQUIRE_EQUAL(indirect->getSize(), sizeof(int*));
+    BOOST_REQUIRE_EQUAL(direct->getSize(), sizeof(int *));
+    BOOST_REQUIRE_EQUAL(indirect->getSize(), sizeof(int *));
 }
 
-BOOST_AUTO_TEST_CASE( test_equality )
-{
+BOOST_AUTO_TEST_CASE(test_equality) {
     Registry ra, rb;
     Typelib::CXX::addStandardTypes(ra);
     Typelib::CXX::addStandardTypes(rb);
@@ -61,17 +58,20 @@ BOOST_AUTO_TEST_CASE( test_equality )
     BOOST_REQUIRE(*ra.get("/int32_t") == *ra.get("/int32_t"));
     // different repositories, same type
     BOOST_REQUIRE(*ra.get("/int32_t") != *rb.get("/int32_t"));
-    BOOST_REQUIRE(ra.get("/int32_t")->isSame(*rb.get("/int32_t"))); 
+    BOOST_REQUIRE(ra.get("/int32_t")->isSame(*rb.get("/int32_t")));
     // same type but different names
-    BOOST_REQUIRE(!ra.get("/int32_t")->isSame(*ra.get("/float"))); // numeric category differs
-    BOOST_REQUIRE(!ra.get("/int32_t")->isSame(*ra.get("/uint32_t"))); // numeric category differs
-    BOOST_REQUIRE(!ra.get("/int16_t")->isSame(*ra.get("/int32_t"))); // size differs
+    BOOST_REQUIRE(!ra.get("/int32_t")
+                       ->isSame(*ra.get("/float"))); // numeric category differs
+    BOOST_REQUIRE(!ra.get("/int32_t")->isSame(
+        *ra.get("/uint32_t"))); // numeric category differs
+    BOOST_REQUIRE(
+        !ra.get("/int16_t")->isSame(*ra.get("/int32_t"))); // size differs
 
     //// Test arrays
     BOOST_REQUIRE(*ra.build("/int[16]") != *rb.build("/int[16]"));
-    BOOST_REQUIRE(*ra.get("/int[16]")   == *ra.get("/int[16]"));
+    BOOST_REQUIRE(*ra.get("/int[16]") == *ra.get("/int[16]"));
     BOOST_REQUIRE(!ra.get("/int[16]")->isSame(*rb.build("/int")));
-    BOOST_REQUIRE( ra.get("/int[16]")->isSame(*rb.build("/int[16]")));
+    BOOST_REQUIRE(ra.get("/int[16]")->isSame(*rb.build("/int[16]")));
     BOOST_REQUIRE(!ra.get("/int[16]")->isSame(*rb.build("/int[32]")));
     BOOST_REQUIRE(!ra.get("/int[16]")->isSame(*rb.build("/float[16]")));
 
@@ -101,34 +101,37 @@ BOOST_AUTO_TEST_CASE( test_equality )
     str_a_dup.addField("b", *rb.build("/float*"), 1);
     str_a_dup.addField("c", *rb.get("/int32_t"), 2);
 
-    { Compound str_c("/C");
-	// type name changed
-	str_c.addField("a", str_a_dup, 0);
-	str_c.addField("b", *rb.build("/nil*"), 1);
-	BOOST_REQUIRE(str_c.isSame(str_b));
+    {
+        Compound str_c("/C");
+        // type name changed
+        str_c.addField("a", str_a_dup, 0);
+        str_c.addField("b", *rb.build("/nil*"), 1);
+        BOOST_REQUIRE(str_c.isSame(str_b));
     }
 
-    { Compound str_c("/B");
-	// field offsets changed
-	// the structure size should remain the same
-	// in order to really check offset checking
-	str_c.addField("a", str_a_dup, 0);
-	str_c.addField("b", *rb.build("/nil*"), 0);
-	BOOST_REQUIRE_EQUAL(str_c.getSize(), str_b.getSize());
-	BOOST_REQUIRE(!str_c.isSame(str_b));
+    {
+        Compound str_c("/B");
+        // field offsets changed
+        // the structure size should remain the same
+        // in order to really check offset checking
+        str_c.addField("a", str_a_dup, 0);
+        str_c.addField("b", *rb.build("/nil*"), 0);
+        BOOST_REQUIRE_EQUAL(str_c.getSize(), str_b.getSize());
+        BOOST_REQUIRE(!str_c.isSame(str_b));
     }
 
-    { Compound str_c("/B");
-	// field name change
-	str_c.addField("a", str_a_dup, 0);
-	str_c.addField("c", *rb.build("/nil*"), 1);
-	BOOST_REQUIRE(!str_c.isSame(str_b));
+    {
+        Compound str_c("/B");
+        // field name change
+        str_c.addField("a", str_a_dup, 0);
+        str_c.addField("c", *rb.build("/nil*"), 1);
+        BOOST_REQUIRE(!str_c.isSame(str_b));
     }
 
     // Directly recursive type
-    { 
-        Compound* direct_a, *indirect_a;
-        Compound* direct_b, *indirect_b;
+    {
+        Compound *direct_a, *indirect_a;
+        Compound *direct_b, *indirect_b;
         tie(direct_a, indirect_a) = recursive_types(ra);
         tie(direct_b, indirect_b) = recursive_types(rb);
 
@@ -139,14 +142,14 @@ BOOST_AUTO_TEST_CASE( test_equality )
     }
 
     /// Test containers
-    Container const& container_a     = Container::createContainer(ra, "/std/vector", str_a);
-    Container const& container_a_dup = Container::createContainer(ra, "/std/vector", str_a_dup);
+    Container const &container_a =
+        Container::createContainer(ra, "/std/vector", str_a);
+    Container const &container_a_dup =
+        Container::createContainer(ra, "/std/vector", str_a_dup);
     BOOST_REQUIRE(container_a.isSame(container_a_dup));
-
 }
 
-BOOST_AUTO_TEST_CASE( test_cast )
-{
+BOOST_AUTO_TEST_CASE(test_cast) {
     Registry ra, rb;
     Typelib::CXX::addStandardTypes(ra);
     Typelib::CXX::addStandardTypes(rb);
@@ -155,12 +158,15 @@ BOOST_AUTO_TEST_CASE( test_cast )
     BOOST_REQUIRE(*ra.get("/int32_t") == *ra.get("/int32_t"));
     // different repositories, same type
     BOOST_REQUIRE(*ra.get("/int32_t") != *rb.get("/int32_t"));
-    BOOST_REQUIRE(ra.get("/int32_t")->canCastTo(*rb.get("/int32_t"))); 
+    BOOST_REQUIRE(ra.get("/int32_t")->canCastTo(*rb.get("/int32_t")));
     // same type but different names
     BOOST_REQUIRE(ra.get("/int16_t")->canCastTo(*rb.get("/short")));
-    BOOST_REQUIRE(!ra.get("/int32_t")->canCastTo(*ra.get("/float"))); // numeric category differs
-    BOOST_REQUIRE(!ra.get("/int32_t")->canCastTo(*ra.get("/uint32_t"))); // numeric category differs
-    BOOST_REQUIRE(!ra.get("/int16_t")->canCastTo(*ra.get("/int32_t"))); // size differs
+    BOOST_REQUIRE(!ra.get("/int32_t")->canCastTo(
+        *ra.get("/float"))); // numeric category differs
+    BOOST_REQUIRE(!ra.get("/int32_t")->canCastTo(
+        *ra.get("/uint32_t"))); // numeric category differs
+    BOOST_REQUIRE(
+        !ra.get("/int16_t")->canCastTo(*ra.get("/int32_t"))); // size differs
 
     //// Test arrays
     BOOST_REQUIRE(*ra.build("/int[16]") != *rb.build("/int[16]"));
@@ -177,7 +183,7 @@ BOOST_AUTO_TEST_CASE( test_cast )
     BOOST_REQUIRE(!ra.get("/int*")->canCastTo(*rb.build("/float*")));
 
     //// Test compounds
-    Compound* str_a = new Compound("/A");
+    Compound *str_a = new Compound("/A");
     str_a->addField("a", *ra.build("/int[16]"), 0);
     str_a->addField("b", *ra.build("/float*"), 1);
     str_a->addField("c", *ra.get("/int32_t"), 2);
@@ -192,7 +198,7 @@ BOOST_AUTO_TEST_CASE( test_cast )
     BOOST_REQUIRE(!str_a->canCastTo(str_b));
 
     // same type than str_a, to test checking on str_b
-    Compound* str_a_dup = new Compound("/A_dup");
+    Compound *str_a_dup = new Compound("/A_dup");
     str_a_dup->addField("a", *rb.build("/int[16]"), 0);
     str_a_dup->addField("b", *rb.build("/float*"), 1);
     str_a_dup->addField("c", *rb.get("/int32_t"), 2);
@@ -200,40 +206,44 @@ BOOST_AUTO_TEST_CASE( test_cast )
     str_a_dup->setSize(str_a->getSize() + 5);
     ra.add(str_a_dup);
 
-    { Compound str_c("/C");
-	// type name changed
-	str_c.addField("a", *str_a, 0);
-	str_c.addField("b", *rb.build("/nil*"), 1);
-	BOOST_REQUIRE(str_c.canCastTo(str_b));
+    {
+        Compound str_c("/C");
+        // type name changed
+        str_c.addField("a", *str_a, 0);
+        str_c.addField("b", *rb.build("/nil*"), 1);
+        BOOST_REQUIRE(str_c.canCastTo(str_b));
     }
 
-    { Compound str_c("/C");
-	// packing changes
-	str_c.addField("a", *str_a_dup, 0);
-	str_c.addField("b", *rb.build("/nil*"), 1);
-	BOOST_REQUIRE(str_c.canCastTo(str_b));
+    {
+        Compound str_c("/C");
+        // packing changes
+        str_c.addField("a", *str_a_dup, 0);
+        str_c.addField("b", *rb.build("/nil*"), 1);
+        BOOST_REQUIRE(str_c.canCastTo(str_b));
     }
 
-    { Compound str_c("/B");
-	// field offsets changed
-	// the structure size should remain the same
-	// in order to really check offset checking
-	str_c.addField("a", *str_a_dup, 0);
-	str_c.addField("b", *rb.build("/nil*"), 0);
-	BOOST_REQUIRE(!str_c.canCastTo(str_b));
+    {
+        Compound str_c("/B");
+        // field offsets changed
+        // the structure size should remain the same
+        // in order to really check offset checking
+        str_c.addField("a", *str_a_dup, 0);
+        str_c.addField("b", *rb.build("/nil*"), 0);
+        BOOST_REQUIRE(!str_c.canCastTo(str_b));
     }
 
-    { Compound str_c("/B");
-	// field name change
-	str_c.addField("a", *str_a_dup, 0);
-	str_c.addField("c", *rb.build("/nil*"), 1);
-	BOOST_REQUIRE(!str_c.canCastTo(str_b));
+    {
+        Compound str_c("/B");
+        // field name change
+        str_c.addField("a", *str_a_dup, 0);
+        str_c.addField("c", *rb.build("/nil*"), 1);
+        BOOST_REQUIRE(!str_c.canCastTo(str_b));
     }
 
     // Directly recursive type
-    { 
-        Compound* direct_a, *indirect_a;
-        Compound* direct_b, *indirect_b;
+    {
+        Compound *direct_a, *indirect_a;
+        Compound *direct_b, *indirect_b;
         tie(direct_a, indirect_a) = recursive_types(ra);
         tie(direct_b, indirect_b) = recursive_types(rb);
 
@@ -244,28 +254,29 @@ BOOST_AUTO_TEST_CASE( test_cast )
     }
 
     /// Test containers
-    Container const& container_a = Container::createContainer(ra, "/std/vector", *str_a);
-    Container const& container_a_dup = Container::createContainer(ra, "/std/vector", *str_a_dup);
+    Container const &container_a =
+        Container::createContainer(ra, "/std/vector", *str_a);
+    Container const &container_a_dup =
+        Container::createContainer(ra, "/std/vector", *str_a_dup);
     BOOST_REQUIRE(container_a.canCastTo(container_a));
     BOOST_REQUIRE(!container_a.canCastTo(container_a_dup));
 
     BOOST_REQUIRE(!ra.build("/A[16]")->canCastTo(*ra.build("/A_dup[16]")));
 }
 
-BOOST_AUTO_TEST_CASE( test_model_merge )
-{
+BOOST_AUTO_TEST_CASE(test_model_merge) {
     Registry ra, rb;
     Typelib::CXX::addStandardTypes(ra);
     Typelib::CXX::addStandardTypes(rb);
 
     //// Add definitions of /A and /B in rb
-    Compound* str_a = new Compound("/A");
+    Compound *str_a = new Compound("/A");
     str_a->addField("a", *rb.build("/int[16]"), 0);
     str_a->addField("b", *rb.build("/float*"), 1);
     str_a->addField("c", *rb.get("/int32_t"), 2);
     rb.add(str_a, "");
 
-    Compound* str_b = new Compound("/B");
+    Compound *str_b = new Compound("/B");
     str_b->addField("a", *str_a, 0);
     str_b->addField("b", *rb.build("/nil*"), 1);
     rb.add(str_b, "");
@@ -292,14 +303,34 @@ BOOST_AUTO_TEST_CASE( test_model_merge )
     BOOST_REQUIRE(ra.get("/R")->isSame(*rb.get("/R")));
     BOOST_REQUIRE(ra.get("/R_indirect")->isSame(*rb.get("/R_indirect")));
 
-    BOOST_REQUIRE(static_cast<Compound const*>(ra.get("/A"))->getField("a")->getType() == *ra.get("/int[16]"));
-    BOOST_REQUIRE(static_cast<Compound const*>(ra.get("/A"))->getField("b")->getType() == *ra.get("/float*"));
-    BOOST_REQUIRE(static_cast<Compound const*>(ra.get("/A"))->getField("c")->getType() == *ra.get("/int32_t"));
-    BOOST_REQUIRE(static_cast<Compound const*>(ra.get("/B"))->getField("a")->getType() == *ra.get("/A"));
-    BOOST_REQUIRE(static_cast<Compound const*>(ra.get("/B"))->getField("b")->getType() == *ra.get("/nil*"));
-    BOOST_REQUIRE(static_cast<Compound const*>(rb.get("/A"))->getField("a")->getType() == *rb.get("/int[16]"));
-    BOOST_REQUIRE(static_cast<Compound const*>(rb.get("/A"))->getField("b")->getType() == *rb.get("/float*"));
-    BOOST_REQUIRE(static_cast<Compound const*>(rb.get("/A"))->getField("c")->getType() == *rb.get("/int32_t"));
-    BOOST_REQUIRE(static_cast<Compound const*>(rb.get("/B"))->getField("a")->getType() == *rb.get("/A"));
-    BOOST_REQUIRE(static_cast<Compound const*>(rb.get("/B"))->getField("b")->getType() == *rb.get("/nil*"));
+    BOOST_REQUIRE(static_cast<Compound const *>(ra.get("/A"))
+                      ->getField("a")
+                      ->getType() == *ra.get("/int[16]"));
+    BOOST_REQUIRE(static_cast<Compound const *>(ra.get("/A"))
+                      ->getField("b")
+                      ->getType() == *ra.get("/float*"));
+    BOOST_REQUIRE(static_cast<Compound const *>(ra.get("/A"))
+                      ->getField("c")
+                      ->getType() == *ra.get("/int32_t"));
+    BOOST_REQUIRE(static_cast<Compound const *>(ra.get("/B"))
+                      ->getField("a")
+                      ->getType() == *ra.get("/A"));
+    BOOST_REQUIRE(static_cast<Compound const *>(ra.get("/B"))
+                      ->getField("b")
+                      ->getType() == *ra.get("/nil*"));
+    BOOST_REQUIRE(static_cast<Compound const *>(rb.get("/A"))
+                      ->getField("a")
+                      ->getType() == *rb.get("/int[16]"));
+    BOOST_REQUIRE(static_cast<Compound const *>(rb.get("/A"))
+                      ->getField("b")
+                      ->getType() == *rb.get("/float*"));
+    BOOST_REQUIRE(static_cast<Compound const *>(rb.get("/A"))
+                      ->getField("c")
+                      ->getType() == *rb.get("/int32_t"));
+    BOOST_REQUIRE(static_cast<Compound const *>(rb.get("/B"))
+                      ->getField("a")
+                      ->getType() == *rb.get("/A"));
+    BOOST_REQUIRE(static_cast<Compound const *>(rb.get("/B"))
+                      ->getField("b")
+                      ->getType() == *rb.get("/nil*"));
 }

--- a/test/test_plugin.cc
+++ b/test/test_plugin.cc
@@ -5,9 +5,7 @@
 
 using namespace Typelib;
 
-BOOST_AUTO_TEST_CASE( test_manager )
-{
+BOOST_AUTO_TEST_CASE(test_manager) {
     PluginManager::self manager;
     BOOST_REQUIRE_THROW(manager->importer("BLAH"), PluginNotFound);
 }
-

--- a/test/test_registry.cc
+++ b/test/test_registry.cc
@@ -11,8 +11,7 @@
 #include <typelib/pluginmanager.hh>
 using namespace Typelib;
 
-BOOST_AUTO_TEST_CASE( test_typename_validation )
-{
+BOOST_AUTO_TEST_CASE(test_typename_validation) {
     BOOST_CHECK(!isValidTypename("std::string", false));
     BOOST_CHECK(!isValidTypename("std::string", true));
     BOOST_CHECK(!isValidTypename("/std/string<double>", false));
@@ -28,59 +27,63 @@ BOOST_AUTO_TEST_CASE( test_typename_validation )
     BOOST_CHECK(isValidTypename("/double[3]", true));
     BOOST_CHECK(isValidTypename("/std/string</double[3]>", true));
     BOOST_CHECK(isValidTypename("/wrappers/Matrix</double,3,1>/Scalar", true));
-    BOOST_CHECK(isValidTypename("/std/vector</wrappers/Matrix</double,3,1>>", true));
-    BOOST_CHECK(isValidTypename("/std/vector</wrappers/Matrix</double,3,1>>[4]", true));
+    BOOST_CHECK(
+        isValidTypename("/std/vector</wrappers/Matrix</double,3,1>>", true));
+    BOOST_CHECK(
+        isValidTypename("/std/vector</wrappers/Matrix</double,3,1>>[4]", true));
 
     BOOST_CHECK(isValidTypename("s", false));
     BOOST_CHECK(!isValidTypename(":blabla", false));
 
-    BOOST_CHECK(isValidTypename("/std/map</std/string,/trigger/behaviour/Description,/std/less</std/string>,/std/allocator</std/pair</const std/basic_string</char,/std/char_traits</char>,/std/allocator</char>>,/trigger/behaviour/Description>>>", true));
+    BOOST_CHECK(
+        isValidTypename("/std/map</std/string,/trigger/behaviour/Description,/"
+                        "std/less</std/string>,/std/allocator</std/pair</const "
+                        "std/basic_string</char,/std/char_traits</char>,/std/"
+                        "allocator</char>>,/trigger/behaviour/Description>>>",
+                        true));
 }
 
-BOOST_AUTO_TEST_CASE( test_typename_is_in_namespace )
-{
-    BOOST_CHECK(!isInNamespace("/A/B/Type" , "/A/C"    , false));
-    BOOST_CHECK(!isInNamespace("/A/B/Type" , "/A/C/"   , false));
-    BOOST_CHECK(!isInNamespace("/B/B/Type" , "/B/A"    , false));
-    BOOST_CHECK(!isInNamespace("/B/B/Type" , "/B/A/"   , false));
-    BOOST_CHECK(!isInNamespace("/A/B/Type" , "/A/B/C"  , false));
-    BOOST_CHECK(!isInNamespace("/A/B/Type" , "/A/B/C/" , false));
-    BOOST_CHECK(!isInNamespace("/A/B/Type" , "/A/C"    , true));
-    BOOST_CHECK(!isInNamespace("/A/B/Type" , "/A/C/"   , true));
-    BOOST_CHECK(!isInNamespace("/B/B/Type" , "/B/A"    , true));
-    BOOST_CHECK(!isInNamespace("/B/B/Type" , "/B/A/"   , true));
-    BOOST_CHECK(!isInNamespace("/A/B/Type" , "/A/B/C"  , true));
-    BOOST_CHECK(!isInNamespace("/A/B/Type" , "/A/B/C/" , true));
+BOOST_AUTO_TEST_CASE(test_typename_is_in_namespace) {
+    BOOST_CHECK(!isInNamespace("/A/B/Type", "/A/C", false));
+    BOOST_CHECK(!isInNamespace("/A/B/Type", "/A/C/", false));
+    BOOST_CHECK(!isInNamespace("/B/B/Type", "/B/A", false));
+    BOOST_CHECK(!isInNamespace("/B/B/Type", "/B/A/", false));
+    BOOST_CHECK(!isInNamespace("/A/B/Type", "/A/B/C", false));
+    BOOST_CHECK(!isInNamespace("/A/B/Type", "/A/B/C/", false));
+    BOOST_CHECK(!isInNamespace("/A/B/Type", "/A/C", true));
+    BOOST_CHECK(!isInNamespace("/A/B/Type", "/A/C/", true));
+    BOOST_CHECK(!isInNamespace("/B/B/Type", "/B/A", true));
+    BOOST_CHECK(!isInNamespace("/B/B/Type", "/B/A/", true));
+    BOOST_CHECK(!isInNamespace("/A/B/Type", "/A/B/C", true));
+    BOOST_CHECK(!isInNamespace("/A/B/Type", "/A/B/C/", true));
 
-    BOOST_CHECK(!isInNamespace("/A/B/C/Type" , "/A/B"  , false));
-    BOOST_CHECK(!isInNamespace("/A/B/C/Type" , "/A/B/" , false));
-    BOOST_CHECK( isInNamespace("/A/B/Type"   , "/A/B"  , false));
-    BOOST_CHECK( isInNamespace("/A/B/Type"   , "/A/B/" , false));
-    BOOST_CHECK( isInNamespace("/A/B/C/Type" , "/A/B"  , true));
-    BOOST_CHECK( isInNamespace("/A/B/C/Type" , "/A/B/" , true));
-    BOOST_CHECK( isInNamespace("/A/B/Type"   , "/A/B"  , true));
-    BOOST_CHECK( isInNamespace("/A/B/Type"   , "/A/B/" , true));
+    BOOST_CHECK(!isInNamespace("/A/B/C/Type", "/A/B", false));
+    BOOST_CHECK(!isInNamespace("/A/B/C/Type", "/A/B/", false));
+    BOOST_CHECK(isInNamespace("/A/B/Type", "/A/B", false));
+    BOOST_CHECK(isInNamespace("/A/B/Type", "/A/B/", false));
+    BOOST_CHECK(isInNamespace("/A/B/C/Type", "/A/B", true));
+    BOOST_CHECK(isInNamespace("/A/B/C/Type", "/A/B/", true));
+    BOOST_CHECK(isInNamespace("/A/B/Type", "/A/B", true));
+    BOOST_CHECK(isInNamespace("/A/B/Type", "/A/B/", true));
 }
 
-BOOST_AUTO_TEST_CASE( test_nameSort )
-{
-    BOOST_CHECK(!nameSort("/A/B/Type" , "/A/B/Type"));
+BOOST_AUTO_TEST_CASE(test_nameSort) {
+    BOOST_CHECK(!nameSort("/A/B/Type", "/A/B/Type"));
 
-    BOOST_CHECK(nameSort("/A/B" , "/A/B/Type"));
-    BOOST_CHECK(!nameSort("/A/B/Type" , "/A/B"));
+    BOOST_CHECK(nameSort("/A/B", "/A/B/Type"));
+    BOOST_CHECK(!nameSort("/A/B/Type", "/A/B"));
 
-    BOOST_CHECK(nameSort("/A/A" , "/A/B/Type"));
-    BOOST_CHECK(!nameSort("/A/B/Type" , "/A/A"));
+    BOOST_CHECK(nameSort("/A/A", "/A/B/Type"));
+    BOOST_CHECK(!nameSort("/A/B/Type", "/A/A"));
 
-    BOOST_CHECK(nameSort("/A/B/Type" , "/AA"));
-    BOOST_CHECK(!nameSort("/AA" , "/A/B/Type"));
+    BOOST_CHECK(nameSort("/A/B/Type", "/AA"));
+    BOOST_CHECK(!nameSort("/AA", "/A/B/Type"));
 
-    BOOST_CHECK(nameSort("/A/B/Ty" , "/A/B/Type"));
-    BOOST_CHECK(!nameSort("/A/B/Type" , "/A/B/Ty"));
+    BOOST_CHECK(nameSort("/A/B/Ty", "/A/B/Type"));
+    BOOST_CHECK(!nameSort("/A/B/Type", "/A/B/Ty"));
 }
 
-BOOST_AUTO_TEST_CASE( test_typename_manipulation )
-{
+BOOST_AUTO_TEST_CASE(test_typename_manipulation) {
     BOOST_CHECK_EQUAL("/NS2/", getNormalizedNamespace("/NS2"));
     BOOST_CHECK_EQUAL("/NS2/", getNormalizedNamespace("/NS2/"));
     BOOST_CHECK_EQUAL("NS2/", getNormalizedNamespace("NS2/"));
@@ -89,21 +92,32 @@ BOOST_AUTO_TEST_CASE( test_typename_manipulation )
     BOOST_CHECK_EQUAL("NS3/Test", getRelativeName("/NS2/NS3/Test", "/NS2"));
 
     BOOST_CHECK_EQUAL("/NS2/NS3/", getNamespace("/NS2/NS3/Test"));
-    BOOST_CHECK_EQUAL("/wrappers/Matrix</double,3,1>/", getNamespace("/wrappers/Matrix</double,3,1>/Scalar"));
-    BOOST_CHECK_EQUAL("Scalar", getTypename("/wrappers/Matrix</double,3,1>/Scalar"));
-    BOOST_CHECK_EQUAL("/wrappers/Matrix</double,3,1>/Gaussian</double,3>/", getNamespace("/wrappers/Matrix</double,3,1>/Gaussian</double,3>/Scalar"));
-    BOOST_CHECK_EQUAL("Scalar", getTypename("/wrappers/Matrix</double,3,1>/Gaussian</double,3>/Scalar"));
-    BOOST_CHECK_EQUAL("/std/", getNamespace("/std/vector</wrappers/Matrix</double,3,1>>"));
+    BOOST_CHECK_EQUAL("/wrappers/Matrix</double,3,1>/",
+                      getNamespace("/wrappers/Matrix</double,3,1>/Scalar"));
+    BOOST_CHECK_EQUAL("Scalar",
+                      getTypename("/wrappers/Matrix</double,3,1>/Scalar"));
+    BOOST_CHECK_EQUAL(
+        "/wrappers/Matrix</double,3,1>/Gaussian</double,3>/",
+        getNamespace(
+            "/wrappers/Matrix</double,3,1>/Gaussian</double,3>/Scalar"));
+    BOOST_CHECK_EQUAL(
+        "Scalar",
+        getTypename(
+            "/wrappers/Matrix</double,3,1>/Gaussian</double,3>/Scalar"));
+    BOOST_CHECK_EQUAL(
+        "/std/", getNamespace("/std/vector</wrappers/Matrix</double,3,1>>"));
 
     BOOST_CHECK_EQUAL("Test", getTypename("/NS2/NS3/Test"));
-    BOOST_CHECK_EQUAL("Scalar", getTypename("/wrappers/Matrix</double,3,1>/Scalar"));
-    BOOST_CHECK_EQUAL("vector</wrappers/Matrix</double,3,1>>", getTypename("/std/vector</wrappers/Matrix</double,3,1>>"));
+    BOOST_CHECK_EQUAL("Scalar",
+                      getTypename("/wrappers/Matrix</double,3,1>/Scalar"));
+    BOOST_CHECK_EQUAL(
+        "vector</wrappers/Matrix</double,3,1>>",
+        getTypename("/std/vector</wrappers/Matrix</double,3,1>>"));
 }
 
-BOOST_AUTO_TEST_CASE( test_typename_path_to )
-{
-    BOOST_CHECK_EQUAL("B/",    getMinimalPathTo("/A/B/Type", "/A/C"));
-    BOOST_CHECK_EQUAL("B/",    getMinimalPathTo("/A/B/Type", "/A/C/"));
+BOOST_AUTO_TEST_CASE(test_typename_path_to) {
+    BOOST_CHECK_EQUAL("B/", getMinimalPathTo("/A/B/Type", "/A/C"));
+    BOOST_CHECK_EQUAL("B/", getMinimalPathTo("/A/B/Type", "/A/C/"));
     BOOST_CHECK_EQUAL("/B/B/", getMinimalPathTo("/B/B/Type", "/B/A"));
     BOOST_CHECK_EQUAL("/B/B/", getMinimalPathTo("/B/B/Type", "/B/A/"));
     BOOST_CHECK_EQUAL("/A/B/", getMinimalPathTo("/A/B/Type", "/A/B/C"));
@@ -115,102 +129,102 @@ BOOST_AUTO_TEST_CASE( test_typename_path_to )
     BOOST_CHECK_EQUAL("/A/", getMinimalPathTo("/A/B", "/C/A"));
 }
 
-BOOST_AUTO_TEST_CASE( test_registry_namespaces )
-{
+BOOST_AUTO_TEST_CASE(test_registry_namespaces) {
     // Add a simple type in an imaginary namespace
     Registry registry;
-    registry.add( new Numeric("/NS1/Test", 1, Numeric::SInt) );
-    registry.add( new Numeric("/NS2/Test", 2, Numeric::SInt) );
+    registry.add(new Numeric("/NS1/Test", 1, Numeric::SInt));
+    registry.add(new Numeric("/NS2/Test", 2, Numeric::SInt));
 
     registry.setDefaultNamespace("/NS2");
     BOOST_REQUIRE_EQUAL("/NS2/Test", registry.getFullName("Test"));
     BOOST_REQUIRE_EQUAL("/NS2/NS3/Test", registry.getFullName("NS3/Test"));
     BOOST_REQUIRE_EQUAL("/Test", registry.getFullName("/Test"));
-    registry.add( new Numeric("/NS2/NS3/Test", 3, Numeric::SInt) );
-    registry.add( new Numeric("/Test", 4, Numeric::SInt) );
+    registry.add(new Numeric("/NS2/NS3/Test", 3, Numeric::SInt));
+    registry.add(new Numeric("/Test", 4, Numeric::SInt));
     registry.setDefaultNamespace("");
 
-    Numeric const* ns1, *ns2, *ns3, *ns;
-    BOOST_REQUIRE(( ns1 = dynamic_cast<Numeric const*>(registry.get("/NS1/Test")) ));
-    BOOST_REQUIRE(( ns2 = dynamic_cast<Numeric const*>(registry.get("/NS2/Test")) ));
-    BOOST_REQUIRE(( ns3 = dynamic_cast<Numeric const*>(registry.get("/NS2/NS3/Test")) ));
-    BOOST_REQUIRE(( ns  = dynamic_cast<Numeric const*>(registry.get("/Test")) ));
+    Numeric const *ns1, *ns2, *ns3, *ns;
+    BOOST_REQUIRE(
+        (ns1 = dynamic_cast<Numeric const *>(registry.get("/NS1/Test"))));
+    BOOST_REQUIRE(
+        (ns2 = dynamic_cast<Numeric const *>(registry.get("/NS2/Test"))));
+    BOOST_REQUIRE(
+        (ns3 = dynamic_cast<Numeric const *>(registry.get("/NS2/NS3/Test"))));
+    BOOST_REQUIRE((ns = dynamic_cast<Numeric const *>(registry.get("/Test"))));
 
     BOOST_REQUIRE_EQUAL(1, ns1->getSize());
     BOOST_REQUIRE_EQUAL(2, ns2->getSize());
     BOOST_REQUIRE_EQUAL(3, ns3->getSize());
     BOOST_REQUIRE_EQUAL(4, ns->getSize());
 
-    { registry.setDefaultNamespace("/NS2");
-	Type const* relative;
-	BOOST_REQUIRE(( relative = registry.get("Test") ));
-	BOOST_REQUIRE_EQUAL(relative, ns2);
-	BOOST_REQUIRE(( relative = registry.get("NS3/Test") ));
-	BOOST_REQUIRE_EQUAL(relative, ns3);
-	BOOST_REQUIRE(( relative = registry.get("/Test") ));
-	BOOST_REQUIRE_EQUAL(relative, ns);
-	BOOST_REQUIRE(( relative = registry.get("/NS1/Test") ));
-	BOOST_REQUIRE_EQUAL(relative, ns1);
+    {
+        registry.setDefaultNamespace("/NS2");
+        Type const *relative;
+        BOOST_REQUIRE((relative = registry.get("Test")));
+        BOOST_REQUIRE_EQUAL(relative, ns2);
+        BOOST_REQUIRE((relative = registry.get("NS3/Test")));
+        BOOST_REQUIRE_EQUAL(relative, ns3);
+        BOOST_REQUIRE((relative = registry.get("/Test")));
+        BOOST_REQUIRE_EQUAL(relative, ns);
+        BOOST_REQUIRE((relative = registry.get("/NS1/Test")));
+        BOOST_REQUIRE_EQUAL(relative, ns1);
     }
-
 }
 
-BOOST_AUTO_TEST_CASE( test_namespace_update_at_insertion )
-{
+BOOST_AUTO_TEST_CASE(test_namespace_update_at_insertion) {
     Registry registry;
     registry.setDefaultNamespace("/A/B/B");
-    registry.add( new Numeric("/A/B/B/Test", 3, Numeric::SInt) );
-    BOOST_REQUIRE(( registry.get("Test") ));
-    BOOST_REQUIRE(( registry.get("B/Test") ));
-    BOOST_REQUIRE(( registry.get("B/B/Test") ));
-    BOOST_REQUIRE(( registry.get("A/B/B/Test") ));
+    registry.add(new Numeric("/A/B/B/Test", 3, Numeric::SInt));
+    BOOST_REQUIRE((registry.get("Test")));
+    BOOST_REQUIRE((registry.get("B/Test")));
+    BOOST_REQUIRE((registry.get("B/B/Test")));
+    BOOST_REQUIRE((registry.get("A/B/B/Test")));
 
-    registry.add( new Numeric("/A/B/Test", 3, Numeric::SInt) );
-    BOOST_REQUIRE(( registry.get("Test") ));
-    BOOST_REQUIRE(( registry.get("B/Test") ));
-    BOOST_REQUIRE(( registry.get("B/B/Test") ));
-    BOOST_REQUIRE(( registry.get("A/B/B/Test") ));
-    BOOST_REQUIRE(( registry.get("A/B/Test") ));
+    registry.add(new Numeric("/A/B/Test", 3, Numeric::SInt));
+    BOOST_REQUIRE((registry.get("Test")));
+    BOOST_REQUIRE((registry.get("B/Test")));
+    BOOST_REQUIRE((registry.get("B/B/Test")));
+    BOOST_REQUIRE((registry.get("A/B/B/Test")));
+    BOOST_REQUIRE((registry.get("A/B/Test")));
 
     BOOST_REQUIRE_EQUAL(registry.get("/A/B/B/Test"), registry.get("Test"));
     BOOST_REQUIRE_EQUAL(registry.get("/A/B/B/Test"), registry.get("B/Test"));
 
     registry.setDefaultNamespace("/A/B/B/B");
-    registry.add( new Numeric("/A/B/B/B/Test", 3, Numeric::SInt) );
+    registry.add(new Numeric("/A/B/B/B/Test", 3, Numeric::SInt));
     BOOST_REQUIRE_EQUAL(registry.get("/A/B/B/B/Test"), registry.get("Test"));
     BOOST_REQUIRE_EQUAL(registry.get("/A/B/B/B/Test"), registry.get("B/Test"));
-    BOOST_REQUIRE_EQUAL(registry.get("/A/B/B/B/Test"), registry.get("B/B/Test"));
+    BOOST_REQUIRE_EQUAL(registry.get("/A/B/B/B/Test"),
+                        registry.get("B/B/Test"));
 }
 
-static void assert_registries_equal(Registry const& registry, Registry const& ref)
-{
+static void assert_registries_equal(Registry const &registry,
+                                    Registry const &ref) {
     BOOST_REQUIRE_EQUAL(ref.size(), registry.size());
 
-    Registry::Iterator
-        t_it = registry.begin(),
-        t_end = registry.end(),
-        r_it = ref.begin(),
-        r_end = ref.end();
+    Registry::Iterator t_it = registry.begin(), t_end = registry.end(),
+                       r_it = ref.begin(), r_end = ref.end();
 
-    for (; t_it != t_end && r_it != r_end; ++t_it, ++r_it)
-    {
+    for (; t_it != t_end && r_it != r_end; ++t_it, ++r_it) {
         BOOST_REQUIRE_EQUAL(t_it.getName(), r_it.getName());
         BOOST_REQUIRE_EQUAL(t_it->getName(), r_it->getName());
-        BOOST_REQUIRE_MESSAGE(t_it->isSame(*r_it), "definitions of " << t_it->getName() << " differ: " << *t_it << "\n" << *r_it);
+        BOOST_REQUIRE_MESSAGE(t_it->isSame(*r_it), "definitions of "
+                                                       << t_it->getName()
+                                                       << " differ: " << *t_it
+                                                       << "\n" << *r_it);
     }
 
     BOOST_REQUIRE(t_it == t_end);
     BOOST_REQUIRE(r_it == r_end);
 }
 
-BOOST_AUTO_TEST_CASE( test_repositories_merge )
-{
-    static const char* test_file = TEST_DATA_PATH("test_cimport.tlb");
+BOOST_AUTO_TEST_CASE(test_repositories_merge) {
+    static const char *test_file = TEST_DATA_PATH("test_cimport.tlb");
 
     utilmm::config_set config;
     PluginManager::self manager;
 
-    std::auto_ptr<Registry> ref( manager->load("tlb", test_file, config));
+    std::auto_ptr<Registry> ref(manager->load("tlb", test_file, config));
     Registry target;
     target.merge(*ref);
     assert_registries_equal(target, *ref);
@@ -219,8 +233,7 @@ BOOST_AUTO_TEST_CASE( test_repositories_merge )
     assert_registries_equal(target, *ref);
 }
 
-BOOST_AUTO_TEST_CASE( test_array_auto_alias )
-{
+BOOST_AUTO_TEST_CASE(test_array_auto_alias) {
     Registry registry;
     Typelib::CXX::addStandardTypes(registry);
     registry.alias("/int", "/A");
@@ -232,8 +245,7 @@ BOOST_AUTO_TEST_CASE( test_array_auto_alias )
     BOOST_REQUIRE(*registry.get("/B[10]") == *registry.get("/int[10]"));
 }
 
-BOOST_AUTO_TEST_CASE( test_registry_merge_keeps_alias_persistent_flag )
-{
+BOOST_AUTO_TEST_CASE(test_registry_merge_keeps_alias_persistent_flag) {
     Registry registry;
     Typelib::CXX::addStandardTypes(registry);
 
@@ -244,19 +256,20 @@ BOOST_AUTO_TEST_CASE( test_registry_merge_keeps_alias_persistent_flag )
 
     Registry target;
     target.merge(registry);
-    { RegistryIterator it = target.find("/Persistent");
+    {
+        RegistryIterator it = target.find("/Persistent");
         BOOST_REQUIRE(it != target.end());
         BOOST_REQUIRE(it.isPersistent());
     }
 
-    { RegistryIterator it = target.find("/Temporary");
+    {
+        RegistryIterator it = target.find("/Temporary");
         BOOST_REQUIRE(it != target.end());
         BOOST_REQUIRE(!it.isPersistent());
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_registry_minimal_keeps_alias_persistent_flag )
-{
+BOOST_AUTO_TEST_CASE(test_registry_minimal_keeps_alias_persistent_flag) {
     Registry registry;
     Typelib::CXX::addStandardTypes(registry);
     Registry target;
@@ -265,19 +278,20 @@ BOOST_AUTO_TEST_CASE( test_registry_minimal_keeps_alias_persistent_flag )
     target.alias("/int", "/Temporary", false);
 
     target.minimal(registry);
-    { RegistryIterator it = target.find("/Persistent");
+    {
+        RegistryIterator it = target.find("/Persistent");
         BOOST_REQUIRE(it != target.end());
         BOOST_REQUIRE(it.isPersistent());
     }
 
-    { RegistryIterator it = target.find("/Temporary");
+    {
+        RegistryIterator it = target.find("/Temporary");
         BOOST_REQUIRE(it != target.end());
         BOOST_REQUIRE(!it.isPersistent());
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_registry_range )
-{
+BOOST_AUTO_TEST_CASE(test_registry_range) {
     Registry registry;
     Typelib::CXX::addStandardTypes(registry);
     registry.alias("/int", "/A/A", true);
@@ -293,4 +307,3 @@ BOOST_AUTO_TEST_CASE( test_registry_range )
     BOOST_REQUIRE_EQUAL("/A/A", registry.begin("/A").getName());
     BOOST_REQUIRE_EQUAL("/B/A", registry.end("/A").getName());
 }
-

--- a/test/test_value.cc
+++ b/test/test_value.cc
@@ -17,111 +17,104 @@ using namespace std;
 #include "test_cimport.1"
 
 // Tests simple value handling
-BOOST_AUTO_TEST_CASE( test_value_simple )
-{
+BOOST_AUTO_TEST_CASE(test_value_simple) {
     Registry registry;
     Typelib::CXX::addStandardTypes(registry);
 
-    float    f32  = 0.52;
+    float f32 = 0.52;
     uint16_t ui16 = 15;
-    int32_t  i32  = 456;
+    int32_t i32 = 456;
 
     BOOST_CHECK(f32 == value_cast<float>(&f32, *registry.get("float")));
     BOOST_CHECK(ui16 == value_cast<uint16_t>(&ui16, *registry.get("uint16_t")));
     BOOST_CHECK(i32 == value_cast<int32_t>(&i32, *registry.get("int32_t")));
-    BOOST_CHECK_THROW(value_cast<float>(&i32, *registry.get("int32_t")), BadValueCast);
+    BOOST_CHECK_THROW(value_cast<float>(&i32, *registry.get("int32_t")),
+                      BadValueCast);
 }
 
 // Tests structure handling
-BOOST_AUTO_TEST_CASE( test_value_struct )
-{
+BOOST_AUTO_TEST_CASE(test_value_struct) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
     {
-	A a = { 10, 20, 'b', 52 };
-	Value v_a(&a, *registry.get("/A"));
+        A a = {10, 20, 'b', 52};
+        Value v_a(&a, *registry.get("/A"));
 
-	BOOST_CHECK_THROW( value_get_field(v_a, "does_not_exists"), FieldNotFound );
-	BOOST_CHECK(a.a == value_cast<long long>(value_get_field(v_a, "a")));
-	BOOST_CHECK(a.b == value_cast<int>(value_get_field(v_a, "b")));
-	BOOST_CHECK(a.c == value_cast<char>(value_get_field(v_a, "c")));
-	BOOST_CHECK(a.d == value_cast<short>(value_get_field(v_a, "d")));
+        BOOST_CHECK_THROW(value_get_field(v_a, "does_not_exists"),
+                          FieldNotFound);
+        BOOST_CHECK(a.a == value_cast<long long>(value_get_field(v_a, "a")));
+        BOOST_CHECK(a.b == value_cast<int>(value_get_field(v_a, "b")));
+        BOOST_CHECK(a.c == value_cast<char>(value_get_field(v_a, "c")));
+        BOOST_CHECK(a.d == value_cast<short>(value_get_field(v_a, "d")));
 
-	B b;
-	b.a = a;
-	for (int i = 0; i < 100; ++i)
-	    b.c[i] = static_cast<float>(i) / 10.0f;
+        B b;
+        b.a = a;
+        for (int i = 0; i < 100; ++i)
+            b.c[i] = static_cast<float>(i) / 10.0f;
 
-	Value v_b(&b, *registry.get("/B"));
-	Value v_b_a(value_get_field(v_b, "a"));
-	BOOST_CHECK(a.a == value_cast<long long>(value_get_field(v_b_a, "a")));
-	BOOST_CHECK(a.b == value_cast<int>(value_get_field(v_b_a, "b")));
-	BOOST_CHECK(a.c == value_cast<char>(value_get_field(v_b_a, "c")));
-	BOOST_CHECK(a.d == value_cast<short>(value_get_field(v_b_a, "d")));
+        Value v_b(&b, *registry.get("/B"));
+        Value v_b_a(value_get_field(v_b, "a"));
+        BOOST_CHECK(a.a == value_cast<long long>(value_get_field(v_b_a, "a")));
+        BOOST_CHECK(a.b == value_cast<int>(value_get_field(v_b_a, "b")));
+        BOOST_CHECK(a.c == value_cast<char>(value_get_field(v_b_a, "c")));
+        BOOST_CHECK(a.d == value_cast<short>(value_get_field(v_b_a, "d")));
     }
 }
 
-
-struct TestArrayVisitor : public ValueVisitor
-{
+struct TestArrayVisitor : public ValueVisitor {
     size_t m_index;
-    uint8_t* m_element;
-    bool visit_(Value const& v, Array const& a)
-    {
-	m_element = static_cast<uint8_t*>(v.getData()) + m_index * a.getIndirection().getSize();
-	return false;
+    uint8_t *m_element;
+    bool visit_(Value const &v, Array const &a) {
+        m_element = static_cast<uint8_t *>(v.getData()) +
+                    m_index * a.getIndirection().getSize();
+        return false;
     }
 
-public:
-    uint8_t* apply(int index, Value v)
-    {
-	m_element = 0;
-	m_index = index;
-	ValueVisitor::apply(v);
-	return m_element;
+  public:
+    uint8_t *apply(int index, Value v) {
+        m_element = 0;
+        m_index = index;
+        ValueVisitor::apply(v);
+        return m_element;
     }
 };
 // Test array handling
-BOOST_AUTO_TEST_CASE( test_value_array )
-{
+BOOST_AUTO_TEST_CASE(test_value_array) {
     // Get the test file into repository
     Registry registry;
     Typelib::CXX::addStandardTypes(registry);
 
     float test[10];
 
-    Type const& array_type = *registry.build("/float[10]");
+    Type const &array_type = *registry.build("/float[10]");
     TestArrayVisitor visitor;
-    uint8_t* e_0 = visitor.apply(0, Value(test, array_type));
-    uint8_t* e_9 = visitor.apply(9, Value(test, array_type));
-    BOOST_REQUIRE_EQUAL(e_0, reinterpret_cast<uint8_t*>(&test[0]));
-    BOOST_REQUIRE_EQUAL(e_9, reinterpret_cast<uint8_t*>(&test[9]));
+    uint8_t *e_0 = visitor.apply(0, Value(test, array_type));
+    uint8_t *e_9 = visitor.apply(9, Value(test, array_type));
+    BOOST_REQUIRE_EQUAL(e_0, reinterpret_cast<uint8_t *>(&test[0]));
+    BOOST_REQUIRE_EQUAL(e_9, reinterpret_cast<uint8_t *>(&test[9]));
 }
 
-BOOST_AUTO_TEST_CASE( test_value_endian_swap )
-{
+BOOST_AUTO_TEST_CASE(test_value_endian_swap) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
-    A a = { 
-	Endian::swap((long long)10), 
-	Endian::swap((int)20), 
-	Endian::swap('b'), 
-	Endian::swap((short)52) 
-    };
+    A a = {Endian::swap((long long)10), Endian::swap((int)20),
+           Endian::swap('b'), Endian::swap((short)52)};
     B b;
     b.a = a;
     for (int i = 0; i < 10; ++i)
-	b.c[i] = Endian::swap(static_cast<float>(i) / 10.0f);
+        b.c[i] = Endian::swap(static_cast<float>(i) / 10.0f);
 
     Value v_b(&b, *registry.get("/B"));
     Typelib::endian_swap(v_b);
@@ -131,134 +124,128 @@ BOOST_AUTO_TEST_CASE( test_value_endian_swap )
     BOOST_REQUIRE_EQUAL('b', b.a.c);
     BOOST_REQUIRE_EQUAL(52, b.a.d);
     for (int i = 0; i < 10; ++i)
-	BOOST_REQUIRE_EQUAL(static_cast<float>(i) / 10.0f, b.c[i]);
+        BOOST_REQUIRE_EQUAL(static_cast<float>(i) / 10.0f, b.c[i]);
 
     C c;
     Value v_c(&c, *registry.get("/C"));
-    BOOST_CHECK_THROW(Typelib::endian_swap(v_c), Typelib::UnsupportedEndianSwap);
+    BOOST_CHECK_THROW(Typelib::endian_swap(v_c),
+                      Typelib::UnsupportedEndianSwap);
 }
 
-BOOST_AUTO_TEST_CASE( test_compile_endian_swap )
-{
+BOOST_AUTO_TEST_CASE(test_compile_endian_swap) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
-    size_t expected_a[]  = {
-	CompileEndianSwapVisitor::FLAG_SWAP_8,
-	CompileEndianSwapVisitor::FLAG_SWAP_4,
-	CompileEndianSwapVisitor::FLAG_SKIP, 2, // char c plus one alignment byte
-	15, 14
-    };
+    size_t expected_a[] = {CompileEndianSwapVisitor::FLAG_SWAP_8,
+                           CompileEndianSwapVisitor::FLAG_SWAP_4,
+                           CompileEndianSwapVisitor::FLAG_SKIP,
+                           2, // char c plus one alignment byte
+                           15,
+                           14};
 
     /* Check a simple structure with alignment issues */
     {
-	Type const& a_t = *registry.get("/A");
-	CompileEndianSwapVisitor compiled_a;
-	compiled_a.apply(a_t);
+        Type const &a_t = *registry.get("/A");
+        CompileEndianSwapVisitor compiled_a;
+        compiled_a.apply(a_t);
 
-	size_t expected_size = sizeof(expected_a) / sizeof(size_t);
+        size_t expected_size = sizeof(expected_a) / sizeof(size_t);
 
-	BOOST_REQUIRE_EQUAL(expected_size, compiled_a.m_compiled.size());
-	for (size_t i = 0; i < sizeof(expected_a) / sizeof(size_t); ++i)
-	    BOOST_REQUIRE_EQUAL(expected_a[i], compiled_a.m_compiled[i]);
+        BOOST_REQUIRE_EQUAL(expected_size, compiled_a.m_compiled.size());
+        for (size_t i = 0; i < sizeof(expected_a) / sizeof(size_t); ++i)
+            BOOST_REQUIRE_EQUAL(expected_a[i], compiled_a.m_compiled[i]);
     }
 
     /* Check handling of byte arrays */
     {
-	Type const& type = *registry.build("/char[100]");
-	CompileEndianSwapVisitor compiled;
-	compiled.apply(type);
+        Type const &type = *registry.build("/char[100]");
+        CompileEndianSwapVisitor compiled;
+        compiled.apply(type);
 
-	BOOST_REQUIRE_EQUAL(2U, compiled.m_compiled.size());
-	BOOST_REQUIRE_EQUAL(CompileEndianSwapVisitor::FLAG_SKIP, compiled.m_compiled[0]);
-	BOOST_REQUIRE_EQUAL(100U, compiled.m_compiled[1]);
+        BOOST_REQUIRE_EQUAL(2U, compiled.m_compiled.size());
+        BOOST_REQUIRE_EQUAL(CompileEndianSwapVisitor::FLAG_SKIP,
+                            compiled.m_compiled[0]);
+        BOOST_REQUIRE_EQUAL(100U, compiled.m_compiled[1]);
     }
 
     /* Check a structure with arrays */
     {
-	Type const& type = *registry.get("/B");
-	CompileEndianSwapVisitor compiled;
-	compiled.apply(type);
+        Type const &type = *registry.get("/B");
+        CompileEndianSwapVisitor compiled;
+        compiled.apply(type);
 
-	// Check the first field, it should be equal to expected_a
-	size_t offset = sizeof(expected_a) / sizeof(size_t);
-	for (size_t i = 0; i < offset; ++i)
-	    BOOST_REQUIRE_EQUAL(expected_a[i], compiled.m_compiled[i]);
+        // Check the first field, it should be equal to expected_a
+        size_t offset = sizeof(expected_a) / sizeof(size_t);
+        for (size_t i = 0; i < offset; ++i)
+            BOOST_REQUIRE_EQUAL(expected_a[i], compiled.m_compiled[i]);
 
-	// The second field is an array of floats, check it
-	size_t expected[] = {
-	    CompileEndianSwapVisitor::FLAG_ARRAY, 100, 4,
-	    CompileEndianSwapVisitor::FLAG_SWAP_4,
-	    CompileEndianSwapVisitor::FLAG_END
-	};
+        // The second field is an array of floats, check it
+        size_t expected[] = {CompileEndianSwapVisitor::FLAG_ARRAY, 100, 4,
+                             CompileEndianSwapVisitor::FLAG_SWAP_4,
+                             CompileEndianSwapVisitor::FLAG_END};
 
-	size_t expected_array_size = sizeof(expected) / sizeof(size_t);
-	for (size_t i = 0; i < expected_array_size; ++i)
-	    BOOST_REQUIRE_EQUAL(expected[i], compiled.m_compiled[i + offset]);
+        size_t expected_array_size = sizeof(expected) / sizeof(size_t);
+        for (size_t i = 0; i < expected_array_size; ++i)
+            BOOST_REQUIRE_EQUAL(expected[i], compiled.m_compiled[i + offset]);
     }
 
     /* Check a multidimensional array */
     {
-	Type const& type = *registry.get("TestMultiDimArray");
-	CompileEndianSwapVisitor compiled;
-	compiled.apply(type);
+        Type const &type = *registry.get("TestMultiDimArray");
+        CompileEndianSwapVisitor compiled;
+        compiled.apply(type);
 
-	size_t expected[] = {
-	    CompileEndianSwapVisitor::FLAG_ARRAY, 100, 4,
-	    CompileEndianSwapVisitor::FLAG_SWAP_4,
-	    CompileEndianSwapVisitor::FLAG_END
-	};
-	size_t expected_size = sizeof(expected) / sizeof(size_t);
-	BOOST_REQUIRE_EQUAL(expected_size, compiled.m_compiled.size());
+        size_t expected[] = {CompileEndianSwapVisitor::FLAG_ARRAY, 100, 4,
+                             CompileEndianSwapVisitor::FLAG_SWAP_4,
+                             CompileEndianSwapVisitor::FLAG_END};
+        size_t expected_size = sizeof(expected) / sizeof(size_t);
+        BOOST_REQUIRE_EQUAL(expected_size, compiled.m_compiled.size());
 
-	for (size_t i = 0; i < expected_size; ++i)
-	    BOOST_REQUIRE_EQUAL(expected[i], compiled.m_compiled[i]);
+        for (size_t i = 0; i < expected_size; ++i)
+            BOOST_REQUIRE_EQUAL(expected[i], compiled.m_compiled[i]);
     }
 
     // Check a structure with pointer (must throw)
     {
-	Type const& type = *registry.get("/C");
-	CompileEndianSwapVisitor compiled;
+        Type const &type = *registry.get("/C");
+        CompileEndianSwapVisitor compiled;
         BOOST_CHECK_THROW(compiled.apply(type), Typelib::UnsupportedEndianSwap);
     }
 
     // Check an opaque type (must throw)
     {
         OpaqueType type("test_opaque", 10);
-	CompileEndianSwapVisitor compiled;
+        CompileEndianSwapVisitor compiled;
         BOOST_CHECK_THROW(compiled.apply(type), Typelib::UnsupportedEndianSwap);
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_apply_endian_swap )
-{
+BOOST_AUTO_TEST_CASE(test_apply_endian_swap) {
     // Get the test file into repository
     Registry registry;
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
-    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    BOOST_REQUIRE_NO_THROW(
+        importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry));
 
-    A a = { 
-	Endian::swap((long long)10), 
-	Endian::swap((int)20), 
-	Endian::swap('b'), 
-	Endian::swap((short)52) 
-    };
+    A a = {Endian::swap((long long)10), Endian::swap((int)20),
+           Endian::swap('b'), Endian::swap((short)52)};
     B b;
     b.a = a;
     for (int i = 0; i < 10; ++i)
-	b.c[i] = Endian::swap(static_cast<float>(i) / 10.0f);
+        b.c[i] = Endian::swap(static_cast<float>(i) / 10.0f);
 
     b.d[0] = Endian::swap<float>(42);
 
     for (int i = 0; i < 10; ++i)
-	for (int j = 0; j < 10; ++j)
-	    b.i[i][j] = Endian::swap<float>(i * 100 + j);
+        for (int j = 0; j < 10; ++j)
+            b.i[i][j] = Endian::swap<float>(i * 100 + j);
 
     Value v_b(&b, *registry.get("/B"));
     B swapped_b;
@@ -273,10 +260,9 @@ BOOST_AUTO_TEST_CASE( test_apply_endian_swap )
     BOOST_REQUIRE_EQUAL('b', swapped_b.a.c);
     BOOST_REQUIRE_EQUAL(52, swapped_b.a.d);
     for (int i = 0; i < 10; ++i)
-	BOOST_REQUIRE_EQUAL(static_cast<float>(i) / 10.0f, swapped_b.c[i]);
+        BOOST_REQUIRE_EQUAL(static_cast<float>(i) / 10.0f, swapped_b.c[i]);
     BOOST_REQUIRE_EQUAL(42, swapped_b.d[0]);
     for (int i = 0; i < 10; ++i)
-	for (int j = 0; j < 10; ++j)
-	    BOOST_REQUIRE_EQUAL(i * 100 + j, swapped_b.i[i][j]);
+        for (int j = 0; j < 10; ++j)
+            BOOST_REQUIRE_EQUAL(i * 100 + j, swapped_b.i[i][j]);
 }
-

--- a/test/testsuite.cc
+++ b/test/testsuite.cc
@@ -4,5 +4,3 @@
 #define BOOST_AUTO_TEST_MAIN
 #include <boost/test/auto_unit_test.hpp>
 #include <boost/test/unit_test.hpp>
-
-

--- a/typelib/csvoutput.cc
+++ b/typelib/csvoutput.cc
@@ -7,154 +7,147 @@
 using namespace Typelib;
 using namespace std;
 
-namespace 
-{
-    using namespace Typelib;
-    using namespace std;
-    using boost::join;
-    class HeaderVisitor : public TypeVisitor
-    {
-        list<string> m_name;
-        list<string> m_headers;
+namespace {
+using namespace Typelib;
+using namespace std;
+using boost::join;
+class HeaderVisitor : public TypeVisitor {
+    list<string> m_name;
+    list<string> m_headers;
 
-    protected:
-        void output()
-        {
-            string name = join(m_name, ""); 
-            m_headers.push_back(name);
-        }
+  protected:
+    void output() {
+        string name = join(m_name, "");
+        m_headers.push_back(name);
+    }
 
-        bool visit_ (OpaqueType const& type) { output(); return true; }
-        bool visit_ (Numeric const&) { output(); return true; }
-        bool visit_ (Enum const&) { output(); return true; }
-             
-        bool visit_ (Pointer const& type)
-        { 
-            m_name.push_front("*(");
-            m_name.push_back(")");
+    bool visit_(OpaqueType const &type) {
+        output();
+        return true;
+    }
+    bool visit_(Numeric const &) {
+        output();
+        return true;
+    }
+    bool visit_(Enum const &) {
+        output();
+        return true;
+    }
+
+    bool visit_(Pointer const &type) {
+        m_name.push_front("*(");
+        m_name.push_back(")");
+        TypeVisitor::visit_(type);
+        m_name.pop_front();
+        m_name.pop_back();
+        return true;
+    }
+    bool visit_(Array const &type) {
+        m_name.push_back("[");
+        m_name.push_back("");
+        m_name.push_back("]");
+        list<string>::iterator count = m_name.end();
+        --(--count);
+        for (size_t i = 0; i < type.getDimension(); ++i) {
+            *count = boost::lexical_cast<string>(i);
             TypeVisitor::visit_(type);
-            m_name.pop_front();
-            m_name.pop_back();
-            return true;
         }
-        bool visit_ (Array const& type)
-        {
-            m_name.push_back("[");
-            m_name.push_back("");
-            m_name.push_back("]");
-            list<string>::iterator count = m_name.end();
-            --(--count);
-            for (size_t i = 0; i < type.getDimension(); ++i)
-            {
-                *count = boost::lexical_cast<string>(i);
-                TypeVisitor::visit_(type);
-            }
-            m_name.pop_back();
-            m_name.pop_back();
-            m_name.pop_back();
-            return true;
-        }
+        m_name.pop_back();
+        m_name.pop_back();
+        m_name.pop_back();
+        return true;
+    }
 
-        bool visit_ (Compound const& type)
-        {
-            m_name.push_back(".");
-            TypeVisitor::visit_(type);
-            m_name.pop_back();
-            return true;
-        }
-        bool visit_ (Compound const& type, Field const& field)
-        {
-            m_name.push_back(field.getName());
-            TypeVisitor::visit_(type, field);
-            m_name.pop_back();
-            return true;
-        }
- 
-        using TypeVisitor::visit_;
-    public:
-        list<string> apply(Type const& type, std::string const& basename)
-        {
-            m_headers.clear();
-            m_name.clear();
-            m_name.push_back(basename);
-            TypeVisitor::apply(type);
-            return m_headers;
-        }
-    };
+    bool visit_(Compound const &type) {
+        m_name.push_back(".");
+        TypeVisitor::visit_(type);
+        m_name.pop_back();
+        return true;
+    }
+    bool visit_(Compound const &type, Field const &field) {
+        m_name.push_back(field.getName());
+        TypeVisitor::visit_(type, field);
+        m_name.pop_back();
+        return true;
+    }
 
-    class LineVisitor : public ValueVisitor
-    {
-        list<string>  m_output;
-        bool m_char_as_numeric;
-        
-    protected:
-        template<typename T>
-        bool display(T value)
-        {
-            m_output.push_back(boost::lexical_cast<string>(value)); 
-            return true;
-        }
-        using ValueVisitor::visit_;
-        bool visit_ (Value value, OpaqueType const& type)
-        {
-            display("<" + type.getName() + ">");
-            return true;
-        }
-        bool visit_ (int8_t  & value)
-        {
-            if (m_char_as_numeric)
-                return display<int>(value);
-            else
-                return display(value);
-        }
-        bool visit_ (uint8_t & value)
-        {
-            if (m_char_as_numeric)
-                return display<int>(value);
-            else
-                return display(value);
-        }
-        bool visit_ (int16_t & value) { return display(value); }
-        bool visit_ (uint16_t& value) { return display(value); }
-        bool visit_ (int32_t & value) { return display(value); }
-        bool visit_ (uint32_t& value) { return display(value); }
-        bool visit_ (int64_t & value) { return display(value); }
-        bool visit_ (uint64_t& value) { return display(value); }
-        bool visit_ (float   & value) { return display(value); }
-        bool visit_ (double  & value) { return display(value); }
-        bool visit_ (Enum::integral_type& v, Enum const& e)
-        { 
-            try { m_output.push_back(e.get(v)); }
-            catch(Typelib::Enum::ValueNotFound)
-            { display(v); }
-            return true;
-        }
+    using TypeVisitor::visit_;
 
-    public:
-        list<string> apply(Value const& value, bool char_as_numeric)
-        {
-            m_output.clear();
-            m_char_as_numeric = char_as_numeric;
-            ValueVisitor::apply(value);
-            return m_output;
+  public:
+    list<string> apply(Type const &type, std::string const &basename) {
+        m_headers.clear();
+        m_name.clear();
+        m_name.push_back(basename);
+        TypeVisitor::apply(type);
+        return m_headers;
+    }
+};
+
+class LineVisitor : public ValueVisitor {
+    list<string> m_output;
+    bool m_char_as_numeric;
+
+  protected:
+    template <typename T> bool display(T value) {
+        m_output.push_back(boost::lexical_cast<string>(value));
+        return true;
+    }
+    using ValueVisitor::visit_;
+    bool visit_(Value value, OpaqueType const &type) {
+        display("<" + type.getName() + ">");
+        return true;
+    }
+    bool visit_(int8_t &value) {
+        if (m_char_as_numeric)
+            return display<int>(value);
+        else
+            return display(value);
+    }
+    bool visit_(uint8_t &value) {
+        if (m_char_as_numeric)
+            return display<int>(value);
+        else
+            return display(value);
+    }
+    bool visit_(int16_t &value) { return display(value); }
+    bool visit_(uint16_t &value) { return display(value); }
+    bool visit_(int32_t &value) { return display(value); }
+    bool visit_(uint32_t &value) { return display(value); }
+    bool visit_(int64_t &value) { return display(value); }
+    bool visit_(uint64_t &value) { return display(value); }
+    bool visit_(float &value) { return display(value); }
+    bool visit_(double &value) { return display(value); }
+    bool visit_(Enum::integral_type &v, Enum const &e) {
+        try {
+            m_output.push_back(e.get(v));
+        } catch (Typelib::Enum::ValueNotFound) {
+            display(v);
         }
-    };
+        return true;
+    }
+
+  public:
+    list<string> apply(Value const &value, bool char_as_numeric) {
+        m_output.clear();
+        m_char_as_numeric = char_as_numeric;
+        ValueVisitor::apply(value);
+        return m_output;
+    }
+};
 }
 
-
-CSVOutput::CSVOutput(Type const& type, std::string const& sep, bool char_as_numeric = true)
+CSVOutput::CSVOutput(Type const &type, std::string const &sep,
+                     bool char_as_numeric = true)
     : m_type(type), m_separator(sep), m_char_as_numeric(char_as_numeric) {}
 
 /** Displays the header */
-void CSVOutput::header(std::ostream& out, std::string const& basename)
-{
+void CSVOutput::header(std::ostream &out, std::string const &basename) {
     HeaderVisitor visitor;
     out << join(visitor.apply(m_type, basename), m_separator);
 }
 
-void CSVOutput::display(std::ostream& out, void* value)
-{
+void CSVOutput::display(std::ostream &out, void *value) {
     LineVisitor visitor;
-    out << join(visitor.apply( Value(value, m_type), m_char_as_numeric ), m_separator );
+    out << join(visitor.apply(Value(value, m_type), m_char_as_numeric),
+                m_separator);
 }
-

--- a/typelib/csvoutput.hh
+++ b/typelib/csvoutput.hh
@@ -3,71 +3,74 @@
 #include <string>
 #include <iosfwd>
 
-namespace Typelib
-{
-    class Type;
+namespace Typelib {
+class Type;
 
-    class CSVOutput
-    {
-        Type const& m_type;
-        std::string m_separator;
-        bool m_char_as_numeric;
+class CSVOutput {
+    Type const &m_type;
+    std::string m_separator;
+    bool m_char_as_numeric;
 
-    public:
-        CSVOutput(Type const& type, std::string const& sep, bool char_as_numeric);
+  public:
+    CSVOutput(Type const &type, std::string const &sep, bool char_as_numeric);
 
-        /** Displays the header */
-        void header(std::ostream& out, std::string const& basename);
-        void display(std::ostream& out, void* value);
-    };
+    /** Displays the header */
+    void header(std::ostream &out, std::string const &basename);
+    void display(std::ostream &out, void *value);
+};
 
-    
-    namespace details {
-        struct csvheader
-        {
-            CSVOutput output;
-            std::string basename;
-            
-            csvheader(Type const& type, std::string const& basename_, std::string const& sep = " ")
-                : output(type, sep, true), basename(basename_) {}
-        };
-        struct csvline
-        {
-            CSVOutput output;
-            void* value;
-            bool char_as_numeric;
-            
-            csvline(Type const& type_, void* value_, std::string const& sep_ = " ", bool char_as_numeric = true)
-                : output(type_, sep_, char_as_numeric), value(value_), char_as_numeric(char_as_numeric) {}
-        };
-        inline std::ostream& operator << (std::ostream& stream, csvheader header)
-        {
-            header.output.header(stream, header.basename);
-            return stream;
-        }
-        inline std::ostream& operator << (std::ostream& stream, csvline line)
-        {
-            line.output.display(stream, line.value);
-            return stream;
-        }
-    }
+namespace details {
+struct csvheader {
+    CSVOutput output;
+    std::string basename;
 
-    /** Display a CSV header matching a Type object
-     * @arg type	the type to display
-     * @arg basename	the basename to use. For simple type, it is the variable name. For compound types, names in the header are &lt;basename&gt;.&lt;fieldname&gt;
-     * @arg sep		the separator to use
-     */
-    inline details::csvheader csv_header(Type const& type, std::string const& basename, std::string const& sep = " ")
-    { return details::csvheader(type, basename, sep); }
+    csvheader(Type const &type, std::string const &basename_,
+              std::string const &sep = " ")
+        : output(type, sep, true), basename(basename_) {}
+};
+struct csvline {
+    CSVOutput output;
+    void *value;
+    bool char_as_numeric;
 
-    /** Display a CSV line for a Type object and some raw data
-     * @arg type	the data type 
-     * @arg value	the data as a void* pointer
-     * @arg sep		the separator to use
-     */
-    inline details::csvline   csv(Type const& type, void* value, std::string const& sep = " ", bool char_as_numeric = true)
-    { return details::csvline(type, value, sep, char_as_numeric); }
+    csvline(Type const &type_, void *value_, std::string const &sep_ = " ",
+            bool char_as_numeric = true)
+        : output(type_, sep_, char_as_numeric), value(value_),
+          char_as_numeric(char_as_numeric) {}
+};
+inline std::ostream &operator<<(std::ostream &stream, csvheader header) {
+    header.output.header(stream, header.basename);
+    return stream;
+}
+inline std::ostream &operator<<(std::ostream &stream, csvline line) {
+    line.output.display(stream, line.value);
+    return stream;
+}
+}
+
+/** Display a CSV header matching a Type object
+ * @arg type	the type to display
+ * @arg basename	the basename to use. For simple type, it is the variable
+ * name. For compound types, names in the header are
+ * &lt;basename&gt;.&lt;fieldname&gt;
+ * @arg sep		the separator to use
+ */
+inline details::csvheader csv_header(Type const &type,
+                                     std::string const &basename,
+                                     std::string const &sep = " ") {
+    return details::csvheader(type, basename, sep);
+}
+
+/** Display a CSV line for a Type object and some raw data
+ * @arg type	the data type
+ * @arg value	the data as a void* pointer
+ * @arg sep		the separator to use
+ */
+inline details::csvline csv(Type const &type, void *value,
+                            std::string const &sep = " ",
+                            bool char_as_numeric = true) {
+    return details::csvline(type, value, sep, char_as_numeric);
+}
 };
 
 #endif
-

--- a/typelib/endian_swap.hh
+++ b/typelib/endian_swap.hh
@@ -4,120 +4,134 @@
 #include <boost/integer.hpp>
 #include <boost/detail/endian.hpp>
 
-namespace Typelib
-{
-    /** This namespace holds various tools to convert between little and big endian 
-     *
-     * @ingroup system
-     */
-    namespace Endian
-    {
-	namespace Details {
-	    template<int size> struct type_from_size
-	    { typedef typename boost::uint_t<size>::least least; };
-	    template<> struct type_from_size<64>
-	    { typedef uint64_t least; };
+namespace Typelib {
+/** This namespace holds various tools to convert between little and big endian
+ *
+ * @ingroup system
+ */
+namespace Endian {
+namespace Details {
+template <int size> struct type_from_size {
+    typedef typename boost::uint_t<size>::least least;
+};
+template <> struct type_from_size<64> { typedef uint64_t least; };
 
-	    template<int size, typename D>
-	    void swap_helper(const D data, D& buffer);
+template <int size, typename D> void swap_helper(const D data, D &buffer);
 
-	    template<> inline void swap_helper<1, uint8_t>(const uint8_t data, uint8_t& buffer)
-	    { buffer = data; }
-	    template<> inline void swap_helper<2, uint16_t>(const uint16_t data, uint16_t& buffer)
-	    { buffer = ((data >> 8) & 0xFF) | ((data << 8) & 0xFF00); }
-	    template<> inline void swap_helper<4, uint32_t>(const uint32_t data, uint32_t& buffer)
-	    { buffer = ((data & 0xFF000000) >> 24) | ((data & 0x00FF0000) >> 8) | ((data & 0xFF) << 24) | ((data & 0xFF00) << 8); }
-	    template<> inline void swap_helper<8, uint64_t>(const uint64_t data, uint64_t& buffer)
-	    { 
-		const uint32_t 
-		      src_low (data & 0xFFFFFFFF)
-		    , src_high(data >> 32);
+template <>
+inline void swap_helper<1, uint8_t>(const uint8_t data, uint8_t &buffer) {
+    buffer = data;
+}
+template <>
+inline void swap_helper<2, uint16_t>(const uint16_t data, uint16_t &buffer) {
+    buffer = ((data >> 8) & 0xFF) | ((data << 8) & 0xFF00);
+}
+template <>
+inline void swap_helper<4, uint32_t>(const uint32_t data, uint32_t &buffer) {
+    buffer = ((data & 0xFF000000) >> 24) | ((data & 0x00FF0000) >> 8) |
+             ((data & 0xFF) << 24) | ((data & 0xFF00) << 8);
+}
+template <>
+inline void swap_helper<8, uint64_t>(const uint64_t data, uint64_t &buffer) {
+    const uint32_t src_low(data & 0xFFFFFFFF), src_high(data >> 32);
 
-		uint32_t dst_low, dst_high;
-		swap_helper<4, uint32_t>( src_high, dst_low );
-		swap_helper<4, uint32_t>( src_low, dst_high );
-		
-		buffer = static_cast<uint64_t>(dst_high) << 32 | dst_low;
-	    }
-	}
+    uint32_t dst_low, dst_high;
+    swap_helper<4, uint32_t>(src_high, dst_low);
+    swap_helper<4, uint32_t>(src_low, dst_high);
 
-	/* Returns in \c buffer the value of \c data with endianness swapped */
-	template<typename S>
-	inline void swap(const S data, S& buffer)
-	{ 
-	    typedef typename Details::type_from_size<sizeof(S) * 8>::least T;
-	    Details::swap_helper<sizeof(S), T> (reinterpret_cast<const T&>(data), reinterpret_cast<T&>(buffer)); 
-	}
+    buffer = static_cast<uint64_t>(dst_high) << 32 | dst_low;
+}
+}
 
-	/* Returns the value of \c data with endianness swapped */
-	template<typename S>
-	inline S swap(const S data)
-	{ S ret;
-	    swap(data, ret);
-	    return ret;
-	}
+/* Returns in \c buffer the value of \c data with endianness swapped */
+template <typename S> inline void swap(const S data, S &buffer) {
+    typedef typename Details::type_from_size<sizeof(S) * 8>::least T;
+    Details::swap_helper<sizeof(S), T>(reinterpret_cast<const T &>(data),
+                                       reinterpret_cast<T &>(buffer));
+}
+
+/* Returns the value of \c data with endianness swapped */
+template <typename S> inline S swap(const S data) {
+    S ret;
+    swap(data, ret);
+    return ret;
+}
 
 #if defined(BOOST_BIG_ENDIAN)
-	/** Converts \c source, which is in native byte order, into big endian and 
-	 * saves the result into \c dest */
-	template<typename S>
-	inline void to_big(const S source, S& dest) { dest = source; }
-	/** Converts \c source, which is in native byte order, into big endian and 
-	 * returns the result */
-	template<typename S>
-	inline S to_big(const S source) { return source; }
-	/** Converts \c source, which is in native byte order, into little endian and 
-	 * saves the result into \c dest */
-	template<typename S>
-	inline void to_little(const S source, S& dest) { swap<S>(source, dest); }
-	/** Converts \c source, which is in native byte order, into little endian and 
-	 * returns the result */
-	template<typename S>
-	inline S to_little(const S source) { return swap<S>(source); }
+/** Converts \c source, which is in native byte order, into big endian and
+ * saves the result into \c dest */
+template <typename S> inline void to_big(const S source, S &dest) {
+    dest = source;
+}
+/** Converts \c source, which is in native byte order, into big endian and
+ * returns the result */
+template <typename S> inline S to_big(const S source) { return source; }
+/** Converts \c source, which is in native byte order, into little endian and
+ * saves the result into \c dest */
+template <typename S> inline void to_little(const S source, S &dest) {
+    swap<S>(source, dest);
+}
+/** Converts \c source, which is in native byte order, into little endian and
+ * returns the result */
+template <typename S> inline S to_little(const S source) {
+    return swap<S>(source);
+}
 #elif defined(BOOST_LITTLE_ENDIAN)
-	template<typename S>
-	inline void to_big(const S source, S& dest) { swap<S>(source, dest); }
-	template<typename S>
-	inline S to_big(const S source) { return swap<S>(source); }
-	template<typename S>
-	inline void to_little(const S source, S& dest) { dest = source; }
-	template<typename S>
-	inline S to_little(const S source) { return source; }
+template <typename S> inline void to_big(const S source, S &dest) {
+    swap<S>(source, dest);
+}
+template <typename S> inline S to_big(const S source) {
+    return swap<S>(source);
+}
+template <typename S> inline void to_little(const S source, S &dest) {
+    dest = source;
+}
+template <typename S> inline S to_little(const S source) { return source; }
 #else
-#       error "unknown endianness, neither BOOST_LITTLE_ENDIAN nor BOOST_BIG_ENDIAN are defined"
+#error                                                                         \
+    "unknown endianness, neither BOOST_LITTLE_ENDIAN nor BOOST_BIG_ENDIAN are defined"
 #endif
 
-	/** Converts \c source, which is in network byte order, into native byte order and 
-	 * saves the result into \c dest */
-	template<typename S>
-	inline void from_network(const S source, S& dest) { to_network(source, dest); }
-	/** Converts \c source, which is in network byte order, into native byte order and
-	 * returns the result */
-	template<typename S>
-	inline S from_network(const S source) { return to_network(source); }
-	/** Converts \c source, which is in little endian, into native byte order and 
-	 * saves the result into \c dest */
-	template<typename S>
-	inline void from_little(const S source, S& dest) { to_little(source, dest); }
-	/** Converts \c source, which is in little endian, into native byte order and
-	 * returns the result */
-	template<typename S>
-	inline S from_little(const S source) { return to_little(source); }
-	/** Converts \c source, which is in big endian, into native byte order and 
-	 * saves the result into \c dest */
-	template<typename S>
-	inline void from_big(const S source, S& dest) { to_big(source, dest); }
-	/** Converts \c source, which is in big endian, into native byte order and
-	 * returns the result */
-	template<typename S>
-	inline S from_big(const S source) { return to_big(source); }
+/** Converts \c source, which is in network byte order, into native byte order
+ * and
+ * saves the result into \c dest */
+template <typename S> inline void from_network(const S source, S &dest) {
+    to_network(source, dest);
+}
+/** Converts \c source, which is in network byte order, into native byte order
+ * and
+ * returns the result */
+template <typename S> inline S from_network(const S source) {
+    return to_network(source);
+}
+/** Converts \c source, which is in little endian, into native byte order and
+ * saves the result into \c dest */
+template <typename S> inline void from_little(const S source, S &dest) {
+    to_little(source, dest);
+}
+/** Converts \c source, which is in little endian, into native byte order and
+ * returns the result */
+template <typename S> inline S from_little(const S source) {
+    return to_little(source);
+}
+/** Converts \c source, which is in big endian, into native byte order and
+ * saves the result into \c dest */
+template <typename S> inline void from_big(const S source, S &dest) {
+    to_big(source, dest);
+}
+/** Converts \c source, which is in big endian, into native byte order and
+ * returns the result */
+template <typename S> inline S from_big(const S source) {
+    return to_big(source);
+}
 
-	template<typename S>
-	inline void to_network(const S source, S& dest) { return to_big(source, dest); }
-	template<typename S>
-	inline S to_network(const S source) { return to_big(source); }
-    }
+template <typename S> inline void to_network(const S source, S &dest) {
+    return to_big(source, dest);
+}
+template <typename S> inline S to_network(const S source) {
+    return to_big(source);
+}
+}
 }
 
 #endif
-

--- a/typelib/endianness.cc
+++ b/typelib/endianness.cc
@@ -4,220 +4,198 @@
 #include <boost/lexical_cast.hpp>
 
 namespace Typelib {
-    size_t const CompileEndianSwapVisitor::FLAG_SKIP;
-    size_t const CompileEndianSwapVisitor::FLAG_ARRAY;
-    size_t const CompileEndianSwapVisitor::FLAG_END;
-    size_t const CompileEndianSwapVisitor::FLAG_SWAP_4;
-    size_t const CompileEndianSwapVisitor::FLAG_SWAP_8;
+size_t const CompileEndianSwapVisitor::FLAG_SKIP;
+size_t const CompileEndianSwapVisitor::FLAG_ARRAY;
+size_t const CompileEndianSwapVisitor::FLAG_END;
+size_t const CompileEndianSwapVisitor::FLAG_SWAP_4;
+size_t const CompileEndianSwapVisitor::FLAG_SWAP_8;
 
-    size_t const CompileEndianSwapVisitor::SizeOfEnum;
+size_t const CompileEndianSwapVisitor::SizeOfEnum;
 
-    void CompileEndianSwapVisitor::skip(int skip_size)
-    { 
-	size_t size = m_compiled.size();
-	if (m_compiled.size() > 1 && m_compiled[size - 2] == FLAG_SKIP)
-	    m_compiled[size - 1] += skip_size;
-	else
-	{
-	    m_compiled.push_back(FLAG_SKIP);
-	    m_compiled.push_back(skip_size);
-	}
-    }
-
-    bool CompileEndianSwapVisitor::visit_ (Numeric const& type)
-    {
-	switch(type.getSize())
-	{
-	case 1:
-	    skip(1);
-	    return true;
-	case 2:
-	    m_compiled.push_back(m_output_index + 1);
-	    m_compiled.push_back(m_output_index);
-	    return true;
-
-	case 4:
-	    m_compiled.push_back(FLAG_SWAP_4);
-	    return true;
-
-	case 8:
-	    m_compiled.push_back(FLAG_SWAP_8);
-	    return true;
-
-	default:
-	    throw UnsupportedEndianSwap("objects of size " + boost::lexical_cast<std::string>(type.getSize()));
-	}
-    }
-
-    bool CompileEndianSwapVisitor::visit_ (Enum const& type)
-    {
-	for (int i = SizeOfEnum - 1; i >= 0; --i)
-	    m_compiled.push_back(m_output_index + i);
-	return true;
-    }
-
-    bool CompileEndianSwapVisitor::visit_ (OpaqueType const& type)
-    { throw UnsupportedEndianSwap("opaque"); }
-    bool CompileEndianSwapVisitor::visit_ (Pointer const& type)
-    { throw UnsupportedEndianSwap("pointers"); }
-    bool CompileEndianSwapVisitor::visit_ (Array const& type)
-    {
-	if (type.getIndirection().getCategory() == Type::Array)
-	{
-	    size_t current_size = m_compiled.size();
-	    visit_(dynamic_cast<Array const&>(type.getIndirection()));
-	    m_compiled[current_size + 1] *= type.getDimension();
-	    return true;
-	}
-
-	m_compiled.push_back(FLAG_ARRAY);
-	m_compiled.push_back(type.getDimension());
-	m_compiled.push_back(type.getIndirection().getSize());
-
-	size_t current_size = m_compiled.size();
-	TypeVisitor::visit_(type);
-
-	if (m_compiled.size() == current_size + 2 && m_compiled[current_size] == FLAG_SKIP)
-	{
-	    m_compiled[current_size - 3] = FLAG_SKIP;
-	    m_compiled[current_size - 2] = m_compiled[current_size + 1] * type.getDimension();
-	    m_compiled.pop_back();
-	    m_compiled.pop_back();
-	    m_compiled.pop_back();
-	}
-	else
-	    m_compiled.push_back(FLAG_END);
-
-	return true;
-    }
-
-    bool CompileEndianSwapVisitor::visit_ (Container const& type)
-    { throw UnsupportedEndianSwap("containers"); }
-
-    bool CompileEndianSwapVisitor::visit_ (Compound const& type)
-    {
-	size_t base_index = m_output_index;
-
-	typedef Compound::FieldList Fields;
-	Fields const& fields(type.getFields());
-	Fields::const_iterator const end = fields.end();
-
-	for (Fields::const_iterator it = fields.begin(); it != end; ++it)
-	{
-	    size_t new_index = base_index + it->getOffset();
-	    if (new_index < m_output_index)
-		continue;
-	    else if (new_index > m_output_index)
-		skip(new_index - m_output_index);
-
-	    m_output_index = new_index;
-	    dispatch(it->getType());
-	    m_output_index = new_index + it->getType().getSize();
-	}
-	return true;
-    }
-
-    void CompileEndianSwapVisitor::apply(Type const& type)
-    {
-	m_output_index = 0;
-	m_compiled.clear();
-	TypeVisitor::apply(type);
-    }
-
-    std::pair<size_t, std::vector<size_t>::const_iterator> 
-	CompileEndianSwapVisitor::swap(
-	    size_t output_offset, size_t input_offset,
-	    std::vector<size_t>::const_iterator it,
-	    std::vector<size_t>::const_iterator end,
-	    Value in, Value out)
-    {
-	uint8_t* input_buffer = reinterpret_cast<uint8_t*>(in.getData());
-	uint8_t* output_buffer = reinterpret_cast<uint8_t*>(out.getData());
-	while(it != end)
-	{
-	    switch(*it)
-	    {
-	    case FLAG_SKIP:
-		{
-		    size_t skip_size = *(++it);
-		    for (size_t i = 0; i < skip_size; ++i)
-		    {
-			output_buffer[output_offset] = input_buffer[output_offset];
-			output_offset++;
-		    }
-		}
-		break;
-	    case FLAG_SWAP_4:
-		{
-		    reinterpret_cast<uint32_t&>(output_buffer[output_offset]) = 
-			Typelib::Endian::swap(reinterpret_cast<uint32_t const&>(input_buffer[output_offset]));
-		    output_offset += 4;
-		}
-		break;
-	    case FLAG_SWAP_8:
-		{
-		    reinterpret_cast<uint64_t&>(output_buffer[output_offset]) = 
-			Typelib::Endian::swap(reinterpret_cast<uint64_t const&>(input_buffer[output_offset]));
-		    output_offset += 8;
-		}
-		break;
-	    case FLAG_ARRAY:
-		{
-		    size_t array_size = *(++it);
-		    size_t element_size = *(++it);
-
-		    // And swap as many elements as needed
-		    ++it;
-
-		    std::vector<size_t>::const_iterator array_end;
-		    for (size_t i = 0; i < array_size; ++i)
-		    {
-			boost::tie(output_offset, array_end) = 
-			    swap(output_offset, input_offset + element_size * i, 
-				it, end, in, out);
-		    }
-		    it = array_end;
-		}
-		break;
-	    case FLAG_END:
-		return make_pair(output_offset, it);
-	    default:
-		{
-		    output_buffer[output_offset] = input_buffer[input_offset + *it];
-		    ++output_offset;
-		}
-		break;
-	    }
-
-	    ++it;
-	}
-
-	return make_pair(output_offset, it);
-    }
-
-    void CompileEndianSwapVisitor::display()
-    {
-	std::string indent = "";
-	std::vector<size_t>::const_iterator it, end;
-	for (it = m_compiled.begin(); it != m_compiled.end(); ++it)
-	{
-	    switch(*it)
-	    {
-		case FLAG_SKIP:
-		    std::cout << std::endl << indent << "SKIP " << *(++it) << std::endl;
-		    break;
-		case FLAG_ARRAY:
-		    std::cout << std::endl << indent << "ARRAY " << *(++it) << " " << *(++it) << std::endl;
-		    indent += "  ";
-		    break;
-		case FLAG_END:
-		    indent.resize(indent.length() - 2);
-		    std::cout << std::endl << indent << "END" << std::endl;
-		    break;
-		default:
-		    std::cout << " " << *it;
-	    }
-	}
+void CompileEndianSwapVisitor::skip(int skip_size) {
+    size_t size = m_compiled.size();
+    if (m_compiled.size() > 1 && m_compiled[size - 2] == FLAG_SKIP)
+        m_compiled[size - 1] += skip_size;
+    else {
+        m_compiled.push_back(FLAG_SKIP);
+        m_compiled.push_back(skip_size);
     }
 }
 
+bool CompileEndianSwapVisitor::visit_(Numeric const &type) {
+    switch (type.getSize()) {
+    case 1:
+        skip(1);
+        return true;
+    case 2:
+        m_compiled.push_back(m_output_index + 1);
+        m_compiled.push_back(m_output_index);
+        return true;
+
+    case 4:
+        m_compiled.push_back(FLAG_SWAP_4);
+        return true;
+
+    case 8:
+        m_compiled.push_back(FLAG_SWAP_8);
+        return true;
+
+    default:
+        throw UnsupportedEndianSwap(
+            "objects of size " +
+            boost::lexical_cast<std::string>(type.getSize()));
+    }
+}
+
+bool CompileEndianSwapVisitor::visit_(Enum const &type) {
+    for (int i = SizeOfEnum - 1; i >= 0; --i)
+        m_compiled.push_back(m_output_index + i);
+    return true;
+}
+
+bool CompileEndianSwapVisitor::visit_(OpaqueType const &type) {
+    throw UnsupportedEndianSwap("opaque");
+}
+bool CompileEndianSwapVisitor::visit_(Pointer const &type) {
+    throw UnsupportedEndianSwap("pointers");
+}
+bool CompileEndianSwapVisitor::visit_(Array const &type) {
+    if (type.getIndirection().getCategory() == Type::Array) {
+        size_t current_size = m_compiled.size();
+        visit_(dynamic_cast<Array const &>(type.getIndirection()));
+        m_compiled[current_size + 1] *= type.getDimension();
+        return true;
+    }
+
+    m_compiled.push_back(FLAG_ARRAY);
+    m_compiled.push_back(type.getDimension());
+    m_compiled.push_back(type.getIndirection().getSize());
+
+    size_t current_size = m_compiled.size();
+    TypeVisitor::visit_(type);
+
+    if (m_compiled.size() == current_size + 2 &&
+        m_compiled[current_size] == FLAG_SKIP) {
+        m_compiled[current_size - 3] = FLAG_SKIP;
+        m_compiled[current_size - 2] =
+            m_compiled[current_size + 1] * type.getDimension();
+        m_compiled.pop_back();
+        m_compiled.pop_back();
+        m_compiled.pop_back();
+    } else
+        m_compiled.push_back(FLAG_END);
+
+    return true;
+}
+
+bool CompileEndianSwapVisitor::visit_(Container const &type) {
+    throw UnsupportedEndianSwap("containers");
+}
+
+bool CompileEndianSwapVisitor::visit_(Compound const &type) {
+    size_t base_index = m_output_index;
+
+    typedef Compound::FieldList Fields;
+    Fields const &fields(type.getFields());
+    Fields::const_iterator const end = fields.end();
+
+    for (Fields::const_iterator it = fields.begin(); it != end; ++it) {
+        size_t new_index = base_index + it->getOffset();
+        if (new_index < m_output_index)
+            continue;
+        else if (new_index > m_output_index)
+            skip(new_index - m_output_index);
+
+        m_output_index = new_index;
+        dispatch(it->getType());
+        m_output_index = new_index + it->getType().getSize();
+    }
+    return true;
+}
+
+void CompileEndianSwapVisitor::apply(Type const &type) {
+    m_output_index = 0;
+    m_compiled.clear();
+    TypeVisitor::apply(type);
+}
+
+std::pair<size_t, std::vector<size_t>::const_iterator>
+CompileEndianSwapVisitor::swap(size_t output_offset, size_t input_offset,
+                               std::vector<size_t>::const_iterator it,
+                               std::vector<size_t>::const_iterator end,
+                               Value in, Value out) {
+    uint8_t *input_buffer = reinterpret_cast<uint8_t *>(in.getData());
+    uint8_t *output_buffer = reinterpret_cast<uint8_t *>(out.getData());
+    while (it != end) {
+        switch (*it) {
+        case FLAG_SKIP: {
+            size_t skip_size = *(++it);
+            for (size_t i = 0; i < skip_size; ++i) {
+                output_buffer[output_offset] = input_buffer[output_offset];
+                output_offset++;
+            }
+        } break;
+        case FLAG_SWAP_4: {
+            reinterpret_cast<uint32_t &>(output_buffer[output_offset]) =
+                Typelib::Endian::swap(reinterpret_cast<uint32_t const &>(
+                    input_buffer[output_offset]));
+            output_offset += 4;
+        } break;
+        case FLAG_SWAP_8: {
+            reinterpret_cast<uint64_t &>(output_buffer[output_offset]) =
+                Typelib::Endian::swap(reinterpret_cast<uint64_t const &>(
+                    input_buffer[output_offset]));
+            output_offset += 8;
+        } break;
+        case FLAG_ARRAY: {
+            size_t array_size = *(++it);
+            size_t element_size = *(++it);
+
+            // And swap as many elements as needed
+            ++it;
+
+            std::vector<size_t>::const_iterator array_end;
+            for (size_t i = 0; i < array_size; ++i) {
+                boost::tie(output_offset, array_end) =
+                    swap(output_offset, input_offset + element_size * i, it,
+                         end, in, out);
+            }
+            it = array_end;
+        } break;
+        case FLAG_END:
+            return make_pair(output_offset, it);
+        default: {
+            output_buffer[output_offset] = input_buffer[input_offset + *it];
+            ++output_offset;
+        } break;
+        }
+
+        ++it;
+    }
+
+    return make_pair(output_offset, it);
+}
+
+void CompileEndianSwapVisitor::display() {
+    std::string indent = "";
+    std::vector<size_t>::const_iterator it, end;
+    for (it = m_compiled.begin(); it != m_compiled.end(); ++it) {
+        switch (*it) {
+        case FLAG_SKIP:
+            std::cout << std::endl << indent << "SKIP " << *(++it) << std::endl;
+            break;
+        case FLAG_ARRAY:
+            std::cout << std::endl << indent << "ARRAY " << *(++it) << " "
+                      << *(++it) << std::endl;
+            indent += "  ";
+            break;
+        case FLAG_END:
+            indent.resize(indent.length() - 2);
+            std::cout << std::endl << indent << "END" << std::endl;
+            break;
+        default:
+            std::cout << " " << *it;
+        }
+    }
+}
+}

--- a/typelib/endianness.hh
+++ b/typelib/endianness.hh
@@ -5,105 +5,133 @@
 #include <typelib/endian_swap.hh>
 #include <limits>
 
-namespace Typelib
-{
-    struct UnsupportedEndianSwap : public std::runtime_error
-    { 
-        UnsupportedEndianSwap(std::string const& what) : std::runtime_error("cannot swap " + what) { }
-    };
+namespace Typelib {
+struct UnsupportedEndianSwap : public std::runtime_error {
+    UnsupportedEndianSwap(std::string const &what)
+        : std::runtime_error("cannot swap " + what) {}
+};
 
-    /* This visitor swaps the endianness of the given value in-place */
-    class EndianSwapVisitor : public ValueVisitor
-    {
-    protected:
-        bool visit_ (int8_t  & value) { value = Endian::swap(value); return true; }
-        bool visit_ (uint8_t & value) { value = Endian::swap(value); return true; }
-        bool visit_ (int16_t & value) { value = Endian::swap(value); return true; }
-        bool visit_ (uint16_t& value) { value = Endian::swap(value); return true; }
-        bool visit_ (int32_t & value) { value = Endian::swap(value); return true; }
-        bool visit_ (uint32_t& value) { value = Endian::swap(value); return true; }
-        bool visit_ (int64_t & value) { value = Endian::swap(value); return true; }
-        bool visit_ (uint64_t& value) { value = Endian::swap(value); return true; }
-        bool visit_ (float   & value) { value = Endian::swap(value); return true; }
-        bool visit_ (double  & value) { value = Endian::swap(value); return true; }
-        bool visit_ (Value const& v, Pointer const& t) { throw UnsupportedEndianSwap("pointers"); }
-        bool visit_ (Enum::integral_type& v, Enum const& e) { v = Endian::swap(v); return true; }
-    };
+/* This visitor swaps the endianness of the given value in-place */
+class EndianSwapVisitor : public ValueVisitor {
+  protected:
+    bool visit_(int8_t &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(uint8_t &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(int16_t &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(uint16_t &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(int32_t &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(uint32_t &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(int64_t &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(uint64_t &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(float &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(double &value) {
+        value = Endian::swap(value);
+        return true;
+    }
+    bool visit_(Value const &v, Pointer const &t) {
+        throw UnsupportedEndianSwap("pointers");
+    }
+    bool visit_(Enum::integral_type &v, Enum const &e) {
+        v = Endian::swap(v);
+        return true;
+    }
+};
 
-    /** Swaps the endianness of +v+ by using a EndianSwapVisitor */
-    void endian_swap(Value v)
-    {
-	EndianSwapVisitor swapper;
-	swapper.apply(v);
+/** Swaps the endianness of +v+ by using a EndianSwapVisitor */
+void endian_swap(Value v) {
+    EndianSwapVisitor swapper;
+    swapper.apply(v);
+}
+
+class CompileEndianSwapVisitor : public TypeVisitor {
+    // The current place into the output: the next element which are to be
+    // byte-swapped will be written at this index in the output data
+    // buffer.
+    size_t m_output_index;
+
+  public:
+    // The compiled-in description of the byte-swap operation
+    //
+    // Given an output index, an element of compiled is the absolute
+    // index of the input byte which should be written at this output index:
+    //   output_buffer[output_index] = input_buffer[*it_compiled]
+    //
+    // After a "normal" operation (i.e. neither a skip nor an array),
+    // output index is incremented and we handle the next operation
+    // found in compiled
+    std::vector<size_t> m_compiled;
+
+    /**
+     * FLAG_SKIP
+     * <number of bytes to skip>
+     */
+    static size_t const FLAG_SKIP = ((size_t)-1);
+    /**
+     * FLAG_ARRAY
+     * <array size in elements>
+     * <element size in bytes>
+     * <endian swapping code for the array elements>
+     * FLAG_END
+     */
+    static size_t const FLAG_ARRAY = ((size_t)-2);
+    static size_t const FLAG_END = ((size_t)-3);
+    static size_t const FLAG_SWAP_4 = ((size_t)-4);
+    static size_t const FLAG_SWAP_8 = ((size_t)-5);
+    static const size_t SizeOfEnum = sizeof(int);
+    ;
+
+  protected:
+    void skip(int skip_size);
+    bool visit_(OpaqueType const &type);
+    bool visit_(Numeric const &type);
+    bool visit_(Enum const &type);
+    bool visit_(Pointer const &type);
+    bool visit_(Array const &type);
+    bool visit_(Compound const &type);
+    bool visit_(Container const &type);
+
+  public:
+    ~CompileEndianSwapVisitor() {}
+    void apply(Type const &type);
+
+    void swap(Value in, Value out) {
+        CompileEndianSwapVisitor::swap(0, 0, m_compiled.begin(),
+                                       m_compiled.end(), in, out);
     }
 
-    class CompileEndianSwapVisitor : public TypeVisitor 
-    {
-	// The current place into the output: the next element which are to be
-	// byte-swapped will be written at this index in the output data
-	// buffer.
-	size_t m_output_index;
+    std::pair<size_t, std::vector<size_t>::const_iterator>
+    swap(size_t output_offset, size_t input_offset,
+         std::vector<size_t>::const_iterator it,
+         std::vector<size_t>::const_iterator end, Value in, Value out);
 
-    public:
-	// The compiled-in description of the byte-swap operation
-	//
-	// Given an output index, an element of compiled is the absolute
-	// index of the input byte which should be written at this output index:
-	//   output_buffer[output_index] = input_buffer[*it_compiled]
-	//
-	// After a "normal" operation (i.e. neither a skip nor an array),
-	// output index is incremented and we handle the next operation
-	// found in compiled
-	std::vector<size_t> m_compiled;
-
-        /**
-         * FLAG_SKIP
-         * <number of bytes to skip>
-         */
-	static size_t const FLAG_SKIP  = ((size_t) -1);
-        /**
-         * FLAG_ARRAY
-         * <array size in elements>
-         * <element size in bytes>
-         * <endian swapping code for the array elements>
-         * FLAG_END
-         */
-	static size_t const FLAG_ARRAY = ((size_t) -2);
-	static size_t const FLAG_END   = ((size_t) -3);
-	static size_t const FLAG_SWAP_4 = ((size_t) -4);
-	static size_t const FLAG_SWAP_8 = ((size_t) -5);
-	static const size_t SizeOfEnum = sizeof(int);;
-
-    protected:
-	void skip(int skip_size);
-        bool visit_ (OpaqueType const& type);
-        bool visit_ (Numeric const& type);
-        bool visit_ (Enum const& type);
-        bool visit_ (Pointer const& type);
-        bool visit_ (Array const& type);
-	bool visit_ (Compound const& type);
-	bool visit_ (Container const& type);
-
-    public:
-	~CompileEndianSwapVisitor() { }
-	void apply(Type const& type);
-
-	void swap(Value in, Value out)
-	{
-	    CompileEndianSwapVisitor::swap(0, 0,
-		    m_compiled.begin(), m_compiled.end(),
-		    in, out);
-	}
-
-	std::pair<size_t, std::vector<size_t>::const_iterator> 
-	    swap(size_t output_offset, size_t input_offset,
-		std::vector<size_t>::const_iterator it,
-		std::vector<size_t>::const_iterator end,
-		Value in, Value out);
-
-	void display();
-    };
+    void display();
+};
 }
 
 #endif
-

--- a/typelib/exporter.cc
+++ b/typelib/exporter.cc
@@ -10,25 +10,24 @@
 using namespace Typelib;
 using namespace std;
 
-void Exporter::save(std::string const& file_name, utilmm::config_set const& config, Registry const& registry)
-{
+void Exporter::save(std::string const &file_name,
+                    utilmm::config_set const &config,
+                    Registry const &registry) {
     std::ofstream file(file_name.c_str(), std::ofstream::trunc);
     save(file, config, registry);
 }
 
-void Exporter::save(std::ostream& stream, utilmm::config_set const& config, Registry const& registry)
-{
+void Exporter::save(std::ostream &stream, utilmm::config_set const &config,
+                    Registry const &registry) {
     begin(stream, registry);
 
-    std::set<Type const*> saved_types;
+    std::set<Type const *> saved_types;
 
-    typedef std::map
-        < const std::string
-        , RegistryIterator
-        , bool (*) (const std::string&, const std::string&)
-        >     TypeMap;
+    typedef std::map<const std::string, RegistryIterator,
+                     bool (*)(const std::string &, const std::string &)>
+        TypeMap;
     TypeMap types(nameSort);
-       
+
     RegistryIterator const it_end(registry.end());
     for (RegistryIterator it = registry.begin(); it != it_end; ++it)
         types.insert(make_pair(it.getName(), it));
@@ -37,37 +36,36 @@ void Exporter::save(std::ostream& stream, utilmm::config_set const& config, Regi
     // main algorithm (here) is meant to limit switching between namespaces.
     TypeMap free_types(nameSort);
     std::string last_namespace;
-    while (!types.empty())
-    {
+    while (!types.empty()) {
         TypeMap::iterator it = types.begin();
         TypeMap::iterator const end = types.end();
 
-        while (it != end)
-        {
-	    bool done_dependencies = false;
-	    if (it->second.isAlias())
-		done_dependencies = (saved_types.find(&(*it->second)) != saved_types.end());
-	    else
-	    {
-                std::set<Type const*> dependencies = it->second->dependsOn();
-		done_dependencies = includes(saved_types.begin(), saved_types.end(),
-			dependencies.begin(), dependencies.end());
-	    }
+        while (it != end) {
+            bool done_dependencies = false;
+            if (it->second.isAlias())
+                done_dependencies =
+                    (saved_types.find(&(*it->second)) != saved_types.end());
+            else {
+                std::set<Type const *> dependencies = it->second->dependsOn();
+                done_dependencies =
+                    includes(saved_types.begin(), saved_types.end(),
+                             dependencies.begin(), dependencies.end());
+            }
 
-            if (done_dependencies)
-            {
+            if (done_dependencies) {
                 free_types.insert(*it);
                 types.erase(it++);
-            }
-            else ++it;
+            } else
+                ++it;
         }
 
-        if (free_types.empty())
-        {
+        if (free_types.empty()) {
             list<string> remaining;
             for (TypeMap::iterator it = types.begin(); it != types.end(); ++it)
                 remaining.push_back(it->first);
-            throw ExportError(boost::join(remaining, " ") + " seem to be recursive type(s). Exporting them is not supported yet");
+            throw ExportError(boost::join(remaining, " ") +
+                              " seem to be recursive type(s). Exporting them "
+                              "is not supported yet");
         }
 
         // Remove all non-persistent types from the free_type set. If we found
@@ -75,17 +73,14 @@ void Exporter::save(std::ostream& stream, utilmm::config_set const& config, Regi
         bool got_some = false;
         TypeMap::iterator free_it = free_types.begin();
         TypeMap::iterator save_it = free_types.end();
-        while (free_it != free_types.end())
-        {
-            if (!free_it->second.isPersistent())
-            {
+        while (free_it != free_types.end()) {
+            if (!free_it->second.isPersistent()) {
                 got_some = true;
                 saved_types.insert(&(*free_it->second));
                 free_types.erase(free_it++);
-            }
-            else
-            {
-                if (save_it == free_types.end() && free_it->second.getNamespace() == last_namespace)
+            } else {
+                if (save_it == free_types.end() &&
+                    free_it->second.getNamespace() == last_namespace)
                     save_it = free_it;
                 ++free_it;
             }
@@ -97,8 +92,8 @@ void Exporter::save(std::ostream& stream, utilmm::config_set const& config, Regi
             save_it = free_types.begin();
 
         std::string ns = save_it->second.getNamespace();
-        while (save_it != free_types.end() && save_it->second.getNamespace() == ns)
-        {
+        while (save_it != free_types.end() &&
+               save_it->second.getNamespace() == ns) {
             saved_types.insert(&(*save_it->second));
             if (save(stream, save_it->second))
                 last_namespace = ns;
@@ -108,8 +103,8 @@ void Exporter::save(std::ostream& stream, utilmm::config_set const& config, Regi
     }
 
     // Now save the remaining types in free_types
-    for (TypeMap::iterator it = free_types.begin(); it != free_types.end(); ++it)
-    {
+    for (TypeMap::iterator it = free_types.begin(); it != free_types.end();
+         ++it) {
         if (it->second.isPersistent())
             save(stream, it->second);
     }
@@ -117,15 +112,17 @@ void Exporter::save(std::ostream& stream, utilmm::config_set const& config, Regi
     end(stream, registry);
 }
 
-bool Exporter::save( std::ostream& stream, Registry const& registry )
-{
+bool Exporter::save(std::ostream &stream, Registry const &registry) {
     utilmm::config_set config;
-    try { save(stream, config, registry); }
-    catch(UnsupportedType) { return false; }
-    catch(ExportError) { return false; }
+    try {
+        save(stream, config, registry);
+    } catch (UnsupportedType) {
+        return false;
+    } catch (ExportError) {
+        return false;
+    }
     return true;
 }
 
-void Exporter::begin(std::ostream& stream, Registry const& registry) {}
-void Exporter::end  (std::ostream& stream, Registry const& registry) {}
-
+void Exporter::begin(std::ostream &stream, Registry const &registry) {}
+void Exporter::end(std::ostream &stream, Registry const &registry) {}

--- a/typelib/exporter.hh
+++ b/typelib/exporter.hh
@@ -5,90 +5,81 @@
 #include "pluginmanager.hh"
 #include "registryiterator.hh"
 
-namespace utilmm
-{
-    class config_set;
+namespace utilmm {
+class config_set;
 }
 
-namespace Typelib
-{
-    class Type;
-    class Registry;
+namespace Typelib {
+class Type;
+class Registry;
 
-    class ExportPlugin
-    {
-        std::string m_name;
+class ExportPlugin {
+    std::string m_name;
 
-    public:
-        ExportPlugin(std::string const& name)
-            : m_name(name) {}
-        virtual ~ExportPlugin() {}
+  public:
+    ExportPlugin(std::string const &name) : m_name(name) {}
+    virtual ~ExportPlugin() {}
 
-        std::string getName() const { return m_name; }
-        virtual Exporter* create() = 0;
-    };
+    std::string getName() const { return m_name; }
+    virtual Exporter *create() = 0;
+};
 
-    /** Base class for export objects */
-    class Exporter
-    {
-    protected:
-        /** Called by save to add a preamble before saving all registry types 
-	 * @see save
-	 */
-        virtual void begin(std::ostream& stream, Registry const& registry);
-        /** Called by save to add data after saving all registry types
-	 * @see save
-	 */
-        virtual void end  (std::ostream& stream, Registry const& registry);
+/** Base class for export objects */
+class Exporter {
+  protected:
+    /** Called by save to add a preamble before saving all registry types
+     * @see save
+     */
+    virtual void begin(std::ostream &stream, Registry const &registry);
+    /** Called by save to add data after saving all registry types
+     * @see save
+     */
+    virtual void end(std::ostream &stream, Registry const &registry);
 
-    public:
-        virtual ~Exporter() {}
+  public:
+    virtual ~Exporter() {}
 
-	/** Serialize a whole registry in a file */
-	virtual void save
-	    ( std::string const& file_name
-	    , utilmm::config_set const& config
-	    , Registry const& registry );
+    /** Serialize a whole registry in a file */
+    virtual void save(std::string const &file_name,
+                      utilmm::config_set const &config,
+                      Registry const &registry);
 
-        /** Serialize a whole registry using this exporter
-         * 
-         * @arg stream   the stream to write to
-	 * @arg config   configuration object if per-exporter configuration is needed
-         * @arg registry the registry to be saved
-	 *
-       	 * The default implementation calls begin(), iterates on all elements
-	 * in registry, taking into account dependencies (i.e. a type will be serialized
-	 * before another type which references it) and finally calls end()
-	 *
-         * @exception UnsupportedType if a type cannot be serialized in this
-         *          format. In particular, this is thrown if the registry contains
-         *          recursive types
-	 * @exception ExportError for all export errors
-	 */
-        virtual void save
-            ( std::ostream& stream
-	    , utilmm::config_set const& config
-            , Registry const& registry );
+    /** Serialize a whole registry using this exporter
+     *
+     * @arg stream   the stream to write to
+     * @arg config   configuration object if per-exporter configuration is
+     *needed
+     * @arg registry the registry to be saved
+     *
+     * The default implementation calls begin(), iterates on all elements
+     * in registry, taking into account dependencies (i.e. a type will be
+     *serialized
+     * before another type which references it) and finally calls end()
+     *
+     * @exception UnsupportedType if a type cannot be serialized in this
+     *          format. In particular, this is thrown if the registry contains
+     *          recursive types
+     * @exception ExportError for all export errors
+     */
+    virtual void save(std::ostream &stream, utilmm::config_set const &config,
+                      Registry const &registry);
 
-	/** \overload
-	 * This version of \c save is provided for backward-compatibility only
-	 *
-	 * @return true if the export has succeeded, false otherwise
-	 */
-        virtual bool save
-            ( std::ostream& stream
-            , Registry const& registry );
+    /** \overload
+     * This version of \c save is provided for backward-compatibility only
+     *
+     * @return true if the export has succeeded, false otherwise
+     */
+    virtual bool save(std::ostream &stream, Registry const &registry);
 
-        /** Serialize one type in \c stream. It is called by Registry::save(ostream&, Registry const&) 
-	 * @arg stream	the stream to write to
-	 * @arg type	the type to be serialized
-         * @return true if the type has been saved and false if it is ignored by this exporter
-         */
-        virtual bool save
-            ( std::ostream& stream
-            , RegistryIterator const& type ) = 0;
-    };
+    /** Serialize one type in \c stream. It is called by
+     * Registry::save(ostream&, Registry const&)
+     * @arg stream	the stream to write to
+     * @arg type	the type to be serialized
+     * @return true if the type has been saved and false if it is ignored by
+     * this exporter
+     */
+    virtual bool save(std::ostream &stream, RegistryIterator const &type) = 0;
+};
 }
 
 #endif
-

--- a/typelib/importer.cc
+++ b/typelib/importer.cc
@@ -8,11 +8,8 @@
 using namespace Typelib;
 using namespace std;
 
-void Importer::load
-    ( std::string const& path
-    , utilmm::config_set const& config
-    , Registry& registry)
-{
+void Importer::load(std::string const &path, utilmm::config_set const &config,
+                    Registry &registry) {
     // Check that the input file can be opened
     ifstream s(path.c_str());
     if (!s)
@@ -20,15 +17,15 @@ void Importer::load
     load(s, config, registry);
 }
 
+ImportError::ImportError(const std::string &file, const std::string &what_,
+                         int line, int column)
+    : std::runtime_error(file + ":" + boost::lexical_cast<string>(line) + ":" +
+                         what_),
+      m_file(file), m_line(line), m_column(column), m_what(what_), m_buffer(0) {
+}
+ImportError::~ImportError() throw() {}
 
-ImportError::ImportError(const std::string& file, const std::string& what_, int line, int column)
-    : std::runtime_error(file + ":" + boost::lexical_cast<string>(line) + ":" + what_)
-    , m_file(file), m_line(line), m_column(column), m_what(what_), m_buffer(0) {}
-ImportError::~ImportError() throw() {} 
-
-void ImportError::setFile(const std::string& path) { m_file = path; }
+void ImportError::setFile(const std::string &path) { m_file = path; }
 std::string ImportError::getFile() const { return m_file; }
 int ImportError::getLine() const { return m_line; }
 int ImportError::getColumn() const { return m_column; }
-
-

--- a/typelib/importer.hh
+++ b/typelib/importer.hh
@@ -4,74 +4,70 @@
 #include <string>
 #include "pluginmanager.hh"
 
-namespace utilmm { class config_set; }
+namespace utilmm {
+class config_set;
+}
 
-namespace Typelib
-{
-    class Registry;
+namespace Typelib {
+class Registry;
 
-    /** Base class for exception thrown during import */
-    class ImportError : public std::runtime_error
-    {
-        std::string m_file;
-        int m_line, m_column;
-        std::string m_what;
-        char* m_buffer;
+/** Base class for exception thrown during import */
+class ImportError : public std::runtime_error {
+    std::string m_file;
+    int m_line, m_column;
+    std::string m_what;
+    char *m_buffer;
 
-    public:
-        ImportError(const std::string& file, const std::string& what_ = "", int line = 0, int column = 0);
-        ~ImportError() throw();
+  public:
+    ImportError(const std::string &file, const std::string &what_ = "",
+                int line = 0, int column = 0);
+    ~ImportError() throw();
 
-        void setFile(const std::string& path);
-	/** The file in which the exception occured */
-        std::string getFile() const;
-	/** Line of error */
-        int getLine() const;
-	/** Column of error */
-        int getColumn() const;
-    };
+    void setFile(const std::string &path);
+    /** The file in which the exception occured */
+    std::string getFile() const;
+    /** Line of error */
+    int getLine() const;
+    /** Column of error */
+    int getColumn() const;
+};
 
-    class ImportPlugin
-    {
-        std::string m_name;
-        
-    public:
-        ImportPlugin(std::string const& name)
-            : m_name(name) {}
-        virtual ~ImportPlugin() {}
+class ImportPlugin {
+    std::string m_name;
 
-        std::string getName() const { return m_name; }
-        virtual Importer* create() = 0;
-    };
+  public:
+    ImportPlugin(std::string const &name) : m_name(name) {}
+    virtual ~ImportPlugin() {}
 
-    /** Base class for import objects */
-    class Importer
-    {
-    public:
-        virtual ~Importer() {}
+    std::string getName() const { return m_name; }
+    virtual Importer *create() = 0;
+};
 
-	/** Loads a registry from an input stream object 
-	 * @arg stream	    the input stream
-	 * @arg config	    the import configuration. Allowed values are importer-dependent 
-	 * @arg registry    the registry the types are to be imported into
-	 */
-        virtual void load
-            ( std::istream& stream
-            , utilmm::config_set const& config
-            , Registry& registry) = 0;
+/** Base class for import objects */
+class Importer {
+  public:
+    virtual ~Importer() {}
 
-	/** Loads a registry from a file. The default implementation calls <tt>load(std::istream&)</tt>
-	 * with the corresponding ifstream object
-	 * @arg path	    the path of the file to load
-	 * @arg config	    the import configuration. Allowed values are importer-dependent  
-	 * @arg registry    the registry to import into
-	 */
-        virtual void load
-            ( std::string const& path
-            , utilmm::config_set const& config
-            , Registry& registry);
-    };
+    /** Loads a registry from an input stream object
+     * @arg stream	    the input stream
+     * @arg config	    the import configuration. Allowed values are
+     * importer-dependent
+     * @arg registry    the registry the types are to be imported into
+     */
+    virtual void load(std::istream &stream, utilmm::config_set const &config,
+                      Registry &registry) = 0;
+
+    /** Loads a registry from a file. The default implementation calls
+     * <tt>load(std::istream&)</tt>
+     * with the corresponding ifstream object
+     * @arg path	    the path of the file to load
+     * @arg config	    the import configuration. Allowed values are
+     * importer-dependent
+     * @arg registry    the registry to import into
+     */
+    virtual void load(std::string const &path, utilmm::config_set const &config,
+                      Registry &registry);
+};
 }
 
 #endif
-

--- a/typelib/manip.hh
+++ b/typelib/manip.hh
@@ -1,20 +1,17 @@
 #ifndef TYPELIB_MANIP_HH
 #define TYPELIB_MANIP_HH
 
-namespace utilmm { class config_set; }
+namespace utilmm {
+class config_set;
+}
 
-namespace Typelib
-{
-    class Registry;
+namespace Typelib {
+class Registry;
 
-    class Manip
-    {
-        virtual bool manip 
-             ( Registry const& source
-             , Registry& destination
-             , utilmm::config_set const& config ); 
-    };
+class Manip {
+    virtual bool manip(Registry const &source, Registry &destination,
+                       utilmm::config_set const &config);
+};
 }
 
 #endif
-

--- a/typelib/memory_layout.cc
+++ b/typelib/memory_layout.cc
@@ -1,22 +1,21 @@
 #include "memory_layout.hh"
 using namespace Typelib;
 
-void MemLayout::Visitor::push_current_op()
-{
-    if (current_op_count)
-    {
+void MemLayout::Visitor::push_current_op() {
+    if (current_op_count) {
         ops.push_back(current_op);
         ops.push_back(current_op_count);
         current_op_count = 0;
     }
 }
-void MemLayout::Visitor::skip(size_t count)
-{ add_generic_op(FLAG_SKIP, count); }
-void MemLayout::Visitor::memcpy(size_t count)
-{ add_generic_op(FLAG_MEMCPY, count); }
+void MemLayout::Visitor::skip(size_t count) {
+    add_generic_op(FLAG_SKIP, count);
+}
+void MemLayout::Visitor::memcpy(size_t count) {
+    add_generic_op(FLAG_MEMCPY, count);
+}
 
-void MemLayout::Visitor::add_generic_op(size_t op, size_t size)
-{
+void MemLayout::Visitor::add_generic_op(size_t op, size_t size) {
     if (size == 0)
         return;
     if (current_op != op)
@@ -26,23 +25,24 @@ void MemLayout::Visitor::add_generic_op(size_t op, size_t size)
     current_op_count += size;
 }
 
-bool MemLayout::Visitor::generic_visit(Type const& value)
-{
+bool MemLayout::Visitor::generic_visit(Type const &value) {
     memcpy(value.getSize());
     return true;
 };
-bool MemLayout::Visitor::visit_ (Numeric const& type) { return generic_visit(type); }
-bool MemLayout::Visitor::visit_ (Enum    const& type) { return generic_visit(type); }
-bool MemLayout::Visitor::visit_ (Array   const& type)
-{
+bool MemLayout::Visitor::visit_(Numeric const &type) {
+    return generic_visit(type);
+}
+bool MemLayout::Visitor::visit_(Enum const &type) {
+    return generic_visit(type);
+}
+bool MemLayout::Visitor::visit_(Array const &type) {
     MemoryLayout subops;
     MemLayout::Visitor array_visitor(subops);
     array_visitor.apply(type.getIndirection(), merge_skip_copy, false);
 
     if (subops.size() == 2 && subops.front() == FLAG_MEMCPY)
         memcpy(subops.back() * type.getDimension());
-    else
-    {
+    else {
         push_current_op();
         ops.push_back(FLAG_ARRAY);
         ops.push_back(type.getDimension());
@@ -51,8 +51,7 @@ bool MemLayout::Visitor::visit_ (Array   const& type)
     }
     return true;
 }
-bool MemLayout::Visitor::visit_ (Container const& type)
-{
+bool MemLayout::Visitor::visit_(Container const &type) {
     push_current_op();
     ops.push_back(FLAG_CONTAINER);
     ops.push_back(reinterpret_cast<size_t>(&type));
@@ -65,15 +64,13 @@ bool MemLayout::Visitor::visit_ (Container const& type)
     ops.push_back(FLAG_END);
     return true;
 }
-bool MemLayout::Visitor::visit_ (Compound const& type)
-{
+bool MemLayout::Visitor::visit_(Compound const &type) {
     typedef Compound::FieldList Fields;
-    Fields const& fields(type.getFields());
+    Fields const &fields(type.getFields());
     Fields::const_iterator const end = fields.end();
 
     size_t current_offset = 0;
-    for (Fields::const_iterator it = fields.begin(); it != end; ++it)
-    {
+    for (Fields::const_iterator it = fields.begin(); it != end; ++it) {
         skip(it->getOffset() - current_offset);
         dispatch(it->getType());
         current_offset = it->getOffset() + it->getType().getSize();
@@ -81,30 +78,28 @@ bool MemLayout::Visitor::visit_ (Compound const& type)
     skip(type.getSize() - current_offset);
     return true;
 }
-bool MemLayout::Visitor::visit_ (Pointer const& type)
-{
+bool MemLayout::Visitor::visit_(Pointer const &type) {
     if (accept_pointers)
         return generic_visit(type);
     else
         throw NoLayout(type, "is a pointer");
 }
-bool MemLayout::Visitor::visit_ (OpaqueType const& type)
-{
-    if (accept_opaques)
-    {
+bool MemLayout::Visitor::visit_(OpaqueType const &type) {
+    if (accept_opaques) {
         skip(type.getSize());
         return true;
-    }
-    else
+    } else
         throw NoLayout(type, "is an opaque type");
 }
 
-MemLayout::Visitor::Visitor(MemoryLayout& ops, bool accept_pointers, bool accept_opaques)
-    : ops(ops), accept_pointers(accept_pointers), accept_opaques(accept_opaques)
-    , current_op(FLAG_MEMCPY), current_op_count(0) {}
+MemLayout::Visitor::Visitor(MemoryLayout &ops, bool accept_pointers,
+                            bool accept_opaques)
+    : ops(ops), accept_pointers(accept_pointers),
+      accept_opaques(accept_opaques), current_op(FLAG_MEMCPY),
+      current_op_count(0) {}
 
-void MemLayout::Visitor::apply(Type const& type, bool merge_skip_copy, bool remove_trailing_skips)
-{
+void MemLayout::Visitor::apply(Type const &type, bool merge_skip_copy,
+                               bool remove_trailing_skips) {
     this->merge_skip_copy = merge_skip_copy;
 
     current_op = FLAG_MEMCPY;
@@ -113,10 +108,8 @@ void MemLayout::Visitor::apply(Type const& type, bool merge_skip_copy, bool remo
     push_current_op();
 
     // Remove trailing skips, they are useless
-    if (remove_trailing_skips)
-    {
-        while (ops.size() > 2 && ops[ops.size() - 2] == FLAG_SKIP)
-        {
+    if (remove_trailing_skips) {
+        while (ops.size() > 2 && ops[ops.size() - 2] == FLAG_SKIP) {
             ops.pop_back();
             ops.pop_back();
         }
@@ -126,22 +119,20 @@ void MemLayout::Visitor::apply(Type const& type, bool merge_skip_copy, bool remo
         merge_skips_and_copies();
 }
 
-void MemLayout::Visitor::merge_skips_and_copies()
-{
+void MemLayout::Visitor::merge_skips_and_copies() {
     // Merge skips and memcpy: if a skip is preceded by a memcpy (or another
     // skip), simply merge the counts.
     MemoryLayout merged;
 
     MemoryLayout::const_iterator it = ops.begin();
     MemoryLayout::const_iterator const end = ops.end();
-    while (it != end)
-    {
-        size_t op   = *it;
-        if (op != FLAG_SKIP && op != FLAG_MEMCPY)
-        {
+    while (it != end) {
+        size_t op = *it;
+        if (op != FLAG_SKIP && op != FLAG_MEMCPY) {
             MemoryLayout::const_iterator element_it = it;
             ++(++(element_it));
-            MemoryLayout::const_iterator block_end_it = skip_block(element_it, end);
+            MemoryLayout::const_iterator block_end_it =
+                skip_block(element_it, end);
             ++block_end_it;
             merged.insert(merged.end(), it, block_end_it);
             it = block_end_it;
@@ -150,8 +141,7 @@ void MemLayout::Visitor::merge_skips_and_copies()
 
         // Merge following FLAG_MEMCPY and FLAG_SKIP operations
         size_t size = *(++it);
-        for (++it; it != end; ++it)
-        {
+        for (++it; it != end; ++it) {
             if (*it == FLAG_MEMCPY)
                 op = FLAG_MEMCPY;
             else if (*it != FLAG_SKIP)
@@ -165,36 +155,30 @@ void MemLayout::Visitor::merge_skips_and_copies()
     ops = merged;
 }
 
-
-
-MemoryLayout::const_iterator MemLayout::skip_block(
-        MemoryLayout::const_iterator begin,
-        MemoryLayout::const_iterator end)
-{
+MemoryLayout::const_iterator
+MemLayout::skip_block(MemoryLayout::const_iterator begin,
+                      MemoryLayout::const_iterator end) {
     size_t nesting = 0;
-    for (MemoryLayout::const_iterator it = begin; it != end; ++it)
-    {
-        switch(*it)
-        {
-            case FLAG_ARRAY:
-            case FLAG_CONTAINER:
-                ++it;
-                ++nesting;
-                break;
+    for (MemoryLayout::const_iterator it = begin; it != end; ++it) {
+        switch (*it) {
+        case FLAG_ARRAY:
+        case FLAG_CONTAINER:
+            ++it;
+            ++nesting;
+            break;
 
-            case FLAG_END:
-                if (nesting == 0)
-                    return it;
-                --nesting;
-                break;
+        case FLAG_END:
+            if (nesting == 0)
+                return it;
+            --nesting;
+            break;
 
-            case FLAG_SKIP:
-            case FLAG_MEMCPY:
-                ++it;
-            default:
-                break;
+        case FLAG_SKIP:
+        case FLAG_MEMCPY:
+            ++it;
+        default:
+            break;
         }
     }
     return end;
 }
-

--- a/typelib/memory_layout.hh
+++ b/typelib/memory_layout.hh
@@ -6,127 +6,129 @@
 #include <vector>
 #include <boost/static_assert.hpp>
 
-namespace Typelib
-{
-    /** Exception raised when generating a memory layout for an unsupported type
-     */
-    struct NoLayout : public std::runtime_error
-    { 
-        NoLayout(Type const& type, std::string const& reason)
-            : std::runtime_error("there is no memory layout for type " + type.getName() + ": " + reason) { }
-    };
+namespace Typelib {
+/** Exception raised when generating a memory layout for an unsupported type
+ */
+struct NoLayout : public std::runtime_error {
+    NoLayout(Type const &type, std::string const &reason)
+        : std::runtime_error("there is no memory layout for type " +
+                             type.getName() + ": " + reason) {}
+};
 
-    /** Thrown in operations that are using memlayout bytecode and found an
-     * invalid bytecode.
-     */
-    struct UnknownLayoutBytecode : public std::runtime_error
-    { 
-        UnknownLayoutBytecode() : std::runtime_error("found an unknown marshalling bytecode operation") { }
-    };
+/** Thrown in operations that are using memlayout bytecode and found an
+ * invalid bytecode.
+ */
+struct UnknownLayoutBytecode : public std::runtime_error {
+    UnknownLayoutBytecode()
+        : std::runtime_error(
+              "found an unknown marshalling bytecode operation") {}
+};
 
-    // This is needed because the FLAG_CONTAINER descriptor is followed by a
-    // pointer on a Container instance
-    BOOST_STATIC_ASSERT((sizeof(size_t) == sizeof(void*)));
+// This is needed because the FLAG_CONTAINER descriptor is followed by a
+// pointer on a Container instance
+BOOST_STATIC_ASSERT((sizeof(size_t) == sizeof(void *)));
 
-    typedef std::vector<size_t> MemoryLayout;
+typedef std::vector<size_t> MemoryLayout;
 
-    /** Namespace used to define basic constants describing the memory layout
-     * of a type. The goal is to have a compact representation, in a buffer, of
-     * what is raw data, what is junk and what is Container objects.
-     *
-     * This is used by most Value operations (init, ...)
-     */
-    namespace MemLayout
-    {
-        /** Valid marshalling operations
-         *
-         * FLAG_MEMCPY    <byte count>
-         * FLAG_SKIP      <byte count>
-         * FLAG_ARRAY     <element count>  [marshalling ops for pointed-to type] FLAG_END
-         * FLAG_CONTAINER <pointer-to-Container-object> [marshalling ops for pointed-to type] FLAG_END
-         */
-        enum Operations {
-            FLAG_MEMCPY,
-            FLAG_ARRAY,
-            FLAG_CONTAINER,
-            FLAG_SKIP,
-            FLAG_END
-        };
+/** Namespace used to define basic constants describing the memory layout
+ * of a type. The goal is to have a compact representation, in a buffer, of
+ * what is raw data, what is junk and what is Container objects.
+ *
+ * This is used by most Value operations (init, ...)
+ */
+namespace MemLayout {
+/** Valid marshalling operations
+ *
+ * FLAG_MEMCPY    <byte count>
+ * FLAG_SKIP      <byte count>
+ * FLAG_ARRAY     <element count>  [marshalling ops for pointed-to type]
+ *FLAG_END
+ * FLAG_CONTAINER <pointer-to-Container-object> [marshalling ops for pointed-to
+ *type] FLAG_END
+ */
+enum Operations {
+    FLAG_MEMCPY,
+    FLAG_ARRAY,
+    FLAG_CONTAINER,
+    FLAG_SKIP,
+    FLAG_END
+};
 
-        /** This visitor computes the memory layout for a given type. This memory
-         * layout is used by quite a few memory operations
-         *
-         * You should not have to use this directly. Use
-         * Typelib.layout_of(type) instead
-         */
-        class Visitor : public TypeVisitor
-        {
-        private:
-            MemoryLayout& ops;
-            bool   accept_pointers;
-            bool   accept_opaques;
-            size_t current_op;
-            size_t current_op_count;
-            bool merge_skip_copy;
+/** This visitor computes the memory layout for a given type. This memory
+ * layout is used by quite a few memory operations
+ *
+ * You should not have to use this directly. Use
+ * Typelib.layout_of(type) instead
+ */
+class Visitor : public TypeVisitor {
+  private:
+    MemoryLayout &ops;
+    bool accept_pointers;
+    bool accept_opaques;
+    size_t current_op;
+    size_t current_op_count;
+    bool merge_skip_copy;
 
-        protected:
-            void push_current_op();
-            void skip(size_t count);
-            void memcpy(size_t count);
-            void add_generic_op(size_t op, size_t count);
-            bool generic_visit(Type const& value);
-            bool visit_ (Numeric const& type);
-            bool visit_ (Enum    const& type);
-            bool visit_ (Array   const& type);
-            bool visit_ (Container const& type);
-            bool visit_ (Compound const& type);
-            bool visit_ (Pointer const& type);
-            bool visit_ (OpaqueType const& type);
+  protected:
+    void push_current_op();
+    void skip(size_t count);
+    void memcpy(size_t count);
+    void add_generic_op(size_t op, size_t count);
+    bool generic_visit(Type const &value);
+    bool visit_(Numeric const &type);
+    bool visit_(Enum const &type);
+    bool visit_(Array const &type);
+    bool visit_(Container const &type);
+    bool visit_(Compound const &type);
+    bool visit_(Pointer const &type);
+    bool visit_(OpaqueType const &type);
 
-            void merge_skips_and_copies();
+    void merge_skips_and_copies();
 
-        public:
-            Visitor(MemoryLayout& ops, bool accept_pointers = false, bool accept_opaques = false);
+  public:
+    Visitor(MemoryLayout &ops, bool accept_pointers = false,
+            bool accept_opaques = false);
 
-            void apply(Type const& type, bool merge_skip_copy = true, bool remove_trailing_skips = true);
-        };
+    void apply(Type const &type, bool merge_skip_copy = true,
+               bool remove_trailing_skips = true);
+};
 
-        /** Skips the block starting at \c begin. \c end is the end of the
-         * complete layout (to avoid invalid memory accesses if the layout is
-         * incorrect)
-         *
-         * It returns the position of the block's FLAG_END
-         */
-        MemoryLayout::const_iterator skip_block(
-                MemoryLayout::const_iterator begin,
-                MemoryLayout::const_iterator end);
-    }
+/** Skips the block starting at \c begin. \c end is the end of the
+ * complete layout (to avoid invalid memory accesses if the layout is
+ * incorrect)
+ *
+ * It returns the position of the block's FLAG_END
+ */
+MemoryLayout::const_iterator skip_block(MemoryLayout::const_iterator begin,
+                                        MemoryLayout::const_iterator end);
+}
 
-    /** Returns the memory layout of the given type
-     *
-     * @param accept_pointers if false (the default), will throw a NoLayout
-     * exception if the type given contains pointers. If true, they will simply
-     * be skipped
-     * @param accept_opaques if false (the default), will throw a NoLayout
-     * exception if the type given contains opaques. If true, they will simply
-     * be skipped
-     * @param merge_skip_copy in a layout, zones that contain data are copied,
-     * while zones that are there because of C++ padding rules are skipped. If
-     * this is true (the default), consecutive copy/skips are merged into one
-     * bigger copy, as doine one big memcpy() is probably more efficient than
-     * skipping the few padding bytes. Set to false to turn that off.
-     * @param remove_trailing_skips because of C/C++ padding rules, structures
-     * might contain trailing bytes that don't contain information. If this
-     * option is true (the default), these bytes are removed from the layout.
-     */
-    inline MemoryLayout layout_of(Type const& t, bool accept_pointers = false, bool accept_opaques = false, bool merge_skip_copy = true, bool remove_trailing_skips = true)
-    {
-        MemoryLayout ret;
-        MemLayout::Visitor visitor(ret, accept_pointers, accept_opaques);
-        visitor.apply(t, merge_skip_copy, remove_trailing_skips);
-        return ret;
-    }
+/** Returns the memory layout of the given type
+ *
+ * @param accept_pointers if false (the default), will throw a NoLayout
+ * exception if the type given contains pointers. If true, they will simply
+ * be skipped
+ * @param accept_opaques if false (the default), will throw a NoLayout
+ * exception if the type given contains opaques. If true, they will simply
+ * be skipped
+ * @param merge_skip_copy in a layout, zones that contain data are copied,
+ * while zones that are there because of C++ padding rules are skipped. If
+ * this is true (the default), consecutive copy/skips are merged into one
+ * bigger copy, as doine one big memcpy() is probably more efficient than
+ * skipping the few padding bytes. Set to false to turn that off.
+ * @param remove_trailing_skips because of C/C++ padding rules, structures
+ * might contain trailing bytes that don't contain information. If this
+ * option is true (the default), these bytes are removed from the layout.
+ */
+inline MemoryLayout layout_of(Type const &t, bool accept_pointers = false,
+                              bool accept_opaques = false,
+                              bool merge_skip_copy = true,
+                              bool remove_trailing_skips = true) {
+    MemoryLayout ret;
+    MemLayout::Visitor visitor(ret, accept_pointers, accept_opaques);
+    visitor.apply(t, merge_skip_copy, remove_trailing_skips);
+    return ret;
+}
 }
 
 #endif
-

--- a/typelib/normalized_numerics.hh
+++ b/typelib/normalized_numerics.hh
@@ -4,41 +4,37 @@
 #include <boost/static_assert.hpp>
 
 namespace Typelib {
-    namespace details {
-        template<int Bits> struct sint_t;
-        template<> struct sint_t<7>  { typedef int8_t type; };
-        template<> struct sint_t<15> { typedef int16_t type; };
-        template<> struct sint_t<31> { typedef int32_t type; };
-        template<> struct sint_t<63> { typedef int64_t type; };
+namespace details {
+template <int Bits> struct sint_t;
+template <> struct sint_t<7> { typedef int8_t type; };
+template <> struct sint_t<15> { typedef int16_t type; };
+template <> struct sint_t<31> { typedef int32_t type; };
+template <> struct sint_t<63> { typedef int64_t type; };
 
-        template<int Bits> struct uint_t;
-        template<> struct uint_t<8>  { typedef uint8_t type; };
-        template<> struct uint_t<16> { typedef uint16_t type; };
-        template<> struct uint_t<32> { typedef uint32_t type; };
-        template<> struct uint_t<64> { typedef uint64_t type; };
-    }
+template <int Bits> struct uint_t;
+template <> struct uint_t<8> { typedef uint8_t type; };
+template <> struct uint_t<16> { typedef uint16_t type; };
+template <> struct uint_t<32> { typedef uint32_t type; };
+template <> struct uint_t<64> { typedef uint64_t type; };
+}
 
-    /** This template converts base C types (long, int, ...) in their normalized form (uin8_t, int16_t, ...) 
-     * For consistency, it is also specialized for float and double */
-    template<typename T>
-    struct normalized_numeric_type 
-    {
-        typedef std::numeric_limits<T>  limits;
-        BOOST_STATIC_ASSERT(( limits::is_integer )); // will specialize for float and double
+/** This template converts base C types (long, int, ...) in their normalized
+ * form (uin8_t, int16_t, ...)
+ * For consistency, it is also specialized for float and double */
+template <typename T> struct normalized_numeric_type {
+    typedef std::numeric_limits<T> limits;
+    BOOST_STATIC_ASSERT(
+        (limits::is_integer)); // will specialize for float and double
 
-        typedef typename boost::mpl::if_
-            < boost::mpl::bool_<std::numeric_limits<T>::is_signed>
-            , details::sint_t< limits::digits >
-            , details::uint_t< limits::digits >
-            >::type                             getter;
-        typedef typename getter::type           type;
-    };
+    typedef typename boost::mpl::if_<
+        boost::mpl::bool_<std::numeric_limits<T>::is_signed>,
+        details::sint_t<limits::digits>,
+        details::uint_t<limits::digits> >::type getter;
+    typedef typename getter::type type;
+};
 
-    template<> struct normalized_numeric_type<float>  { typedef float	type; };
-    template<> struct normalized_numeric_type<double> { typedef double	type; };
+template <> struct normalized_numeric_type<float> { typedef float type; };
+template <> struct normalized_numeric_type<double> { typedef double type; };
 }
 
 #endif
-
-
-

--- a/typelib/pluginmanager.cc
+++ b/typelib/pluginmanager.cc
@@ -11,43 +11,41 @@ using namespace std;
 using namespace Typelib;
 using namespace boost::filesystem;
 
-namespace
-{
-    using namespace std;
-    
-    template<typename Map, typename Object>
-    bool add_plugin(Map& plugin_map, Object* object)
-    { return (plugin_map.insert( make_pair(object->getName(), object) ).second); }
+namespace {
+using namespace std;
 
-    template<typename Object>
-    Object* get_plugin( map<string, Object*> const& plugin_map, string const& name)
-    {
-        typename map<string, Object*>::const_iterator it = plugin_map.find(name);
-        if (it == plugin_map.end())
-            throw PluginNotFound();
-        return it->second;
-    }
-
-    template<typename Container>
-    void clear(Container& container)
-    {
-        for (typename Container::iterator it = container.begin(); it != container.end(); ++it)
-            delete it->second;
-        container.clear();
-    }
+template <typename Map, typename Object>
+bool add_plugin(Map &plugin_map, Object *object) {
+    return (plugin_map.insert(make_pair(object->getName(), object)).second);
 }
 
-PluginManager::PluginManager()
-{
+template <typename Object>
+Object *get_plugin(map<string, Object *> const &plugin_map,
+                   string const &name) {
+    typename map<string, Object *>::const_iterator it = plugin_map.find(name);
+    if (it == plugin_map.end())
+        throw PluginNotFound();
+    return it->second;
+}
+
+template <typename Container> void clear(Container &container) {
+    for (typename Container::iterator it = container.begin();
+         it != container.end(); ++it)
+        delete it->second;
+    container.clear();
+}
+}
+
+PluginManager::PluginManager() {
     // Load plugins from standard path
-    if (! exists(TYPELIB_PLUGIN_PATH))
+    if (!exists(TYPELIB_PLUGIN_PATH))
         return;
     path plugin_dir(TYPELIB_PLUGIN_PATH);
 
     directory_iterator end_it;
-    for (directory_iterator it(plugin_dir); it != end_it; ++it)
-    {
-        if (it->path().extension() == ".so" || it->path().extension() == ".dylib")
+    for (directory_iterator it(plugin_dir); it != end_it; ++it) {
+        if (it->path().extension() == ".so" ||
+            it->path().extension() == ".dylib")
 #if BOOST_VERSION >= 104600
             loadPlugin(it->path().string());
 #else
@@ -56,31 +54,31 @@ PluginManager::PluginManager()
     }
 }
 
-PluginManager::~PluginManager()
-{
+PluginManager::~PluginManager() {
     clear(m_importers);
     clear(m_exporters);
-    for (std::vector<TypeDefinitionPlugin*>::iterator it = m_definition_plugins.begin();
-            it != m_definition_plugins.end(); ++it)
+    for (std::vector<TypeDefinitionPlugin *>::iterator it =
+             m_definition_plugins.begin();
+         it != m_definition_plugins.end(); ++it)
         delete *it;
     m_definition_plugins.clear();
-    //for (vector<void*>::iterator it = m_library_handles.begin(); it != m_library_handles.end(); ++it)
+    // for (vector<void*>::iterator it = m_library_handles.begin(); it !=
+    // m_library_handles.end(); ++it)
     //    dlclose(*it);
 }
 
-bool PluginManager::loadPlugin(std::string const& path)
-{
-    void* libhandle = dlopen(path.c_str(), RTLD_LAZY);
-    if (!libhandle)
-    {
-        cerr << "typelib: cannot load plugin " << path << ": " << dlerror() << endl;
+bool PluginManager::loadPlugin(std::string const &path) {
+    void *libhandle = dlopen(path.c_str(), RTLD_LAZY);
+    if (!libhandle) {
+        cerr << "typelib: cannot load plugin " << path << ": " << dlerror()
+             << endl;
         return false;
     }
 
-    void* libentry  = dlsym(libhandle, "registerPlugins");
-    if (!libentry)
-    {
-        cerr << "typelib: " << libentry << " does not seem to be a valid typelib plugin" << endl;
+    void *libentry = dlsym(libhandle, "registerPlugins");
+    if (!libentry) {
+        cerr << "typelib: " << libentry
+             << " does not seem to be a valid typelib plugin" << endl;
         return false;
     }
 
@@ -90,94 +88,95 @@ bool PluginManager::loadPlugin(std::string const& path)
     return true;
 }
 
-bool PluginManager::add(ExportPlugin* plugin)
-{ return add_plugin(m_exporters, plugin); }
-bool PluginManager::add(ImportPlugin* plugin)
-{ return add_plugin(m_importers, plugin); }
-void PluginManager::add(TypeDefinitionPlugin* plugin)
-{ return m_definition_plugins.push_back(plugin); }
+bool PluginManager::add(ExportPlugin *plugin) {
+    return add_plugin(m_exporters, plugin);
+}
+bool PluginManager::add(ImportPlugin *plugin) {
+    return add_plugin(m_importers, plugin);
+}
+void PluginManager::add(TypeDefinitionPlugin *plugin) {
+    return m_definition_plugins.push_back(plugin);
+}
 
-void PluginManager::registerPluginTypes(Registry& registry)
-{
-    for (vector<TypeDefinitionPlugin*>::iterator it = m_definition_plugins.begin();
-            it != m_definition_plugins.end(); ++it)
-    {
+void PluginManager::registerPluginTypes(Registry &registry) {
+    for (vector<TypeDefinitionPlugin *>::iterator it =
+             m_definition_plugins.begin();
+         it != m_definition_plugins.end(); ++it) {
         (*it)->registerTypes(registry);
     }
 }
 
-Importer* PluginManager::importer(std::string const& name) const
-{ return get_plugin(m_importers, name)->create(); }
-Exporter* PluginManager::exporter(std::string const& name) const
-{ return get_plugin(m_exporters, name)->create(); }
+Importer *PluginManager::importer(std::string const &name) const {
+    return get_plugin(m_importers, name)->create();
+}
+Exporter *PluginManager::exporter(std::string const &name) const {
+    return get_plugin(m_exporters, name)->create();
+}
 
-
-std::string PluginManager::save(std::string const& kind, Registry const& registry)
-{
+std::string PluginManager::save(std::string const &kind,
+                                Registry const &registry) {
     utilmm::config_set config;
     return save(kind, config, registry);
 }
 
-std::string PluginManager::save(std::string const& kind, utilmm::config_set const& config, Registry const& registry)
-{
+std::string PluginManager::save(std::string const &kind,
+                                utilmm::config_set const &config,
+                                Registry const &registry) {
     ostringstream stream;
     save(kind, config, registry, stream);
     return stream.str();
 }
-void PluginManager::save(std::string const& kind, Registry const& registry, std::ostream& into)
-{
+void PluginManager::save(std::string const &kind, Registry const &registry,
+                         std::ostream &into) {
     utilmm::config_set config;
     save(kind, config, registry, into);
 }
-void PluginManager::save(std::string const& kind, utilmm::config_set const& config, Registry const& registry, std::ostream& into)
-{
+void PluginManager::save(std::string const &kind,
+                         utilmm::config_set const &config,
+                         Registry const &registry, std::ostream &into) {
     auto_ptr<Exporter> exporter(PluginManager::self()->exporter(kind));
     exporter->save(into, config, registry);
 }
 
-Registry* PluginManager::load(std::string const& kind, std::istream& stream)
-{
+Registry *PluginManager::load(std::string const &kind, std::istream &stream) {
     utilmm::config_set config;
     return load(kind, stream, config);
 }
-void PluginManager::load(std::string const& kind, std::istream& stream, Registry& into )
-{
+void PluginManager::load(std::string const &kind, std::istream &stream,
+                         Registry &into) {
     utilmm::config_set config;
     return load(kind, stream, config, into);
 }
-Registry* PluginManager::load(std::string const& kind, std::string const& file)
-{
+Registry *PluginManager::load(std::string const &kind,
+                              std::string const &file) {
     utilmm::config_set config;
     return load(kind, file, config);
 }
-void PluginManager::load(std::string const& kind, std::string const& file, Registry& into)
-{
+void PluginManager::load(std::string const &kind, std::string const &file,
+                         Registry &into) {
     utilmm::config_set config;
     return load(kind, file, config, into);
 }
 
-Registry* PluginManager::load(std::string const& kind, std::istream& stream, utilmm::config_set const& config )
-{
+Registry *PluginManager::load(std::string const &kind, std::istream &stream,
+                              utilmm::config_set const &config) {
     auto_ptr<Registry> registry(new Registry);
     load(kind, stream, config, *registry.get());
     return registry.release();
 }
-void PluginManager::load(std::string const& kind, std::istream& stream, utilmm::config_set const& config
-        , Registry& into )
-{
+void PluginManager::load(std::string const &kind, std::istream &stream,
+                         utilmm::config_set const &config, Registry &into) {
     std::auto_ptr<Importer> importer(PluginManager::self()->importer(kind));
     importer->load(stream, config, into);
 }
-Registry* PluginManager::load(std::string const& kind, std::string const& file, utilmm::config_set const& config)
-{
+Registry *PluginManager::load(std::string const &kind, std::string const &file,
+                              utilmm::config_set const &config) {
     auto_ptr<Registry> registry(new Registry);
     load(kind, file, config, *registry.get());
     return registry.release();
 }
-void PluginManager::load(std::string const& kind, std::string const& file, utilmm::config_set const& config
-        , Registry& into)
-{
+void PluginManager::load(std::string const &kind, std::string const &file,
+                         utilmm::config_set const &config, Registry &into) {
     auto_ptr<Importer> importer(PluginManager::self()->importer(kind));
     importer->load(file, config, into);
 }
-

--- a/typelib/pluginmanager.hh
+++ b/typelib/pluginmanager.hh
@@ -8,188 +8,159 @@
 #include <typelib/utilmm/configset.hh>
 #include <stdexcept>
 
-namespace Typelib
-{
-    class Registry;
-    
-    class Exporter;
-    class ExportPlugin;
+namespace Typelib {
+class Registry;
 
-    class Importer;
-    class ImportPlugin;
+class Exporter;
+class ExportPlugin;
 
-    class TypeDefinitionPlugin;
-    
-    /** Exception thrown when an unknown plugin is found */
-    struct PluginNotFound : std::runtime_error
-    {
-        PluginNotFound() : std::runtime_error("plugin not found") { }
-    };
+class Importer;
+class ImportPlugin;
 
-    /** Generic error for problems during export */
-    struct ExportError : std::runtime_error
-    { 
-        ExportError(std::string const& msg) : std::runtime_error(msg) {}
-    };
+class TypeDefinitionPlugin;
 
-    /** The plugin manager 
-     * 
-     * It is a singleton, using utilmm::singleton
-     * You have to access it using
-     * <code>
-     *  PluginManager::self manager;
-     *
-     *  manager->importer()
-     * </code>
-     *
-     * The object is destroyed when the last of the use<> objects
-     * is, and created back when a new use<> object is built.
+/** Exception thrown when an unknown plugin is found */
+struct PluginNotFound : std::runtime_error {
+    PluginNotFound() : std::runtime_error("plugin not found") {}
+};
+
+/** Generic error for problems during export */
+struct ExportError : std::runtime_error {
+    ExportError(std::string const &msg) : std::runtime_error(msg) {}
+};
+
+/** The plugin manager
+ *
+ * It is a singleton, using utilmm::singleton
+ * You have to access it using
+ * <code>
+ *  PluginManager::self manager;
+ *
+ *  manager->importer()
+ * </code>
+ *
+ * The object is destroyed when the last of the use<> objects
+ * is, and created back when a new use<> object is built.
+ */
+class PluginManager {
+    std::map<std::string, ExportPlugin *> m_exporters;
+    std::map<std::string, ImportPlugin *> m_importers;
+    std::vector<TypeDefinitionPlugin *> m_definition_plugins;
+    std::vector<void *> m_library_handles;
+    bool loadPlugin(std::string const &path);
+
+    typedef void (*PluginEntryPoint)(PluginManager &);
+
+    PluginManager();
+    ~PluginManager();
+
+  public:
+    /** Registers a new exporter */
+    bool add(ExportPlugin *plugin);
+
+    /** Build a new import plugin from its plugin name
+     * @throws PluginNotFound */
+    Importer *importer(std::string const &name) const;
+
+    /** Registers a new importer */
+    bool add(ImportPlugin *plugin);
+
+    /** Build a new export plugin from its plugin name
+     * @throws PluginNotFound */
+    Exporter *exporter(std::string const &name) const;
+
+    /** Adds a type definition plugin. A type definition plugin defines a
+     * set of "default" types that gets added automatically to new
+     * registries
      */
-    class PluginManager
-    {
-        std::map<std::string, ExportPlugin*> m_exporters;
-        std::map<std::string, ImportPlugin*> m_importers;
-        std::vector<TypeDefinitionPlugin*> m_definition_plugins;
-        std::vector<void*> m_library_handles;
-        bool loadPlugin(std::string const& path);
+    void add(TypeDefinitionPlugin *plugin);
 
-        typedef void (*PluginEntryPoint)(PluginManager&);
+    /** Adds the types from the type definition plugins to \c registry
+     */
+    void registerPluginTypes(Registry &registry);
 
-        PluginManager();
-        ~PluginManager();
-        
-    public:
-	/** Registers a new exporter */
-        bool add(ExportPlugin* plugin);
+    /** \overload
+     * This is provided for backward compatibility only
+     */
+    static std::string save(std::string const &kind, Registry const &registry);
 
-	/** Build a new import plugin from its plugin name
-	 * @throws PluginNotFound */
-        Importer* importer(std::string const& name) const;
+    /** \overload
+     */
+    static std::string save(std::string const &kind,
+                            utilmm::config_set const &config,
+                            Registry const &registry);
 
-	/** Registers a new importer */
-        bool add(ImportPlugin* plugin);
+    /** \overload
+     * This is provided for backward compatibility only
+     */
+    static void save(std::string const &kind, Registry const &registry,
+                     std::ostream &into);
 
-	/** Build a new export plugin from its plugin name 
-	 * @throws PluginNotFound */
-        Exporter* exporter(std::string const& name) const;
+    /** Exports a registry to an ostream object
+     * @arg kind	    the output format. It has to be a valid exporter
+     * name
+     * @arg config      format-specific configuration. See each exporter
+     * documentation for details.
+     * @arg registry    the registry to export
+     * @arg into	    the ostream object to export to
+     * @throws PluginNotFound if \c kind is invalid
+     * @throws UnsupportedType if a specific type cannot be exported into this
+     * format
+     * @throws ExportError if another error occured during the export
+     */
+    static void save(std::string const &kind, utilmm::config_set const &config,
+                     Registry const &registry, std::ostream &into);
 
-        /** Adds a type definition plugin. A type definition plugin defines a
-         * set of "default" types that gets added automatically to new
-         * registries
-         */
-        void add(TypeDefinitionPlugin* plugin);
+    /** \overload
+     */
+    static Registry *load(std::string const &kind, std::istream &stream);
 
-        /** Adds the types from the type definition plugins to \c registry
-         */
-        void registerPluginTypes(Registry& registry);
+    /** Imports types from a istream object to an already existing registry
+     */
+    static void load(std::string const &kind, std::istream &stream,
+                     Registry &into);
 
-	/** \overload
-	 * This is provided for backward compatibility only
-	 */
-        static std::string save
-	    ( std::string const& kind
-	    , Registry const& registry);
+    /** Creates a registry from a file
+     * @see Importer::load
+     */
+    static Registry *load(std::string const &kind, std::string const &file);
 
-	/** \overload
-	 */
-        static std::string save
-	    ( std::string const& kind
-	    , utilmm::config_set const& config
-	    , Registry const& registry);
+    /** Imports types from a file into an already existing registry
+     * @see Importer::load
+     */
+    static void load(std::string const &kind, std::string const &file,
+                     Registry &into);
 
-       	/** \overload
-	 * This is provided for backward compatibility only
-	 */
-	static void save
-	    ( std::string const& kind
-	    , Registry const& registry
-	    , std::ostream& into);
+    /** \overload
+     */
+    static Registry *load(std::string const &kind, std::istream &stream,
+                          utilmm::config_set const &config);
 
-       	/** Exports a registry to an ostream object
-	 * @arg kind	    the output format. It has to be a valid exporter name
-	 * @arg config      format-specific configuration. See each exporter documentation for details.
-	 * @arg registry    the registry to export
-	 * @arg into	    the ostream object to export to
-	 * @throws PluginNotFound if \c kind is invalid
-	 * @throws UnsupportedType if a specific type cannot be exported into this format
-	 * @throws ExportError if another error occured during the export
-	 */
-	static void save
-	    ( std::string const& kind
-	    , utilmm::config_set const& config
-	    , Registry const& registry
-	    , std::ostream& into);
+    /** Imports types from a istream object to an already existing registry
+     */
+    static void load(std::string const &kind, std::istream &stream,
+                     utilmm::config_set const &config, Registry &into);
 
-	/** \overload
-	 */
-        static Registry* load
-            ( std::string const& kind
-            , std::istream& stream );
-	
-       	/** Imports types from a istream object to an already existing registry
-	 */
-	static void load
-            ( std::string const& kind
-            , std::istream& stream
-            , Registry& into );
+    /** Creates a registry from a file
+     * @see Importer::load
+     */
+    static Registry *load(std::string const &kind, std::string const &file,
+                          utilmm::config_set const &config);
 
-       	/** Creates a registry from a file
-	 * @see Importer::load
-	 */
-        static Registry* load
-            ( std::string const& kind
-            , std::string const& file );
+    /** Imports types from a file into an already existing registry
+     * @see Importer::load
+     */
+    static void load(std::string const &kind, std::string const &file,
+                     utilmm::config_set const &config, Registry &into);
 
-       	/** Imports types from a file into an already existing registry
-	 * @see Importer::load
-	 */
-        static void load
-            ( std::string const& kind
-            , std::string const& file
-            , Registry& into );
+    /** The one PluginManager object. See main PluginManager documentation
+     * for its use.
+     */
+    typedef utilmm::singleton::use<PluginManager> self;
 
-
-	/** \overload
-	 */
-        static Registry* load
-            ( std::string const& kind
-            , std::istream& stream
-            , utilmm::config_set const& config );
-	
-       	/** Imports types from a istream object to an already existing registry
-	 */
-	static void load
-            ( std::string const& kind
-            , std::istream& stream
-            , utilmm::config_set const& config
-            , Registry& into );
-
-       	/** Creates a registry from a file
-	 * @see Importer::load
-	 */
-        static Registry* load
-            ( std::string const& kind
-            , std::string const& file
-            , utilmm::config_set const& config );
-
-       	/** Imports types from a file into an already existing registry
-	 * @see Importer::load
-	 */
-        static void load
-            ( std::string const& kind
-            , std::string const& file
-            , utilmm::config_set const& config
-            , Registry& into );
-
-	/** The one PluginManager object. See main PluginManager documentation
-	 * for its use.
-	 */
-        typedef utilmm::singleton::use<PluginManager> self;
-
-    private:
-        friend class utilmm::singleton::wrapper<PluginManager>;
-    };
+  private:
+    friend class utilmm::singleton::wrapper<PluginManager>;
+};
 }
 
 #endif
-

--- a/typelib/plugins.hh
+++ b/typelib/plugins.hh
@@ -4,54 +4,45 @@
 #include <boost/type_traits/is_base_and_derived.hpp>
 #include <boost/mpl/if.hpp>
 
-namespace Typelib
-{
-    class ExportPlugin;
-    class ImportPlugin;
-    class Exporter;
-    class Importer;
+namespace Typelib {
+class ExportPlugin;
+class ImportPlugin;
+class Exporter;
+class Importer;
 
-    template<typename Type>
-    struct plugin_traits
-    {
-        typedef typename boost::mpl::if_
-            < boost::is_base_and_derived<Exporter, Type>
-            , ExportPlugin
-            , ImportPlugin >::type   plugin_base;
+template <typename Type> struct plugin_traits {
+    typedef typename boost::mpl::if_<boost::is_base_and_derived<Exporter, Type>,
+                                     ExportPlugin,
+                                     ImportPlugin>::type plugin_base;
 
-        typedef typename boost::mpl::if_
-            < boost::is_base_and_derived<Exporter, Type>
-            , Exporter
-            , Importer >::type   object_base;
-    };
+    typedef typename boost::mpl::if_<boost::is_base_and_derived<Exporter, Type>,
+                                     Exporter, Importer>::type object_base;
+};
 
-    template<typename Type>
-    class GenericIOPlugin 
-        : public plugin_traits<Type>::plugin_base
-    {
-    public:
-        GenericIOPlugin(char const* name)
-            : plugin_traits<Type>::plugin_base(name) {}
-        typename plugin_traits<Type>::object_base* create()
-        { return new Type; }
-    };
+template <typename Type>
+class GenericIOPlugin : public plugin_traits<Type>::plugin_base {
+  public:
+    GenericIOPlugin(char const *name)
+        : plugin_traits<Type>::plugin_base(name) {}
+    typename plugin_traits<Type>::object_base *create() { return new Type; }
+};
 
-    class TypeDefinitionPlugin
-    {
-    public:
-        virtual ~TypeDefinitionPlugin() {}
-        virtual void registerTypes(Typelib::Registry& registry) = 0;
-    };
+class TypeDefinitionPlugin {
+  public:
+    virtual ~TypeDefinitionPlugin() {}
+    virtual void registerTypes(Typelib::Registry &registry) = 0;
+};
 }
 
-#define TYPELIB_REGISTER_IO2(name, klass1, klass2) extern "C" void registerPlugins(Typelib::PluginManager& manager) {\
-    manager.add(new Typelib::GenericIOPlugin<klass1>(#name)); \
-    manager.add(new Typelib::GenericIOPlugin<klass2>(#name)); \
-}
+#define TYPELIB_REGISTER_IO2(name, klass1, klass2)                             \
+    extern "C" void registerPlugins(Typelib::PluginManager &manager) {         \
+        manager.add(new Typelib::GenericIOPlugin<klass1>(#name));              \
+        manager.add(new Typelib::GenericIOPlugin<klass2>(#name));              \
+    }
 
-#define TYPELIB_REGISTER_IO1(name, klass1) extern "C" void registerPlugins(Typelib::PluginManager& manager) {\
-    manager.add(new Typelib::GenericIOPlugin<klass1>(#name)); \
-}
+#define TYPELIB_REGISTER_IO1(name, klass1)                                     \
+    extern "C" void registerPlugins(Typelib::PluginManager &manager) {         \
+        manager.add(new Typelib::GenericIOPlugin<klass1>(#name));              \
+    }
 
 #endif
-

--- a/typelib/registry.cc
+++ b/typelib/registry.cc
@@ -19,20 +19,17 @@ using boost::lexical_cast;
 using namespace Typelib;
 
 /* Returns true if \c name1 is either in a more in-depth namespace than
- * name2 (i.e. name2 == /A/B/class and name1 == /A/B/C/class2 or if 
+ * name2 (i.e. name2 == /A/B/class and name1 == /A/B/C/class2 or if
  * name2 < name1 (lexicographic sort). Otherwise, returns false
  */
-bool Typelib::nameSort( const std::string& name1, const std::string& name2 )
-{
-    for (size_t i = 0; i < name1.length(); ++i)
-    {
+bool Typelib::nameSort(const std::string &name1, const std::string &name2) {
+    for (size_t i = 0; i < name1.length(); ++i) {
         if (name2.length() <= i)
             return false;
 
         std::string::const_reference c1 = name1[i];
         std::string::const_reference c2 = name2[i];
-        if (c1 != c2)
-        {
+        if (c1 != c2) {
             if (c1 == '/')
                 return true;
             if (c2 == '/')
@@ -43,628 +40,581 @@ bool Typelib::nameSort( const std::string& name1, const std::string& name2 )
     return (name1.length() < name2.length());
 }
 
-namespace Typelib
-{
-    Type const& Registry::null() { 
-        static NullType const null_type("/nil");
-        return null_type; 
+namespace Typelib {
+Type const &Registry::null() {
+    static NullType const null_type("/nil");
+    return null_type;
+}
+
+Registry::Registry() : m_global(nameSort) {
+    PluginManager::self manager;
+    manager->registerPluginTypes(*this);
+    setDefaultNamespace("/");
+}
+Registry::~Registry() { clear(); }
+
+void Registry::updateCurrentNameMap() {
+    m_current.clear();
+
+    for (TypeMap::iterator it = m_global.begin(); it != m_global.end(); ++it)
+        m_current.insert(make_pair(it->first, it->second));
+
+    importNamespace(NamespaceMarkString);
+    std::string cur_space = NamespaceMarkString;
+    NameTokenizer tokens(m_namespace);
+    NameTokenizer::const_iterator ns_it = tokens.begin();
+    for (; ns_it != tokens.end(); ++ns_it) {
+        cur_space += *ns_it + NamespaceMarkString;
+        importNamespace(cur_space, true);
     }
-    
-    Registry::Registry()
-        : m_global(nameSort)
-    { 
-        PluginManager::self manager;
-        manager->registerPluginTypes(*this);
-        setDefaultNamespace("/");
+}
+
+std::string Registry::getDefaultNamespace() const { return m_namespace; }
+bool Registry::setDefaultNamespace(const std::string &space) {
+    if (!isValidNamespace(space, true))
+        return false;
+
+    m_namespace = getNormalizedNamespace(space);
+    updateCurrentNameMap();
+    return true;
+}
+
+void Registry::importNamespace(const std::string &name, bool erase_existing) {
+    const std::string norm_name(getNormalizedNamespace(name));
+    const int norm_length(norm_name.length());
+
+    TypeMap::const_iterator it = m_global.lower_bound(norm_name);
+
+    while (it != m_global.end() && isInNamespace(it->first, norm_name, true)) {
+        const std::string rel_name(it->first, norm_length, string::npos);
+        if (erase_existing)
+            m_current.erase(rel_name);
+        m_current.insert(make_pair(rel_name, it->second));
+        ++it;
     }
-    Registry::~Registry() { clear(); }
+}
 
-    void Registry::updateCurrentNameMap()
-    {
-	m_current.clear();
+std::string Registry::getFullName(const std::string &name) const {
+    if (isAbsoluteName(name))
+        return name;
+    return m_namespace + name;
+}
 
-        for (TypeMap::iterator it = m_global.begin(); it != m_global.end(); ++it)
-            m_current.insert( make_pair(it->first, it->second) );
+namespace {
+template <typename T> Numeric *make_std_numeric(char const *name) {
+    typedef numeric_limits<T> limits;
+    Numeric::NumericCategory category =
+        limits::is_signed ? Numeric::SInt : Numeric::UInt;
+    unsigned int size = (limits::digits + 1) / 8;
+    return new Numeric(name, size, category);
+}
+}
 
-        importNamespace(NamespaceMarkString);
-        std::string cur_space = NamespaceMarkString;
-        NameTokenizer tokens( m_namespace );
-        NameTokenizer::const_iterator ns_it = tokens.begin();
-        for (; ns_it != tokens.end(); ++ns_it)
-        {
-            cur_space += *ns_it + NamespaceMarkString;
-            importNamespace(cur_space, true);
+/** Returns true if +type+ is a type included in this registry */
+bool Registry::isIncluded(Type const &type) const {
+    Type const *this_type = get(type.getName());
+    return (this_type == &type);
+}
+
+void Registry::merge(Registry const &registry) {
+    Typelib::Type::RecursionStack stack;
+
+    // Merge non aliased types. Aliases are never used by type model classes
+    // so we can safely call merge()
+    for (Iterator it = registry.begin(); it != registry.end(); ++it) {
+        if (it.isAlias())
+            continue;
+        it->merge(*this, stack);
+    }
+
+    for (Iterator it = registry.begin(); it != registry.end(); ++it) {
+        // Either the alias already points to a concrete type, and
+        // we must check that it is the same concrete type, or
+        // we have to add the alias
+        if (!it.isAlias())
+            continue;
+
+        Type const *old_type = get(it.getName());
+        if (old_type) {
+            if (!old_type->isSame(*it))
+                throw DefinitionMismatch(it.getName());
+        } else {
+            // we are sure the concrete type we are pointing to is
+            // already in the target registry
+            alias(it->getName(), it.getName(), it.isPersistent(),
+                  it.getSource());
+        }
+    }
+    copySourceIDs(registry);
+    mergeMetaData(registry);
+}
+
+void Registry::mergeMetaData(Registry const &registry) {
+    for (Iterator other_it = registry.begin(); other_it != registry.end();
+         ++other_it) {
+        RegistryIterator it = find(other_it.getName());
+        if (it == end())
+            continue;
+        it->mergeMetaData(*other_it);
+    }
+}
+
+void Registry::copySourceIDs(Registry const &registry) {
+    for (Iterator other_it = registry.begin(); other_it != registry.end();
+         ++other_it) {
+        RegistryIterator it = find(other_it.getName());
+        if (it == end())
+            continue;
+
+        string source_id = other_it.getSource();
+        if (!source_id.empty() && it.getSource().empty())
+            setSourceID(*it, source_id);
+    }
+}
+
+Registry *Registry::minimal(std::string const &name, bool with_aliases) const {
+    auto_ptr<Registry> result(new Registry);
+    Type const *type = get(name);
+    if (!type)
+        throw std::runtime_error("there is not type '" + name +
+                                 "' in this registry");
+
+    type->merge(*result);
+
+    // Copy now the aliases
+    if (with_aliases) {
+        for (Iterator it = begin(); it != end(); ++it) {
+            if (!it.isAlias())
+                continue;
+            if (result->has(it->getName(), false))
+                result->alias(it->getName(), it.getName());
         }
     }
 
-    std::string Registry::getDefaultNamespace() const { return m_namespace; }
-    bool Registry::setDefaultNamespace(const std::string& space)
-    {
-        if (! isValidNamespace(space, true))
-            return false;
+    result->copySourceIDs(*this);
+    result->mergeMetaData(*this);
+    return result.release();
+}
 
-        m_namespace = getNormalizedNamespace(space);
-        updateCurrentNameMap();
+Registry *Registry::minimal(Registry const &auto_types) const {
+    auto_ptr<Registry> result(new Registry);
+
+    // Merge non aliased types. Aliases are never used by type model classes
+    // so we can safely call merge()
+    for (Iterator it = begin(); it != end(); ++it) {
+        if (it.isAlias())
+            continue;
+        if (!auto_types.has(it->getName()))
+            it->merge(*result);
+    }
+
+    for (Iterator it = begin(); it != end(); ++it) {
+        // Either the alias already points to a concrete type, and
+        // we must check that it is the same concrete type, or
+        // we have to add the alias
+        if (!it.isAlias())
+            continue;
+        if (auto_types.has(it.getName()))
+            continue;
+        // Do not continue if it is a typedef on a type that we don't need
+        if (!result->has(it->getName(), false))
+            continue;
+
+        Type const *old_type = result->get(it.getName());
+        if (old_type) {
+            if (!old_type->isSame(*it))
+                throw DefinitionMismatch(it.getName());
+        } else {
+            result->alias(it->getName(), it.getName(), it.isPersistent(),
+                          it.getSource());
+        }
+    }
+
+    return result.release();
+}
+
+bool Registry::has(const std::string &name, bool build_if_missing) const {
+    if (m_current.find(name) != m_current.end())
         return true;
-    }
 
-    void Registry::importNamespace(const std::string& name, bool erase_existing)
-    {
-        const std::string norm_name(getNormalizedNamespace(name));
-        const int         norm_length(norm_name.length());
-            
-        TypeMap::const_iterator it = m_global.lower_bound(norm_name);
+    if (!build_if_missing)
+        return false;
 
-        while ( it != m_global.end() && isInNamespace(it->first, norm_name, true) )
-        {
-            const std::string rel_name(it->first, norm_length, string::npos);
-	    if (erase_existing)
-		m_current.erase(rel_name);
-            m_current.insert( make_pair(rel_name, it->second) );
-            ++it;
-        }
-    }
+    const Type *base_type = TypeBuilder::getBaseType(*this, getFullName(name));
+    return base_type;
+}
 
-    std::string Registry::getFullName(const std::string& name) const
-    {
-        if (isAbsoluteName(name))
-            return name;
-        return m_namespace + name;
-    }
+const Type *Registry::build(const std::string &name, std::size_t size) {
+    const Type *type = get(name);
+    if (type)
+        return type;
 
-    namespace {
-        template<typename T>
-        Numeric* make_std_numeric(char const* name)
-        {
-            typedef numeric_limits<T>   limits;
-            Numeric::NumericCategory category = limits::is_signed ? Numeric::SInt : Numeric::UInt;
-            unsigned int size = (limits::digits + 1) / 8;
-            return new Numeric(name, size, category);
-        }
-    }
+    return TypeBuilder::build(*this, getFullName(name), size);
+}
 
-    /** Returns true if +type+ is a type included in this registry */
-    bool Registry::isIncluded(Type const& type) const
-    {
-        Type const* this_type = get(type.getName());
-        return (this_type == &type);
-    }
+Type *Registry::get_(const std::string &name) {
+    NameMap::const_iterator it = m_current.find(name);
+    if (it != m_current.end())
+        return it->second.type;
+    return 0;
+}
 
-    void Registry::merge(Registry const& registry)
-    {
-        Typelib::Type::RecursionStack stack;
+Type &Registry::get_(Type const &type) {
+    Type *pType = get_(type.getName());
+    if (!pType)
+        throw Undefined(type.getName());
+    return *pType;
+}
 
-	// Merge non aliased types. Aliases are never used by type model classes
-	// so we can safely call merge()
-	for(Iterator it = registry.begin(); it != registry.end(); ++it)
-	{
-	    if (it.isAlias()) continue;
-	    it->merge(*this, stack);
-	}
+const Type *Registry::get(const std::string &name) const {
+    NameMap::const_iterator it = m_current.find(name);
+    if (it != m_current.end())
+        return it->second.type;
+    return 0;
+}
 
-	for (Iterator it = registry.begin(); it != registry.end(); ++it)
-	{
-	    // Either the alias already points to a concrete type, and
-	    // we must check that it is the same concrete type, or
-	    // we have to add the alias
-	    if (!it.isAlias()) continue;
+RegistryIterator Registry::find(std::string const &name) const {
+    TypeMap::const_iterator global_it = m_global.find(name);
+    return RegistryIterator(*this, global_it);
+}
 
-	    Type const* old_type = get(it.getName());
-	    if (old_type)
-	    {
-		if (!old_type->isSame(*it))
-		    throw DefinitionMismatch(it.getName());
-	    }
-	    else
-	    {
-		// we are sure the concrete type we are pointing to is 
-		// already in the target registry
-		alias(it->getName(), it.getName(), it.isPersistent(), it.getSource());
-	    }
-	}
-        copySourceIDs(registry);
-        mergeMetaData(registry);
-    }
+bool Registry::isPersistent(std::string const &name, Type const &type,
+                            std::string const &source_id) {
+    if (name != type.getName())
+        return true;
 
-    void Registry::mergeMetaData(Registry const& registry)
-    {
-        for (Iterator other_it = registry.begin(); other_it != registry.end(); ++other_it)
-        {
-            RegistryIterator it = find(other_it.getName());
-            if (it == end())
-                continue;
-            it->mergeMetaData(*other_it);
-        }
-    }
+    switch (type.getCategory()) {
+    case Type::Pointer:
+    case Type::Array:
+        return false;
+    default:
+        return true;
+    };
+}
 
-    void Registry::copySourceIDs(Registry const& registry)
-    {
-        for (Iterator other_it = registry.begin(); other_it != registry.end(); ++other_it)
-        {
-            RegistryIterator it = find(other_it.getName());
-            if (it == end())
-                continue;
+void Registry::add(std::string const &name, Type *new_type, bool persistent,
+                   std::string const &source_id) {
+    if (!isValidTypename(name, true))
+        throw BadName(name);
 
-            string source_id = other_it.getSource();
-            if (!source_id.empty() && it.getSource().empty())
-                setSourceID(*it, source_id);
-        }
-    }
+    const Type *old_type = get(name);
+    if (old_type == new_type)
+        return;
+    else if (old_type)
+        throw AlreadyDefined(name);
 
-    Registry* Registry::minimal(std::string const& name, bool with_aliases) const
-    {
-        auto_ptr<Registry> result(new Registry);
-        Type const* type = get(name);
-        if (!type)
-            throw std::runtime_error("there is not type '" + name + "' in this registry");
+    RegistryType regtype = {new_type, persistent, source_id};
 
-        type->merge(*result);
+    m_global.insert(make_pair(name, regtype));
+    m_current.insert(make_pair(name, regtype));
 
-        // Copy now the aliases
-        if (with_aliases)
-        {
-            for(Iterator it = begin(); it != end(); ++it)
-            {
-                if (!it.isAlias()) continue;
-                if (result->has(it->getName(), false))
-                    result->alias(it->getName(), it.getName());
-            }
+    NameTokenizer tokens(m_namespace);
+    NameTokenizer::const_iterator ns_it = tokens.begin();
+    std::string cur_space = NamespaceMarkString;
+    while (true) {
+        if (name.size() <= cur_space.size() ||
+            string(name, 0, cur_space.size()) != cur_space)
+            break;
+
+        string cur_name = getRelativeName(name, cur_space);
+
+        // Check if there is already a type with the same relative name
+        TypeMap::iterator it = m_current.find(cur_name);
+        if (it == m_current.end() ||
+            !nameSort(it->second.type->getName(), name)) {
+            m_current.erase(cur_name);
+            m_current.insert(make_pair(cur_name, regtype));
         }
 
-        result->copySourceIDs(*this);
-        result->mergeMetaData(*this);
-        return result.release();
+        if (ns_it == tokens.end())
+            break;
+        cur_space += *ns_it + NamespaceMarkString;
+        ++ns_it;
     }
+}
 
-    Registry* Registry::minimal(Registry const& auto_types) const
-    {
-        auto_ptr<Registry> result(new Registry);
- 
-	// Merge non aliased types. Aliases are never used by type model classes
-	// so we can safely call merge()
-	for(Iterator it = begin(); it != end(); ++it)
-	{
-	    if (it.isAlias()) continue;
-            if (!auto_types.has(it->getName()))
-                it->merge(*result);
-	}
+void Registry::add(Type *new_type, const std::string &source_id) {
+    return add(new_type,
+               isPersistent(new_type->getName(), *new_type, source_id),
+               source_id);
+}
 
-	for (Iterator it = begin(); it != end(); ++it)
-	{
-	    // Either the alias already points to a concrete type, and
-	    // we must check that it is the same concrete type, or
-	    // we have to add the alias
-	    if (!it.isAlias()) continue;
-            if (auto_types.has(it.getName())) continue;
-            // Do not continue if it is a typedef on a type that we don't need
-            if (!result->has(it->getName(), false)) continue;
+void Registry::add(Type *new_type, bool persistent,
+                   const std::string &source_id) {
+    add(new_type->getName(), new_type, persistent, source_id);
 
-	    Type const* old_type = result->get(it.getName());
-	    if (old_type)
-	    {
-		if (!old_type->isSame(*it))
-		    throw DefinitionMismatch(it.getName());
-	    }
-	    else
-	    {
-		result->alias(it->getName(), it.getName(), it.isPersistent(), it.getSource());
-	    }
-	}
-
-        return result.release();
-    }
-
-    bool Registry::has(const std::string& name, bool build_if_missing) const
-    {
-        if (m_current.find(name) != m_current.end())
-            return true;
-
-        if (! build_if_missing)
-            return false;
-
-        const Type* base_type = TypeBuilder::getBaseType(*this, getFullName(name));
-        return base_type;
-    }
-
-    const Type* Registry::build(const std::string& name, std::size_t size)
-    {
-        const Type* type = get(name);
-        if (type)
-            return type;
-
-        return TypeBuilder::build(*this, getFullName(name), size);
-    }
-
-    Type* Registry::get_(const std::string& name)
-    {
-        NameMap::const_iterator it = m_current.find(name);
-        if (it != m_current.end()) 
-            return it->second.type;
-        return 0;
-    }
-
-    Type& Registry::get_(Type const& type)
-    {
-        Type* pType = get_(type.getName());
-        if (!pType)
-            throw Undefined(type.getName());
-        return *pType;
-    }
-
-    const Type* Registry::get(const std::string& name) const
-    {
-        NameMap::const_iterator it = m_current.find(name);
-        if (it != m_current.end()) 
-            return it->second.type;
-        return 0;
-    }
-
-    RegistryIterator Registry::find(std::string const& name) const
-    {
-        TypeMap::const_iterator global_it =
-            m_global.find(name);
-        return RegistryIterator(*this, global_it);
-    }
-
-    bool Registry::isPersistent(std::string const& name, Type const& type, std::string const& source_id)
-    {
-        if (name != type.getName())
-            return true;
-
-        switch(type.getCategory())
-        {
-            case Type::Pointer:
-            case Type::Array:
-                return false;
-            default:
-                return true;
-        };
-    }
-
-    void Registry::add(std::string const& name, Type* new_type, bool persistent, std::string const& source_id)
-    {
-        if (! isValidTypename(name, true))
-            throw BadName(name);
-
-        const Type* old_type = get(name);
-        if (old_type == new_type) 
-            return; 
-        else if (old_type)
-            throw AlreadyDefined(name);
-
-        RegistryType regtype = 
-            { new_type
-            , persistent
-            , source_id };
-            
-        m_global.insert (make_pair(name, regtype));
-        m_current.insert(make_pair(name, regtype));
-
-        NameTokenizer tokens( m_namespace );
-        NameTokenizer::const_iterator ns_it = tokens.begin();
-        std::string cur_space = NamespaceMarkString;
-	while(true)
-        {
-            if (name.size() <= cur_space.size() || string(name, 0, cur_space.size()) != cur_space)
-                break;
-
-	    string cur_name  = getRelativeName(name, cur_space);
-
-	    // Check if there is already a type with the same relative name
-	    TypeMap::iterator it = m_current.find(cur_name);
-	    if (it == m_current.end() || !nameSort(it->second.type->getName(), name))
-	    {
-		m_current.erase(cur_name);
-		m_current.insert(make_pair(cur_name, regtype));
-	    }
-
-	    if (ns_it == tokens.end())
-		break;
-            cur_space += *ns_it + NamespaceMarkString;
-	    ++ns_it;
+    // If there are any aliases for any of the type's dependencies, trigger
+    // modifiedDependencyAliases()
+    set<Type const *> dependencies = new_type->dependsOn();
+    for (set<Type const *>::const_iterator dep_it = dependencies.begin();
+         dep_it != dependencies.end(); ++dep_it) {
+        if (!getAliasesOf(**dep_it).empty()) {
+            new_type->modifiedDependencyAliases(*this);
+            break;
         }
     }
+}
 
-    void Registry::add(Type* new_type, const std::string& source_id)
-    {
-        return add(new_type, isPersistent(new_type->getName(), *new_type, source_id), source_id);
+void Registry::alias(std::string const &base, std::string const &newname,
+                     std::string const &source_id) {
+    Type *base_type = get_(base);
+    if (!base_type)
+        throw Undefined(base);
+
+    return alias(base, newname, isPersistent(newname, *base_type, source_id),
+                 source_id);
+}
+
+void Registry::alias(std::string const &base, std::string const &newname,
+                     bool persistent, std::string const &source_id) {
+    if (!isValidTypename(newname, true))
+        throw BadName(newname);
+
+    Type *base_type = get_(base);
+    if (!base_type)
+        throw Undefined(base);
+
+    add(newname, base_type, persistent, source_id);
+
+    // If base_type is in use in any type, trigger
+    // modifiedDependencyAliases() on it
+    //
+    // We do it in two stages as modifying a container while iterating on it
+    // is evil ...
+    std::list<Type const *> triggers;
+    RegistryIterator const end = this->end();
+    for (RegistryIterator it = begin(); it != end; ++it) {
+        if (it.isAlias())
+            continue;
+        set<Type const *> dependencies = it->dependsOn();
+        if (dependencies.count(base_type))
+            triggers.push_back(&(*it));
     }
 
-    void Registry::add(Type* new_type, bool persistent, const std::string& source_id)
-    {
-        add(new_type->getName(), new_type, persistent, source_id);
+    for (list<Type const *>::const_iterator trigger_it = triggers.begin();
+         trigger_it != triggers.end(); ++trigger_it) {
+        (*trigger_it)->modifiedDependencyAliases(*this);
+    }
+}
 
-        // If there are any aliases for any of the type's dependencies, trigger
-        // modifiedDependencyAliases()
-	set<Type const*> dependencies = new_type->dependsOn();
-        for (set<Type const*>::const_iterator dep_it = dependencies.begin();
-                dep_it != dependencies.end(); ++dep_it)
-        {
-            if (!getAliasesOf(**dep_it).empty())
-            {
-                new_type->modifiedDependencyAliases(*this);
-                break;
-            }
-        }
+void Registry::clearAliases() {
+    // We remove the aliases from +m_global+ and recompute m_current from
+    // scratch
+    TypeMap::iterator global_it = m_global.begin(), global_end = m_global.end();
+    while (global_it != global_end) {
+        if (global_it->first != global_it->second.type->getName())
+            m_global.erase(global_it++);
+        else
+            ++global_it;
     }
 
-    void Registry::alias(std::string const& base, std::string const& newname, std::string const& source_id)
-    {
-        Type* base_type = get_(base);
-        if (! base_type) 
-            throw Undefined(base);
+    updateCurrentNameMap();
+}
 
-        return alias(base, newname, isPersistent(newname, *base_type, source_id), source_id);
+size_t Registry::size() const { return m_global.size(); }
+void Registry::clear() {
+    // Set the type pointer to 0 on aliases
+    for (TypeMap::iterator it = m_global.begin(); it != m_global.end(); ++it) {
+        if (it->first != it->second.type->getName())
+            it->second.type = 0;
     }
 
-    void Registry::alias(std::string const& base, std::string const& newname, bool persistent, std::string const& source_id)
-    {
-        if (! isValidTypename(newname, true))
-            throw BadName(newname);
+    // ... then delete the objects
+    for (TypeMap::iterator it = m_global.begin(); it != m_global.end(); ++it)
+        delete it->second.type;
 
-        Type* base_type = get_(base);
-        if (! base_type) 
-            throw Undefined(base);
+    m_global.clear();
+    m_current.clear();
+}
 
-        add(newname, base_type, persistent, source_id);
+namespace {
+bool filter_source(std::string const &filter, std::string const &source) {
+    if (filter == "*")
+        return true;
+    return filter == source;
+}
+}
 
-        // If base_type is in use in any type, trigger
-        // modifiedDependencyAliases() on it
-        //
-        // We do it in two stages as modifying a container while iterating on it
-        // is evil ...
-        std::list<Type const*> triggers;
-        RegistryIterator const end = this->end();
-        for (RegistryIterator it = begin(); it != end; ++it)
-        {
-            if (it.isAlias()) continue;
-            set<Type const*> dependencies = it->dependsOn();
-            if (dependencies.count(base_type))
-                triggers.push_back(&(*it));
-        }
+void Registry::dump(std::ostream &stream, int mode,
+                    const std::string &source_filter) const {
+    stream << "Types in registry";
+    if (source_filter == "")
+        stream << " not defined in any type library";
+    else if (source_filter != "*")
+        stream << " defined in " << source_filter;
+    stream << endl;
 
-        for (list<Type const*>::const_iterator trigger_it = triggers.begin();
-                trigger_it != triggers.end(); ++trigger_it)
-        {
-            (*trigger_it)->modifiedDependencyAliases(*this);
-        }
-    }
+    TypeDisplayVisitor display(stream, "");
+    for (TypeMap::const_iterator it = m_global.begin(); it != m_global.end();
+         ++it) {
+        RegistryType regtype(it->second);
+        if (!regtype.persistent)
+            continue;
+        if (!filter_source(source_filter, regtype.source_id))
+            continue;
 
-    void Registry::clearAliases()
-    {
-        // We remove the aliases from +m_global+ and recompute m_current from
-        // scratch
-        TypeMap::iterator global_it = m_global.begin(), global_end = m_global.end();
-        while (global_it != global_end)
-        {
-            if (global_it->first != global_it->second.type->getName())
-                m_global.erase(global_it++);
-            else ++global_it;
-        }
-
-        updateCurrentNameMap();
-    }
-
-    size_t Registry::size() const { return m_global.size(); }
-    void Registry::clear()
-    {
-	// Set the type pointer to 0 on aliases
-	for (TypeMap::iterator it = m_global.begin(); it != m_global.end(); ++it)
-	{
-	    if (it->first != it->second.type->getName())
-		it->second.type = 0;
-	}
-	    
-	// ... then delete the objects
-        for (TypeMap::iterator it = m_global.begin(); it != m_global.end(); ++it)
-            delete it->second.type;
-            
-        m_global.clear();
-        m_current.clear();
-    }
-
-    namespace
-    {
-        bool filter_source(std::string const& filter, std::string const& source)
-        {
-            if (filter == "*")
-                return true;
-            return filter == source;
-        }
-    }
-
-    void Registry::dump(std::ostream& stream, int mode, const std::string& source_filter) const
-    {
-        stream << "Types in registry";
-        if (source_filter == "")
-            stream << " not defined in any type library";
-        else if (source_filter != "*")
-            stream << " defined in " << source_filter;
-        stream << endl;
-
-        TypeDisplayVisitor display(stream, "");
-        for (TypeMap::const_iterator it = m_global.begin(); it != m_global.end(); ++it)
-        {
-            RegistryType regtype(it->second);
-            if (! regtype.persistent)
-                continue;
-            if (!filter_source(source_filter, regtype.source_id))
-                continue;
-
-            if (mode & WithSourceId)
-            {
-                string it_source_id = regtype.source_id;
-                if (it_source_id.empty()) stream << "\t\t";
-                else stream << it_source_id << "\t";
-            }
-
-            Type const* type = regtype.type;
-            if (mode & AllType)
-            {
-                if (type->getName() == it->first)
-                {
-                    display.apply(*type);
-                    stream << "\n";
-                }
-                else
-                    stream << it->first << " is an alias for " << type->getName() << "\n";
-            }
+        if (mode & WithSourceId) {
+            string it_source_id = regtype.source_id;
+            if (it_source_id.empty())
+                stream << "\t\t";
             else
-                stream << "\t" << type->getName() << endl;
+                stream << it_source_id << "\t";
         }
-    }
 
-    RegistryIterator Registry::begin() const { return RegistryIterator(*this, m_global.begin()); }
-    RegistryIterator Registry::end() const { return RegistryIterator(*this, m_global.end()); }
-    RegistryIterator Registry::begin(std::string const& prefix) const
-    {
-        RegistryIterator it(*this, m_global.lower_bound(prefix));
-        RegistryIterator const end = this->end();
-        if (it != end && it.getName().compare(0, prefix.length(), prefix) == 0)
-            return it;
-        else return end;
+        Type const *type = regtype.type;
+        if (mode & AllType) {
+            if (type->getName() == it->first) {
+                display.apply(*type);
+                stream << "\n";
+            } else
+                stream << it->first << " is an alias for " << type->getName()
+                       << "\n";
+        } else
+            stream << "\t" << type->getName() << endl;
     }
-    RegistryIterator Registry::end(std::string const& prefix) const
-    {
-        RegistryIterator it(begin(prefix));
-        RegistryIterator const end = this->end();
-        while (it != end && it.getName().compare(0, prefix.length(), prefix) == 0)
-            ++it;
+}
 
+RegistryIterator Registry::begin() const {
+    return RegistryIterator(*this, m_global.begin());
+}
+RegistryIterator Registry::end() const {
+    return RegistryIterator(*this, m_global.end());
+}
+RegistryIterator Registry::begin(std::string const &prefix) const {
+    RegistryIterator it(*this, m_global.lower_bound(prefix));
+    RegistryIterator const end = this->end();
+    if (it != end && it.getName().compare(0, prefix.length(), prefix) == 0)
         return it;
-    }
+    else
+        return end;
+}
+RegistryIterator Registry::end(std::string const &prefix) const {
+    RegistryIterator it(begin(prefix));
+    RegistryIterator const end = this->end();
+    while (it != end && it.getName().compare(0, prefix.length(), prefix) == 0)
+        ++it;
 
-    bool Registry::isSame(Registry const& other) const
-    {
-        if (m_global.size() != other.m_global.size())
+    return it;
+}
+
+bool Registry::isSame(Registry const &other) const {
+    if (m_global.size() != other.m_global.size())
+        return false;
+
+    TypeMap::const_iterator left_it = m_global.begin(),
+                            left_end = m_global.end(),
+                            right_it = other.m_global.begin();
+
+    while (left_it != left_end) {
+        if (!left_it->second.type->isSame(*right_it->second.type))
             return false;
+        left_it++;
+        left_end++;
+    }
+    return true;
+}
 
-        TypeMap::const_iterator
-            left_it   = m_global.begin(),
-            left_end  = m_global.end(),
-            right_it  = other.m_global.begin();
-
-        while (left_it != left_end)
-        {
-            if (!left_it->second.type->isSame(*right_it->second.type))
-                return false;
-            left_it++; left_end++;
-        }
-        return true;
+void Registry::resize(std::map<std::string, size_t> const &new_sizes) {
+    typedef std::map<std::string, std::pair<size_t, size_t> > SizeMap;
+    // First, do a copy of new_sizes for our own use. Most importantly, we
+    // resolve aliases
+    SizeMap sizes;
+    for (std::map<std::string, size_t>::const_iterator it = new_sizes.begin();
+         it != new_sizes.end(); ++it) {
+        Type &t = *get_(it->first);
+        sizes.insert(
+            make_pair(t.getName(), make_pair(t.getSize(), it->second)));
+        t.setSize(it->second);
     }
 
-    void Registry::resize(std::map<std::string, size_t> const& new_sizes)
-    {
-        typedef std::map<std::string, std::pair<size_t, size_t> > SizeMap;
-        // First, do a copy of new_sizes for our own use. Most importantly, we
-        // resolve aliases
-        SizeMap sizes;
-        for (std::map<std::string, size_t>::const_iterator it = new_sizes.begin();
-                it != new_sizes.end(); ++it)
-        {
-            Type& t = *get_(it->first);
-            sizes.insert(make_pair(t.getName(),
-                        make_pair(t.getSize(), it->second)
-                        ));
-            t.setSize(it->second);
-        }
-
-	for(Iterator it = begin(); it != end(); ++it)
-	{
-	    if (it.isAlias()) continue;
-	    it.get_().resize(*this, sizes);
-	}
+    for (Iterator it = begin(); it != end(); ++it) {
+        if (it.isAlias())
+            continue;
+        it.get_().resize(*this, sizes);
     }
+}
 
-    std::set<Type const*> Registry::reverseDepends(Type const& type) const
-    {
-        typedef std::set<Type const*> TypeSet;
-        TypeSet result, queue, new_queue;
-        queue.insert(&type);
+std::set<Type const *> Registry::reverseDepends(Type const &type) const {
+    typedef std::set<Type const *> TypeSet;
+    TypeSet result, queue, new_queue;
+    queue.insert(&type);
 
-        while (!queue.empty())
-        {
-            RegistryIterator const end = this->end();
-            for (RegistryIterator it = this->begin(); it != end; ++it)
-            {
-                Type const& t = *it;
-                if (it.isAlias()) continue;
-                if (result.count(&t) || queue.count(&t)) continue;
+    while (!queue.empty()) {
+        RegistryIterator const end = this->end();
+        for (RegistryIterator it = this->begin(); it != end; ++it) {
+            Type const &t = *it;
+            if (it.isAlias())
+                continue;
+            if (result.count(&t) || queue.count(&t))
+                continue;
 
-                std::set<Type const*> dependencies = t.dependsOn();
-                for (TypeSet::const_iterator it = queue.begin(); it != queue.end(); ++it)
-                {
-                    if (dependencies.count(*it))
-                    {
-                        new_queue.insert(&t);
-                        break;
-                    }
+            std::set<Type const *> dependencies = t.dependsOn();
+            for (TypeSet::const_iterator it = queue.begin(); it != queue.end();
+                 ++it) {
+                if (dependencies.count(*it)) {
+                    new_queue.insert(&t);
+                    break;
                 }
             }
-            result.insert(queue.begin(), queue.end());
-            queue.swap(new_queue);
-            new_queue.clear();
         }
-
-        return result;
+        result.insert(queue.begin(), queue.end());
+        queue.swap(new_queue);
+        new_queue.clear();
     }
 
-    std::set<Type*> Registry::reverseDepends(Type const& type)
-    {
-        std::set<Type*> result;
+    return result;
+}
 
-        std::set<Type const*> const_result =
-            static_cast<Registry const*>(this)->reverseDepends(type);
-        std::set<Type const*>::const_iterator it, end;
-        for (it = const_result.begin(); it != const_result.end(); ++it)
-            result.insert(const_cast<Type*>(*it));
+std::set<Type *> Registry::reverseDepends(Type const &type) {
+    std::set<Type *> result;
 
-        return result;
+    std::set<Type const *> const_result =
+        static_cast<Registry const *>(this)->reverseDepends(type);
+    std::set<Type const *>::const_iterator it, end;
+    for (it = const_result.begin(); it != const_result.end(); ++it)
+        result.insert(const_cast<Type *>(*it));
+
+    return result;
+}
+
+std::set<Type *> Registry::remove(Type const &type) {
+    std::set<Type *> types = reverseDepends(type);
+
+    TypeMap::iterator global_it = m_global.begin(), global_end = m_global.end();
+    while (global_it != global_end) {
+        if (types.count(global_it->second.type))
+            m_global.erase(global_it++);
+        else
+            ++global_it;
     }
 
-    std::set<Type *> Registry::remove(Type const& type)
-    {
-        std::set<Type*> types = reverseDepends(type);
-
-        TypeMap::iterator global_it = m_global.begin(), global_end = m_global.end();
-        while (global_it != global_end)
-        {
-            if (types.count(global_it->second.type))
-                m_global.erase(global_it++);
-            else ++global_it;
-        }
-
-        NameMap::iterator current_it = m_current.begin(), current_end = m_current.end();
-        while (current_it != current_end)
-        {
-            if (types.count(current_it->second.type))
-                m_current.erase(current_it++);
-            else ++current_it;
-        }
-
-        return types;
+    NameMap::iterator current_it = m_current.begin(),
+                      current_end = m_current.end();
+    while (current_it != current_end) {
+        if (types.count(current_it->second.type))
+            m_current.erase(current_it++);
+        else
+            ++current_it;
     }
 
-    std::set<std::string> Registry::getAliasesOf(Type const& type) const
-    {
-        set<string> result;
-        RegistryIterator const end = this->end();
-        for (RegistryIterator it = begin(); it != end; ++it)
-        {
-            if (it.isAlias() && *it == type)
-                result.insert(it.getName());
-        }
-        return result;
-    }
+    return types;
+}
 
-    void Registry::setSourceID(Type const& type, std::string const& source_id)
-    {
-        TypeMap::iterator it = m_global.find(type.getName());
-        if (it != m_global.end())
-        {
-            it->second.source_id = source_id;
-            type.getMetaData().set("source_id", source_id);
-        }
+std::set<std::string> Registry::getAliasesOf(Type const &type) const {
+    set<string> result;
+    RegistryIterator const end = this->end();
+    for (RegistryIterator it = begin(); it != end; ++it) {
+        if (it.isAlias() && *it == type)
+            result.insert(it.getName());
     }
+    return result;
+}
+
+void Registry::setSourceID(Type const &type, std::string const &source_id) {
+    TypeMap::iterator it = m_global.find(type.getName());
+    if (it != m_global.end()) {
+        it->second.source_id = source_id;
+        type.getMetaData().set("source_id", source_id);
+    }
+}
 }; // namespace Typelib
-

--- a/typelib/registry.hh
+++ b/typelib/registry.hh
@@ -5,315 +5,310 @@
 #include <boost/shared_ptr.hpp>
 #include <stdexcept>
 
-namespace Typelib
-{
-    class RegistryIterator;
-    
-    /** Base for exceptions thrown by the registry */
-    class RegistryException : public std::runtime_error 
-    { 
-    public:
-        RegistryException(std::string const& what) : std::runtime_error(what) {}
+namespace Typelib {
+class RegistryIterator;
+
+/** Base for exceptions thrown by the registry */
+class RegistryException : public std::runtime_error {
+  public:
+    RegistryException(std::string const &what) : std::runtime_error(what) {}
+};
+
+/** A type has not been found while it was expected */
+class Undefined : public RegistryException {
+    std::string m_name;
+
+  public:
+    Undefined(const std::string &name)
+        : RegistryException("undefined type '" + name + "'"), m_name(name) {}
+    ~Undefined() throw() {}
+
+    std::string getName() const { return m_name; }
+};
+
+/** A type is already defined (duplicates definitions are
+ * not allowed in type registries) */
+class AlreadyDefined : public RegistryException {
+    std::string m_name;
+
+  public:
+    AlreadyDefined(std::string const &name)
+        : RegistryException("type " + name + " already defined in registry"),
+          m_name(name) {}
+    ~AlreadyDefined() throw() {}
+
+    std::string getName() const { return m_name; }
+};
+
+/** An attempt has been made of registering a type with an invalid name */
+class BadName : public RegistryException {
+    const std::string m_name;
+
+  public:
+    BadName(const std::string &name)
+        : RegistryException(name + " is not a valid type name"), m_name(name) {}
+    ~BadName() throw() {}
+};
+
+/** We are trying to merge two registries where two types have the same
+ * name but different definitions
+ */
+class DefinitionMismatch : public RegistryException {
+    const std::string m_name;
+
+  public:
+    DefinitionMismatch(const std::string &name)
+        : RegistryException(name + " already defines a type in the registry, "
+                                   "but with a different definition") {}
+    ~DefinitionMismatch() throw() {}
+};
+
+/** Manipulation of a set of types
+ * Any complex type in a Registry object can only reference types in the same
+ * registry. No duplicates are allowed.
+ *
+ * Registry objects provide the following services:
+ * <ul>
+ *	<li> type aliases (Registry::alias)
+ *	<li> namespace management: default namespace
+ *(Registry::setDefaultNamespace, Registry::getDefaultNamespace),
+ *  namespace import (like <tt>using namespace</tt> in C++)
+ *  <li> derived types (array, pointers) automatic building (Registry::build)
+ * </ul>
+ */
+class Registry {
+    friend class RegistryIterator;
+
+  private:
+    struct RegistryType {
+        Type *type;
+        bool persistent;
+        std::string source_id;
     };
+    typedef std::map<const std::string, RegistryType,
+                     bool (*)(const std::string &, const std::string &)>
+        TypeMap;
 
-    /** A type has not been found while it was expected */
-    class Undefined : public RegistryException
-    {
-        std::string m_name;
+    typedef std::map<const std::string, RegistryType> NameMap;
 
-    public:
-        Undefined(const std::string& name)
-            : RegistryException("undefined type '" + name + "'")
-            , m_name(name) {}
-        ~Undefined() throw() {}
+    TypeMap m_global;
+    NameMap m_current;
+    std::string m_namespace;
 
-        std::string getName() const { return m_name; }
-    };
+    static bool isPersistent(std::string const &name, Type const &type,
+                             std::string const &source_id);
+    void add(std::string const &name, Type *new_type, bool persistent,
+             std::string const &source_id);
 
-    /** A type is already defined (duplicates definitions are
-     * not allowed in type registries) */
-    class AlreadyDefined : public RegistryException
-    {
-        std::string m_name;
-
-    public:
-        AlreadyDefined(std::string const& name)
-            : RegistryException("type " + name + " already defined in registry")
-            , m_name(name) {}
-        ~AlreadyDefined() throw() {}
-
-        std::string getName() const { return m_name; }
-    };
-
-    /** An attempt has been made of registering a type with an invalid name */
-    class BadName : public RegistryException
-    {
-        const std::string m_name;
-
-    public:
-        BadName(const std::string& name)
-            : RegistryException(name + " is not a valid type name")
-            , m_name(name) {}
-        ~BadName() throw() {}
-    };
-
-    /** We are trying to merge two registries where two types have the same
-     * name but different definitions
+    /** Returns the set of types that depend on \c type recursively
      */
-    class DefinitionMismatch : public RegistryException
-    {
-        const std::string m_name;
+    std::set<Type *> reverseDepends(Type const &type);
 
-    public:
-        DefinitionMismatch(const std::string& name)
-            : RegistryException(name + " already defines a type in the registry, but with a different definition") {}
-        ~DefinitionMismatch() throw() {}
-    };
+    /** Updates +m_current+ based on +m_global+ and the current default
+     * namespace
+     */
+    void updateCurrentNameMap();
 
+  public:
+    typedef RegistryIterator Iterator;
 
-    /** Manipulation of a set of types
-     * Any complex type in a Registry object can only reference types in the same
-     * registry. No duplicates are allowed.
+    Registry();
+    ~Registry();
+
+    /** Import the \c name namespace into the current namespace.
+     * @arg erase_existing controls the behaviour in case of name collision. If
+     * true,
+     * the type from the namespace being imported will have priority. If false,
+     * an already imported type will have priority.
+     */
+    void importNamespace(const std::string &name, bool erase_existing = false);
+
+    /** Sets the default namespace. This removes all namespace import and
+     * imports \c name in the current namespace
+     */
+    bool setDefaultNamespace(const std::string &name);
+    /** Get the default namespace (if any). Returns '/' (i.e. the root)
+     * if no default namespace have been set
+     */
+    std::string getDefaultNamespace() const;
+
+    /** Checks for the availability of a particular type
      *
-     * Registry objects provide the following services:
-     * <ul>
-     *	<li> type aliases (Registry::alias)
-     *	<li> namespace management: default namespace (Registry::setDefaultNamespace, Registry::getDefaultNamespace),
-     *  namespace import (like <tt>using namespace</tt> in C++)
-     *  <li> derived types (array, pointers) automatic building (Registry::build)
-     * </ul>
+     * @arg name the type name
+     * @arg build if true, the method returns true if \c name is
+     * a derived version (pointer or array) of a known type
+     *
+     * @return true if the Type exists, or if it is a derived type and build is
+     *true, false otherwise
      */
-    class Registry
-    {
-        friend class RegistryIterator;
-        
-    private:
-        struct RegistryType
-        {
-            Type*       type;
-            bool        persistent;
-            std::string source_id;
-        };
-        typedef std::map
-            < const std::string
-            , RegistryType
-            , bool (*) (const std::string&, const std::string&)
-            >     TypeMap;
+    bool has(const std::string &name, bool build = true) const;
 
-        typedef std::map<const std::string, RegistryType>  NameMap;
+    /** Get the source ID of \c type. Throws Undefined if \c type is not
+     * a registered type
+     */
+    std::string source(Type const *type) const;
 
-        TypeMap                 m_global;
-        NameMap                 m_current;
-        std::string             m_namespace;
+    /** Build a derived type from its canonical name */
+    Type const *build(const std::string &name, std::size_t size = 0);
 
-        static bool isPersistent(std::string const& name, Type const& type, std::string const& source_id);
-        void add(std::string const& name, Type* new_type, bool persistent, std::string const& source_id);
+    /** Gets a Type object
+     * @arg name the type name
+     * @return the type object if it exists, 0 otherwise
+     */
+    Type const *get(const std::string &name) const;
 
-        /** Returns the set of types that depend on \c type recursively
-         */
-        std::set<Type*> reverseDepends(Type const& type);
+    /** Gets a RegistryIterator on a given type
+     *
+     * @arg name the type name
+     * @return the iterator, or end() if it is not found
+     */
+    RegistryIterator find(std::string const &name) const;
 
-        /** Updates +m_current+ based on +m_global+ and the current default
-         * namespace
-         */
-        void updateCurrentNameMap();
+    /* Internal version to get a non-const Type object
+     *
+     * You should not be using it. This is for internal Typelib use only */
+    Type *get_(const std::string &name);
 
-    public:
-	typedef RegistryIterator Iterator;
+    /** Returns the set of types that depend on \c type recursively
+     */
+    std::set<Type const *> reverseDepends(Type const &type) const;
 
-        Registry();
-        ~Registry();
+    /** Removes the given type from the registry, along with all the types
+     * that depend on it.
+     *
+     * @return the set of types that have been removed. Their ownership is
+     * passed to the caller (i.e. the caller has to delete them)
+     */
+    std::set<Type *> remove(Type const &type);
 
-        /** Import the \c name namespace into the current namespace.
-	 * @arg erase_existing controls the behaviour in case of name collision. If true,
-	 * the type from the namespace being imported will have priority. If false, 
-	 * an already imported type will have priority.
-	 */
-        void importNamespace(const std::string& name, bool erase_existing = false);
+    /* Internal version to get a non-const Type object
+     *
+     * You should not be using it. This is for internal Typelib use only */
+    Type &get_(Type const &type);
 
-        /** Sets the default namespace. This removes all namespace import and
-         * imports \c name in the current namespace
-         */
-        bool setDefaultNamespace(const std::string& name);
-        /** Get the default namespace (if any). Returns '/' (i.e. the root)
-         * if no default namespace have been set
-         */
-        std::string getDefaultNamespace() const;
-       
-        /** Checks for the availability of a particular type
-         *
-         * @arg name the type name
-         * @arg build if true, the method returns true if \c name is 
-	 * a derived version (pointer or array) of a known type
-         *
-         * @return true if the Type exists, or if it is a derived type and build is true, false otherwise
-         */
-        bool        has(const std::string& name, bool build = true) const;
+    /** \overload
+     */
+    void add(Type *type, std::string const &source_id = "");
 
-        /** Get the source ID of \c type. Throws Undefined if \c type is not
-         * a registered type
-         */
-        std::string source(Type const* type) const;
+    /** Adds a new type
+     * @return true on success, false if the type was already
+     * defined in the registry
+     */
+    void add(Type *type, bool persistent, std::string const &source_id);
 
-        /** Build a derived type from its canonical name */
-        Type const* build(const std::string& name, std::size_t size = 0);
+    /** Creates an alias
+     * While base can be a derived type, all aliases are considered persistent
+     *since
+     * they can be referenced by their name in other types
+     *
+     * @arg base       the base type
+     * @arg alias      the alias name
+     * @arg source_id  a source ID for the newly created type
+     */
+    void alias(std::string const &base, std::string const &alias,
+               bool persistent, std::string const &source_id = "");
 
-        /** Gets a Type object
-         * @arg name the type name
-         * @return the type object if it exists, 0 otherwise
-         */
-        Type const* get(const std::string& name) const;  
+    /** \overload
+     */
+    void alias(std::string const &base, std::string const &alias,
+               std::string const &source_id = "");
 
-        /** Gets a RegistryIterator on a given type
-         *
-         * @arg name the type name
-         * @return the iterator, or end() if it is not found
-         */
-        RegistryIterator find(std::string const& name) const;
+    /** Returns the count of types defined in this registry, including
+     * non-persistent and aliases */
+    size_t size() const;
+    /** Remove all types */
+    void clear();
 
-        /* Internal version to get a non-const Type object
-         *
-         * You should not be using it. This is for internal Typelib use only */
-        Type* get_(const std::string& name);
+    /** Get the absolute type name of \c name,
+     * taking the default namespace into account
+     * @see setDefaultNamespace getDefaultNamespace */
+    std::string getFullName(const std::string &name) const;
 
-        /** Returns the set of types that depend on \c type recursively
-         */
-        std::set<Type const*> reverseDepends(Type const& type) const;
+    /** Iterator pointing on the first type of the registry */
+    RegistryIterator begin() const;
+    /** Past-the-end iterator on the registry */
+    RegistryIterator end() const;
+    /** Returns an iterator on the first type whose name starts with
+     * +prefix+. If +prefix+ is a namespace name, it will be the first type
+     * in that namespace
+     */
+    RegistryIterator begin(std::string const &prefix) const;
+    /** Returns an iterator on the first type whose name does not start with
+     * +prefix+ and which is preceded by a type whose name starts with
+     * +prefix
+     *
+     * If +prefix+ is a namespace name, it will be the past-the-end iterator
+     * allowing you to iterate on the namespace types:
+     *
+     * <code>
+     * RegistryIterator const end = registry.end("/A");
+     * for (RegistryIterator it = registry.begin("/A"); it != end; ++it)
+     * {
+     *   // iterates on all types in namespace A
+     * }
+     * </code>
+     */
+    RegistryIterator end(std::string const &prefix) const;
 
-        /** Removes the given type from the registry, along with all the types
-         * that depend on it.
-         *
-         * @return the set of types that have been removed. Their ownership is
-         * passed to the caller (i.e. the caller has to delete them)
-         */
-        std::set<Type *> remove(Type const& type);
+    /** Returns a null type */
+    static Type const &null();
 
-        /* Internal version to get a non-const Type object
-         *
-         * You should not be using it. This is for internal Typelib use only */
-        Type& get_(Type const& type);
+    /** Merges the content of \c registry into this object */
+    void merge(Registry const &registry);
 
-        /** \overload
-         */
-        void        add(Type* type, std::string const& source_id = "");
+    /** Merge the metadata information contained in a registry into this one
+     */
+    void mergeMetaData(Registry const &registry);
 
-        /** Adds a new type
-         * @return true on success, false if the type was already
-         * defined in the registry
-         */
-        void        add(Type* type, bool persistent, std::string const& source_id);
+    /** Modifies the size of a subset of the types, and propagate this size
+     * change to the other types
+     */
+    void resize(std::map<std::string, size_t> const &new_sizes);
 
-        /** Creates an alias
-         * While base can be a derived type, all aliases are considered persistent since
-         * they can be referenced by their name in other types
-         *
-         * @arg base       the base type
-         * @arg alias      the alias name
-         * @arg source_id  a source ID for the newly created type
-         */
-        void        alias(std::string const& base, std::string const& alias, bool persistent, std::string const& source_id = "");
+    /** Returns a registry containing the minimal set of types needed to
+     * define \c name */
+    Registry *minimal(std::string const &name, bool with_aliases = true) const;
 
-        /** \overload
-         */
-        void        alias(std::string const& base, std::string const& alias, std::string const& source_id = "");
+    /** Returns a registry containing the minimal set of types needed to
+     * define the types that are in \c this and not in \c auto_types */
+    Registry *minimal(Registry const &auto_types) const;
 
-        /** Returns the count of types defined in this registry, including
-         * non-persistent and aliases */
-        size_t      size() const;
-        /** Remove all types */
-        void        clear();
+    /** Compares the two registries. Returns true if they contain the same
+     * set of types, referenced under the same name
+     *
+     * Note that for now, if this contains a type 'A' aliased to 'B' and \c
+     * other contains the \b same type but named 'B' and aliased to 'A',
+     * the method will return false.
+     */
+    bool isSame(Registry const &other) const;
 
-        /** Get the absolute type name of \c name, 
-         * taking the default namespace into account 
-         * @see setDefaultNamespace getDefaultNamespace */
-        std::string getFullName (const std::string& name) const;
+    /** Returns true if +type+ is a type included in this registry */
+    bool isIncluded(Type const &type) const;
 
-	/** Iterator pointing on the first type of the registry */
-        RegistryIterator begin() const;
-	/** Past-the-end iterator on the registry */
-        RegistryIterator end() const;
-        /** Returns an iterator on the first type whose name starts with
-         * +prefix+. If +prefix+ is a namespace name, it will be the first type
-         * in that namespace
-         */
-        RegistryIterator begin(std::string const& prefix) const;
-        /** Returns an iterator on the first type whose name does not start with
-         * +prefix+ and which is preceded by a type whose name starts with
-         * +prefix
-         *
-         * If +prefix+ is a namespace name, it will be the past-the-end iterator
-         * allowing you to iterate on the namespace types:
-         *
-         * <code>
-         * RegistryIterator const end = registry.end("/A");
-         * for (RegistryIterator it = registry.begin("/A"); it != end; ++it)
-         * {
-         *   // iterates on all types in namespace A
-         * }
-         * </code>
-         */
-        RegistryIterator end(std::string const& prefix) const;
-        
-        /** Returns a null type */
-        static Type const& null();
+    /** Returns the set of aliases that exist for +type+ */
+    std::set<std::string> getAliasesOf(Type const &type) const;
 
-	/** Merges the content of \c registry into this object */
-	void merge(Registry const& registry);
+    /** Changes the source ID of a particular type */
+    void setSourceID(Type const &type, std::string const &source_id);
 
-        /** Merge the metadata information contained in a registry into this one
-         */
-	void mergeMetaData(Registry const& registry);
+    /** Get from the provided all registry all source IDs from types in
+     * +this+ which have no source ID yet */
+    void copySourceIDs(Registry const &registry);
 
-        /** Modifies the size of a subset of the types, and propagate this size
-         * change to the other types
-         */
-        void resize(std::map<std::string, size_t> const& new_sizes);
+    /** Removes all defined aliases
+     */
+    void clearAliases();
 
-        /** Returns a registry containing the minimal set of types needed to
-         * define \c name */
-        Registry* minimal(std::string const& name, bool with_aliases = true) const;
-
-        /** Returns a registry containing the minimal set of types needed to
-         * define the types that are in \c this and not in \c auto_types */
-        Registry* minimal(Registry const& auto_types) const;
-
-        /** Compares the two registries. Returns true if they contain the same
-         * set of types, referenced under the same name
-         *
-         * Note that for now, if this contains a type 'A' aliased to 'B' and \c
-         * other contains the \b same type but named 'B' and aliased to 'A',
-         * the method will return false.
-         */
-        bool isSame(Registry const& other) const;
-
-        /** Returns true if +type+ is a type included in this registry */
-        bool isIncluded(Type const& type) const;
-
-        /** Returns the set of aliases that exist for +type+ */
-        std::set<std::string> getAliasesOf(Type const& type) const;
-
-        /** Changes the source ID of a particular type */
-        void setSourceID(Type const& type, std::string const& source_id);
-
-        /** Get from the provided all registry all source IDs from types in
-         * +this+ which have no source ID yet */
-        void copySourceIDs(Registry const& registry);
-
-        /** Removes all defined aliases
-         */
-        void clearAliases();
-        
-    public:
-        enum DumpMode
-        {
-            NameOnly = 0, 
-            AllType  = 1, 
-            WithSourceId = 2,
-            RecursiveTypeDump = 4
-        };
-        void dump(std::ostream& stream, int dumpmode = AllType, const std::string& source_filter = "*") const;
+  public:
+    enum DumpMode {
+        NameOnly = 0,
+        AllType = 1,
+        WithSourceId = 2,
+        RecursiveTypeDump = 4
     };
+    void dump(std::ostream &stream, int dumpmode = AllType,
+              const std::string &source_filter = "*") const;
+};
 }
 
 #endif
-

--- a/typelib/registryiterator.hh
+++ b/typelib/registryiterator.hh
@@ -6,60 +6,59 @@
 #include "typename.hh"
 #include <boost/iterator/iterator_facade.hpp>
 
-namespace Typelib
-{
-    class Registry;
+namespace Typelib {
+class Registry;
 
-    /** Iterator on the types of the registry */
-    class RegistryIterator 
-        : public boost::iterator_facade
-            < RegistryIterator
-            , Type const
-            , boost::forward_traversal_tag >
-    {
-        friend class Registry;
+/** Iterator on the types of the registry */
+class RegistryIterator
+    : public boost::iterator_facade<RegistryIterator, Type const,
+                                    boost::forward_traversal_tag> {
+    friend class Registry;
 
-    public:
-        RegistryIterator(RegistryIterator const& other)
-            : m_registry(other.m_registry), m_iter(other.m_iter) {}
+  public:
+    RegistryIterator(RegistryIterator const &other)
+        : m_registry(other.m_registry), m_iter(other.m_iter) {}
 
-	/** The type name */
-        std::string getName() const { return m_iter->first; }
-	/** The type name without the namespace */
-	std::string getBasename() const { return getTypename(m_iter->first); }
-	/** The type namespace */
-	std::string getNamespace() const { return Typelib::getNamespace(m_iter->first); }
-	/** The source ID for this type */
-        std::string getSource() const { return m_iter->second.source_id; }
-	/** Returns true if the type is an alias for another type */
-        bool isAlias() const { return m_iter->first != m_iter->second.type->getName(); }
-	/** Returns the aliased type if isAlias() is true */
-	Type const& aliased() const { return *m_iter->second.type; }
-	/** Returns true if the type should be saved on export. Derived types (arrays, pointers) 
-	 * are not persistent */
-        bool isPersistent() const { return m_iter->second.persistent; }
+    /** The type name */
+    std::string getName() const { return m_iter->first; }
+    /** The type name without the namespace */
+    std::string getBasename() const { return getTypename(m_iter->first); }
+    /** The type namespace */
+    std::string getNamespace() const {
+        return Typelib::getNamespace(m_iter->first);
+    }
+    /** The source ID for this type */
+    std::string getSource() const { return m_iter->second.source_id; }
+    /** Returns true if the type is an alias for another type */
+    bool isAlias() const {
+        return m_iter->first != m_iter->second.type->getName();
+    }
+    /** Returns the aliased type if isAlias() is true */
+    Type const &aliased() const { return *m_iter->second.type; }
+    /** Returns true if the type should be saved on export. Derived types
+     * (arrays, pointers)
+     * are not persistent */
+    bool isPersistent() const { return m_iter->second.persistent; }
 
-        Registry const& getRegistry() const { return m_registry; }
+    Registry const &getRegistry() const { return m_registry; }
 
-        Type& get_() { return *m_iter->second.type; }
+    Type &get_() { return *m_iter->second.type; }
 
-    private:
-        typedef Registry::TypeMap::const_iterator BaseIter;
-        Registry const& m_registry;
-        BaseIter m_iter;
-            
-        explicit RegistryIterator(Registry const& registry, BaseIter init)
-            : m_registry(registry), m_iter(init) {}
-        friend class boost::iterator_core_access;
+  private:
+    typedef Registry::TypeMap::const_iterator BaseIter;
+    Registry const &m_registry;
+    BaseIter m_iter;
 
-        bool equal(RegistryIterator const& other) const
-        { return other.m_iter == m_iter; }
-        void increment()
-        { ++m_iter; }
-        Type const& dereference() const
-        { return *m_iter->second.type; }
-    };
+    explicit RegistryIterator(Registry const &registry, BaseIter init)
+        : m_registry(registry), m_iter(init) {}
+    friend class boost::iterator_core_access;
+
+    bool equal(RegistryIterator const &other) const {
+        return other.m_iter == m_iter;
+    }
+    void increment() { ++m_iter; }
+    Type const &dereference() const { return *m_iter->second.type; }
+};
 }
 
 #endif
-

--- a/typelib/typebuilder.cc
+++ b/typelib/typebuilder.cc
@@ -8,172 +8,157 @@
 using std::string;
 using std::list;
 
-namespace
-{
-    static string join(const string& acc, const string& add)
-    {
-        if (acc.empty()) return add;
-        return acc + ' ' + add;
-    }
+namespace {
+static string join(const string &acc, const string &add) {
+    if (acc.empty())
+        return add;
+    return acc + ' ' + add;
+}
 }
 
-namespace Typelib
-{
-    TypeBuilder::TypeBuilder(Registry& registry, const std::list<std::string>& name)
-        : m_registry(registry) 
-    {
-        string basename = accumulate(name.begin(), name.end(), string(), join);
-        
-        m_type = m_registry.get_(basename);
-        if (!m_type) 
-            throw Undefined(basename);
-    }
-    TypeBuilder::TypeBuilder(Registry& registry, const Type* base)
-        : m_type(const_cast<Type*>(base)), m_registry(registry) { }
+namespace Typelib {
+TypeBuilder::TypeBuilder(Registry &registry, const std::list<std::string> &name)
+    : m_registry(registry) {
+    string basename = accumulate(name.begin(), name.end(), string(), join);
 
+    m_type = m_registry.get_(basename);
+    if (!m_type)
+        throw Undefined(basename);
+}
+TypeBuilder::TypeBuilder(Registry &registry, const Type *base)
+    : m_type(const_cast<Type *>(base)), m_registry(registry) {}
 
-
-    const Type& TypeBuilder::getType() const { return *m_type; }
-    void TypeBuilder::addPointer(int level) 
-    {
-        for (; level; --level)
-        {
-            // Try to get the type object in the registry
-            Type* base_type = m_registry.get_(Pointer::getPointerName(m_type->getName()));
-            if (base_type)
-                m_type = base_type;
-            else
-            {
-                Type* new_type = new Pointer(*m_type);
-                m_registry.add(new_type);
-                m_type = new_type;
-            }
-        }
-    }
-
-    void TypeBuilder::addArrayMinor(int new_dim)
-    {
-	// build the list of array dimensions
-	std::vector<int> dims;
-
-	while(m_type->getCategory() == Type::Array)
-	{
-	    Array* array = dynamic_cast<Array*>(m_type);
-	    dims.push_back(array->getDimension());
-	    m_type = const_cast<Type*>(&array->getIndirection());
-	}
-
-	addArrayMajor(new_dim);
-	for (std::vector<int>::reverse_iterator it = dims.rbegin();
-		it != dims.rend(); ++it)
-	    addArrayMajor(*it);
-    }
-
-    void TypeBuilder::addArrayMajor(int new_dim)
-    {
-        Type* base_type = m_registry.get_(Array::getArrayName(m_type->getName(), new_dim));
+const Type &TypeBuilder::getType() const { return *m_type; }
+void TypeBuilder::addPointer(int level) {
+    for (; level; --level) {
+        // Try to get the type object in the registry
+        Type *base_type =
+            m_registry.get_(Pointer::getPointerName(m_type->getName()));
         if (base_type)
             m_type = base_type;
-        else
-        {
-            Type* new_type = new Array(*m_type, new_dim);
+        else {
+            Type *new_type = new Pointer(*m_type);
             m_registry.add(new_type);
             m_type = new_type;
         }
     }
+}
 
-    void TypeBuilder::setSize(int size)
-    {
-        m_type->setSize(size);
+void TypeBuilder::addArrayMinor(int new_dim) {
+    // build the list of array dimensions
+    std::vector<int> dims;
+
+    while (m_type->getCategory() == Type::Array) {
+        Array *array = dynamic_cast<Array *>(m_type);
+        dims.push_back(array->getDimension());
+        m_type = const_cast<Type *>(&array->getIndirection());
     }
 
-    const Type& TypeBuilder::build(Registry& registry, const TypeSpec& spec, int size)
-    {
-        const Type* base = spec.first;
-        const ModifierList& stack(spec.second);
+    addArrayMajor(new_dim);
+    for (std::vector<int>::reverse_iterator it = dims.rbegin();
+         it != dims.rend(); ++it)
+        addArrayMajor(*it);
+}
 
-        TypeBuilder builder(registry, base);
-        for (ModifierList::const_iterator it = stack.begin(); it != stack.end(); ++it)
-        {
-            Type::Category category = it -> category;
-            int size = it -> size;
+void TypeBuilder::addArrayMajor(int new_dim) {
+    Type *base_type =
+        m_registry.get_(Array::getArrayName(m_type->getName(), new_dim));
+    if (base_type)
+        m_type = base_type;
+    else {
+        Type *new_type = new Array(*m_type, new_dim);
+        m_registry.add(new_type);
+        m_type = new_type;
+    }
+}
 
-            if (category == Type::Pointer)
-                builder.addPointer(size);
-            else if (category == Type::Array)
-                builder.addArrayMajor(size);
-        }
+void TypeBuilder::setSize(int size) { m_type->setSize(size); }
 
-        if (size != 0)
-            builder.setSize(size);
-        return builder.getType();
+const Type &TypeBuilder::build(Registry &registry, const TypeSpec &spec,
+                               int size) {
+    const Type *base = spec.first;
+    const ModifierList &stack(spec.second);
+
+    TypeBuilder builder(registry, base);
+    for (ModifierList::const_iterator it = stack.begin(); it != stack.end();
+         ++it) {
+        Type::Category category = it->category;
+        int size = it->size;
+
+        if (category == Type::Pointer)
+            builder.addPointer(size);
+        else if (category == Type::Array)
+            builder.addArrayMajor(size);
     }
 
-    struct InvalidIndirectName : public std::runtime_error
-    {
-        InvalidIndirectName(std::string const& what)
-            : std::runtime_error(what) {}
-    };
+    if (size != 0)
+        builder.setSize(size);
+    return builder.getType();
+}
 
-    TypeBuilder::TypeSpec TypeBuilder::parse(const Registry& registry, const std::string& full_name)
-    {
-        static const char* first_chars = "*[";
-
-        TypeSpec spec;
-
-        size_t end = full_name.find_first_of(first_chars);
-        string base_name = full_name.substr(0, end);
-        spec.first = registry.get(base_name);
-        if (! spec.first) throw Undefined(base_name);
-
-        size_t full_length(full_name.length());
-        ModifierList& modlist(spec.second);
-        while (end < full_length)
-        {
-            Modifier new_mod;
-            if (full_name[end] == '[')
-            {
-                new_mod.category = Type::Array;
-                new_mod.size = atoi(&full_name[end] + 1);
-                end = full_name.find(']', end) + 1;
-            }
-            else if (full_name[end] == '*')
-            {
-                new_mod.category = Type::Pointer;
-                new_mod.size = 1;
-                ++end;
-            } 
-	    else
-		throw InvalidIndirectName(full_name + " is not a valid type name");
-            modlist.push_back(new_mod);
-        }
-
-        return spec;
-    }
-
-    const Type* TypeBuilder::build(Registry& registry, const std::string& full_name, int size)
-    {
-        TypeSpec spec;
-        try { spec = parse(registry, full_name); }
-        catch(Undefined) { return 0; }
-
-        return &build(registry, spec, size);
-    }
-
-    const Type* TypeBuilder::getBaseType(const Registry& registry, const std::string& full_name)
-    {
-        TypeSpec spec;
-        try { spec = parse(registry, full_name); }
-        catch(Undefined) { return 0; }
-        return spec.first;
-    }
-
-    std::string TypeBuilder::getBaseTypename(const std::string& full_name)
-    {
-        static const char* first_chars = "*[";
-
-        size_t end = full_name.find_first_of(first_chars);
-        return string(full_name, 0, end);
-    }
+struct InvalidIndirectName : public std::runtime_error {
+    InvalidIndirectName(std::string const &what) : std::runtime_error(what) {}
 };
 
+TypeBuilder::TypeSpec TypeBuilder::parse(const Registry &registry,
+                                         const std::string &full_name) {
+    static const char *first_chars = "*[";
+
+    TypeSpec spec;
+
+    size_t end = full_name.find_first_of(first_chars);
+    string base_name = full_name.substr(0, end);
+    spec.first = registry.get(base_name);
+    if (!spec.first)
+        throw Undefined(base_name);
+
+    size_t full_length(full_name.length());
+    ModifierList &modlist(spec.second);
+    while (end < full_length) {
+        Modifier new_mod;
+        if (full_name[end] == '[') {
+            new_mod.category = Type::Array;
+            new_mod.size = atoi(&full_name[end] + 1);
+            end = full_name.find(']', end) + 1;
+        } else if (full_name[end] == '*') {
+            new_mod.category = Type::Pointer;
+            new_mod.size = 1;
+            ++end;
+        } else
+            throw InvalidIndirectName(full_name + " is not a valid type name");
+        modlist.push_back(new_mod);
+    }
+
+    return spec;
+}
+
+const Type *TypeBuilder::build(Registry &registry, const std::string &full_name,
+                               int size) {
+    TypeSpec spec;
+    try {
+        spec = parse(registry, full_name);
+    } catch (Undefined) {
+        return 0;
+    }
+
+    return &build(registry, spec, size);
+}
+
+const Type *TypeBuilder::getBaseType(const Registry &registry,
+                                     const std::string &full_name) {
+    TypeSpec spec;
+    try {
+        spec = parse(registry, full_name);
+    } catch (Undefined) {
+        return 0;
+    }
+    return spec.first;
+}
+
+std::string TypeBuilder::getBaseTypename(const std::string &full_name) {
+    static const char *first_chars = "*[";
+
+    size_t end = full_name.find_first_of(first_chars);
+    return string(full_name, 0, end);
+}
+};

--- a/typelib/typebuilder.hh
+++ b/typelib/typebuilder.hh
@@ -6,70 +6,70 @@
 
 #include "typemodel.hh"
 
-namespace Typelib
-{
-    class Registry;
+namespace Typelib {
+class Registry;
 
-    /** Helper class to easily build a derived type (pointer, array) */
-    class TypeBuilder
-    {
-        std::string m_basename;
-        Type* m_type;
+/** Helper class to easily build a derived type (pointer, array) */
+class TypeBuilder {
+    std::string m_basename;
+    Type *m_type;
 
-        struct Modifier
-        {
-            Type::Category category;
-            int size; // Size of an array, deference count on multi-dim pointers
-        };
-        typedef std::list<Modifier> ModifierList;
-        typedef std::pair<const Type*, ModifierList> TypeSpec;
+    struct Modifier {
+        Type::Category category;
+        int size; // Size of an array, deference count on multi-dim pointers
+    };
+    typedef std::list<Modifier> ModifierList;
+    typedef std::pair<const Type *, ModifierList> TypeSpec;
 
-        static TypeSpec parse(const Registry& registry, const std::string& full_name);
-        static const Type& build(Registry& registry, const TypeSpec& spec, int size);
+    static TypeSpec parse(const Registry &registry,
+                          const std::string &full_name);
+    static const Type &build(Registry &registry, const TypeSpec &spec,
+                             int size);
 
-        Registry& m_registry;
+    Registry &m_registry;
 
-    public:
-        /** Initializes the type builder
-         * This constructor builds the canonical name based on @c base
-         * an gets its initial type from @c registry. It throws 
-         * Undefined(typename) if @c base is not defined
-         *
-         * @arg registry the registry to act on
-         * @arg base the base type
-         */
-        TypeBuilder(Registry& registry, const std::list<std::string>& base);
+  public:
+    /** Initializes the type builder
+     * This constructor builds the canonical name based on @c base
+     * an gets its initial type from @c registry. It throws
+     * Undefined(typename) if @c base is not defined
+     *
+     * @arg registry the registry to act on
+     * @arg base the base type
+     */
+    TypeBuilder(Registry &registry, const std::list<std::string> &base);
 
-        /** Initializes the type builder
-         * @arg registry the registry to act on
-         * @arg base_type the base type
-         */
-        TypeBuilder(Registry& registry, const Type* base_type);
+    /** Initializes the type builder
+     * @arg registry the registry to act on
+     * @arg base_type the base type
+     */
+    TypeBuilder(Registry &registry, const Type *base_type);
 
-        /** Builds a level-deferenced pointer of the current type */
-        void addPointer(int level);
-        /** Add an outermost dimension to the current type (if it is not
-	 * an array, builds an array */
-        void addArrayMajor(int size);
-        /** Add an innermost dimension to the current type (if it is not
-	 * an array, builds an array */
-        void addArrayMinor(int size);
-        /** Sets the size of the current type */
-        void setSize(int size);
+    /** Builds a level-deferenced pointer of the current type */
+    void addPointer(int level);
+    /** Add an outermost dimension to the current type (if it is not
+     * an array, builds an array */
+    void addArrayMajor(int size);
+    /** Add an innermost dimension to the current type (if it is not
+     * an array, builds an array */
+    void addArrayMinor(int size);
+    /** Sets the size of the current type */
+    void setSize(int size);
 
-        /** Get the current type */
-        const Type& getType() const;
+    /** Get the current type */
+    const Type &getType() const;
 
-	/** Build a type from its full name 
-	 * @return the new type or 0 if it can't be built */
-        static const Type* build(Registry& registry, const std::string& full_name, int size = 0);
-	/** Get base name, that is the type \c full_name is derived from */
-        static std::string getBaseTypename(const std::string& full_name);
-	/** Get base type, that is the type \c full_name is derived from
-	 * @return the new type or 0 if it can't be built */
-        static const Type* getBaseType(const Registry& registry, const std::string& full_name);
+    /** Build a type from its full name
+     * @return the new type or 0 if it can't be built */
+    static const Type *build(Registry &registry, const std::string &full_name,
+                             int size = 0);
+    /** Get base name, that is the type \c full_name is derived from */
+    static std::string getBaseTypename(const std::string &full_name);
+    /** Get base type, that is the type \c full_name is derived from
+     * @return the new type or 0 if it can't be built */
+    static const Type *getBaseType(const Registry &registry,
+                                   const std::string &full_name);
 };
 };
 
 #endif
-

--- a/typelib/typedisplay.cc
+++ b/typelib/typedisplay.cc
@@ -5,59 +5,53 @@
 using namespace Typelib;
 using namespace std;
 
-namespace
-{
-    struct Indent
-    {
-        std::string& m_indent;
-        std::string  m_save;
-        Indent(std::string& current)
-            : m_indent(current), m_save(current)
-        { m_indent += "  "; }
-        ~Indent() { m_indent = m_save; }
-    };
+namespace {
+struct Indent {
+    std::string &m_indent;
+    std::string m_save;
+    Indent(std::string &current) : m_indent(current), m_save(current) {
+        m_indent += "  ";
+    }
+    ~Indent() { m_indent = m_save; }
+};
 }
 
-TypeDisplayVisitor::TypeDisplayVisitor(std::ostream& stream, std::string const& base_indent)
+TypeDisplayVisitor::TypeDisplayVisitor(std::ostream &stream,
+                                       std::string const &base_indent)
     : m_stream(stream), m_indent(base_indent) {}
-            
-bool TypeDisplayVisitor::visit_(NullType const& type)
-{
+
+bool TypeDisplayVisitor::visit_(NullType const &type) {
     m_stream << "null\n";
     return true;
 }
 
-bool TypeDisplayVisitor::visit_(OpaqueType const& type)
-{
+bool TypeDisplayVisitor::visit_(OpaqueType const &type) {
     m_stream << "opaque " << type.getName() << "\n";
     return true;
 }
 
-bool TypeDisplayVisitor::visit_(Compound const& type)
-{ 
-    m_stream << "compound " << type.getName() << " [" << type.getSize() << "] {\n";
-    
-    { Indent indenter(m_indent);
+bool TypeDisplayVisitor::visit_(Compound const &type) {
+    m_stream << "compound " << type.getName() << " [" << type.getSize()
+             << "] {\n";
+
+    {
+        Indent indenter(m_indent);
         TypeVisitor::visit_(type);
     }
 
-    m_stream << m_indent
-        << "};";
+    m_stream << m_indent << "};";
     return true;
 }
-bool TypeDisplayVisitor::visit_(Compound const& type, Field const& field)
-{ 
+bool TypeDisplayVisitor::visit_(Compound const &type, Field const &field) {
     m_stream << m_indent << "(+" << field.getOffset() << ") ";
     TypeVisitor::visit_(type, field);
     m_stream << "\n";
     return true;
 }
 
-bool TypeDisplayVisitor::visit_(Numeric const& type)
-{
-    char const* name = "";
-    switch (type.getNumericCategory())
-    {
+bool TypeDisplayVisitor::visit_(Numeric const &type) {
+    char const *name = "";
+    switch (type.getNumericCategory()) {
     case Numeric::SInt:
         name = "sint";
         break;
@@ -69,31 +63,26 @@ bool TypeDisplayVisitor::visit_(Numeric const& type)
         break;
     };
 
-    m_stream
-        << name << "(" << type.getSize() << ")";
+    m_stream << name << "(" << type.getSize() << ")";
     return true;
 }
 
-bool TypeDisplayVisitor::visit_(Enum const& type)
-{
+bool TypeDisplayVisitor::visit_(Enum const &type) {
     m_stream << "enum " << type.getName();
     return true;
 }
 
-bool TypeDisplayVisitor::visit_(Pointer const& type)
-{
+bool TypeDisplayVisitor::visit_(Pointer const &type) {
     m_stream << "pointer on " << type.getIndirection().getName() << "\n";
     return true;
 }
 
-bool TypeDisplayVisitor::visit_(Array const& type)
-{
+bool TypeDisplayVisitor::visit_(Array const &type) {
     m_stream << "array[" << type.getDimension() << "] of\n";
-    { Indent indenter(m_indent);
+    {
+        Indent indenter(m_indent);
         m_stream << m_indent;
         TypeVisitor::visit_(type);
     }
     return true;
 }
-
-

--- a/typelib/typedisplay.hh
+++ b/typelib/typedisplay.hh
@@ -4,71 +4,68 @@
 #include "typevisitor.hh"
 #include <iosfwd>
 
-namespace Typelib
-{
-    /** Visitor to pretty-print a Type object to an output stream.
-     * You can use <code>stream << type</code> and 
-     * <code>stream << type_display(type, indent)</code> instead
-     */
-    class TypeDisplayVisitor : public TypeVisitor
-    {
-        template<typename T>
-        void display_compound(T const& type, char const* compound_name);
+namespace Typelib {
+/** Visitor to pretty-print a Type object to an output stream.
+ * You can use <code>stream << type</code> and
+ * <code>stream << type_display(type, indent)</code> instead
+ */
+class TypeDisplayVisitor : public TypeVisitor {
+    template <typename T>
+    void display_compound(T const &type, char const *compound_name);
 
-        std::ostream& m_stream;
-        std::string   m_indent;
+    std::ostream &m_stream;
+    std::string m_indent;
 
-    protected:
-        bool visit_(NullType const& type);
-        bool visit_(OpaqueType const& type);
-        bool visit_(Compound const& type);
-        bool visit_(Compound const& type, Field const& field);
-        
-        bool visit_(Numeric const& type);
-        bool visit_(Enum const& type);
-       
-        bool visit_(Pointer const& type);
-        bool visit_(Array const& type);
+  protected:
+    bool visit_(NullType const &type);
+    bool visit_(OpaqueType const &type);
+    bool visit_(Compound const &type);
+    bool visit_(Compound const &type, Field const &field);
 
-    public:
-        TypeDisplayVisitor(std::ostream& stream, std::string const& base_indent);
-    };
+    bool visit_(Numeric const &type);
+    bool visit_(Enum const &type);
 
-    namespace details
-    {
-        struct do_type_display
-        {
-            Type const& type;
-            std::string indent;
-            do_type_display(Type const& type_, std::string const& indent_ = "")
-                : type(type_), indent(indent_) {}
-        };
-        inline std::ostream& operator << (std::ostream& stream, do_type_display display)
-        {
-            TypeDisplayVisitor visitor(stream, display.indent);
-            visitor.apply(display.type);
-            return stream;
-        }
-    }
+    bool visit_(Pointer const &type);
+    bool visit_(Array const &type);
 
-    /** stream operator to pretty-print a type on a stream, with indenting
-     * <code>
-     *	std::cout << Typelib::type_display(type, 2) << std::endl;
-     * </code>
-     *
-     * @arg type    the type
-     * @arg indent  base indentation
-     */
-    inline details::do_type_display type_display(Type const& type, std::string const& indent = "")
-    { return details::do_type_display(type, indent); }
+  public:
+    TypeDisplayVisitor(std::ostream &stream, std::string const &base_indent);
+};
 
-    /** Pretty prints a type on a given output stream
-     * @arg stream  the stream to output to
-     * @arg indent  the type to display
-     */
-    inline std::ostream& operator << (std::ostream& stream, Type const& type)
-    { return stream << type_display(type); }
+namespace details {
+struct do_type_display {
+    Type const &type;
+    std::string indent;
+    do_type_display(Type const &type_, std::string const &indent_ = "")
+        : type(type_), indent(indent_) {}
+};
+inline std::ostream &operator<<(std::ostream &stream, do_type_display display) {
+    TypeDisplayVisitor visitor(stream, display.indent);
+    visitor.apply(display.type);
+    return stream;
+}
+}
+
+/** stream operator to pretty-print a type on a stream, with indenting
+ * <code>
+ *	std::cout << Typelib::type_display(type, 2) << std::endl;
+ * </code>
+ *
+ * @arg type    the type
+ * @arg indent  base indentation
+ */
+inline details::do_type_display type_display(Type const &type,
+                                             std::string const &indent = "") {
+    return details::do_type_display(type, indent);
+}
+
+/** Pretty prints a type on a given output stream
+ * @arg stream  the stream to output to
+ * @arg indent  the type to display
+ */
+inline std::ostream &operator<<(std::ostream &stream, Type const &type) {
+    return stream << type_display(type);
+}
 }
 
 #endif
-

--- a/typelib/typemodel.cc
+++ b/typelib/typemodel.cc
@@ -4,7 +4,7 @@
 
 #include "typename.hh"
 #include <boost/tuple/tuple.hpp>
-  
+
 #include <iostream>
 #include <sstream>
 
@@ -17,633 +17,604 @@ using namespace std;
 #include <boost/lexical_cast.hpp>
 using boost::lexical_cast;
 
-namespace Typelib
-{
-    Type::Type(std::string const& name, size_t size, Category category)
-        : m_size(size)
-        , m_category(category)
-        , m_metadata(new MetaData)
-    {
-        setName(name);
+namespace Typelib {
+Type::Type(std::string const &name, size_t size, Category category)
+    : m_size(size), m_category(category), m_metadata(new MetaData) {
+    setName(name);
+}
+
+Type::Type(Type const &type)
+    : m_name(type.m_name), m_size(type.m_size), m_category(type.m_category),
+      m_metadata(new MetaData(*type.m_metadata)) {}
+
+Type::~Type() { delete m_metadata; }
+
+std::string Type::getName() const { return m_name; }
+std::string Type::getBasename() const { return getTypename(m_name); }
+std::string Type::getNamespace() const { return Typelib::getNamespace(m_name); }
+void Type::setName(const std::string &name) { m_name = name; }
+Type::Category Type::getCategory() const { return m_category; }
+void Type::modifiedDependencyAliases(Registry &registry) const {}
+
+void Type::setSize(size_t size) { m_size = size; }
+size_t Type::getSize() const { return m_size; }
+bool Type::isNull() const { return m_category == NullType; }
+bool Type::operator!=(Type const &with) const { return (this != &with); }
+bool Type::operator==(Type const &with) const { return (this == &with); }
+bool Type::isSame(Type const &with) const {
+    if (this == &with)
+        return true;
+
+    RecursionStack stack;
+    stack.insert(make_pair(this, &with));
+    return do_compare(with, true, stack);
+}
+bool Type::canCastTo(Type const &with) const {
+    if (this == &with)
+        return true;
+
+    RecursionStack stack;
+    stack.insert(make_pair(this, &with));
+    return do_compare(with, false, stack);
+}
+
+unsigned int Type::getTrailingPadding() const { return 0; }
+
+bool Type::rec_compare(Type const &left, Type const &right, bool equality,
+                       RecursionStack &stack) const {
+    if (&left == &right)
+        return true;
+
+    RecursionStack::const_iterator it = stack.find(&left);
+    if (it != stack.end()) {
+        /** One type cannot be equal to two different types. So either we
+         * are already comparing left and right and it is fine (return
+         * true). Or we are comparing it with a different type and that
+         * means the two types are different (return false)
+         */
+        return (&right == it->second);
     }
 
-    Type::Type(Type const& type)
-        : m_name(type.m_name)
-        , m_size(type.m_size)
-        , m_category(type.m_category)
-        , m_metadata(new MetaData(*type.m_metadata))
-    {
+    RecursionStack::iterator new_it =
+        stack.insert(make_pair(&left, &right)).first;
+    try {
+        return left.do_compare(right, equality, stack);
+    } catch (...) {
+        stack.erase(new_it);
+        throw;
     }
+}
+bool Type::do_compare(Type const &other, bool equality,
+                      RecursionStack &stack) const {
+    return (getSize() == other.getSize() &&
+            getCategory() == other.getCategory());
+}
 
-    Type::~Type()
-    {
-        delete m_metadata;
-    }
-
-    std::string Type::getName() const { return m_name; }
-    std::string Type::getBasename() const { return getTypename(m_name); }
-    std::string Type::getNamespace() const { return Typelib::getNamespace(m_name); }
-    void Type::setName(const std::string& name) { m_name = name; }
-    Type::Category Type::getCategory() const { return m_category; }
-    void Type::modifiedDependencyAliases(Registry& registry) const {}
-
-    void   Type::setSize(size_t size) { m_size = size; }
-    size_t Type::getSize() const { return m_size; }
-    bool   Type::isNull() const { return m_category == NullType; }
-    bool   Type::operator != (Type const& with) const { return (this != &with); }
-    bool   Type::operator == (Type const& with) const { return (this == &with); }
-    bool   Type::isSame(Type const& with) const
-    { 
-        if (this == &with)
-            return true;
-
-        RecursionStack stack;
-        stack.insert(make_pair(this, &with));
-        return do_compare(with, true, stack);
-    }
-    bool   Type::canCastTo(Type const& with) const
-    {
-        if (this == &with)
-            return true;
-
-        RecursionStack stack;
-        stack.insert(make_pair(this, &with));
-        return do_compare(with, false, stack);
-    }
-
-    unsigned int Type::getTrailingPadding() const
-    { return 0; }
-
-    bool Type::rec_compare(Type const& left, Type const& right, bool equality, RecursionStack& stack) const
-    {
-        if (&left == &right)
-            return true;
-
-        RecursionStack::const_iterator it = stack.find(&left);
-        if (it != stack.end())
-        {
-            /** One type cannot be equal to two different types. So either we
-             * are already comparing left and right and it is fine (return
-             * true). Or we are comparing it with a different type and that
-             * means the two types are different (return false)
-             */
-            return (&right == it->second);
-        }
-
-        RecursionStack::iterator new_it = stack.insert( make_pair(&left, &right) ).first;
-        try {
-            return left.do_compare(right, equality, stack);
-        }
-        catch(...) {
-            stack.erase(new_it);
-            throw;
-        }
-    }
-    bool Type::do_compare(Type const& other, bool equality, RecursionStack& stack) const
-    { return (getSize() == other.getSize() && getCategory() == other.getCategory()); }
-
-    Type const& Type::merge(Registry& registry) const
-    {
-        RecursionStack stack;
-        return merge(registry, stack);
-    }
-    Type const* Type::try_merge(Registry& registry, RecursionStack& stack) const
-    {
-        RecursionStack::iterator it = stack.find(this);
-        if (it != stack.end())
-            return it->second;
-
-	Type const* old_type = registry.get(getName());
-	if (old_type)
-	{
-            if (old_type->do_compare(*this, true, stack))
-            {
-                stack.insert(make_pair(this, old_type));
-		return old_type;
-            }
-	    else
-		throw DefinitionMismatch(getName());
-	}
-        return 0;
-    }
-    Type const& Type::merge(Registry& registry, RecursionStack& stack) const
-    {
-        Type const* old_type = try_merge(registry, stack);
-        if (old_type)
-            return *old_type;
-
-	Type* new_type = do_merge(registry, stack);
-        stack.insert(make_pair(this, new_type));
-	registry.add(new_type);
-	return *new_type;
-    }
-
-    bool Type::resize(Registry& registry, std::map<std::string, std::pair<size_t, size_t> >& new_sizes)
-    {
-        size_t old_size = getSize();
-        if (new_sizes.count(getName()))
-            return true;
-        else if (do_resize(registry, new_sizes))
-        {
-            new_sizes.insert(make_pair(getName(), make_pair(old_size, getSize()) ));
-            return true;
-        }
-        else
-            return false;
-    }
-
-    bool Type::do_resize(Registry& into, std::map<std::string, std::pair<size_t, size_t> >& new_sizes)
-    {
-        map<std::string, std::pair<size_t, size_t> >::const_iterator it =
-            new_sizes.find(getName());
-        if (it != new_sizes.end())
-        {
-            size_t new_size = it->second.second;
-            if (getSize() != new_size)
-            {
-                setSize(new_size);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    MetaData& Type::getMetaData() const
-    {
-        return *m_metadata;
-    }
-
-    MetaData::Values Type::getMetaData(std::string const& key) const
-    {
-        return m_metadata->get(key);
-    }
-
-    void Type::mergeMetaData(Type const& other) const
-    {
-        m_metadata->merge(other.getMetaData());
-    }
-
-    MetaData::Map const& MetaData::get() const
-    {
-        return m_values;
-    }
-
-    MetaData::Values MetaData::get(std::string const& key) const
-    {
-        Map::const_iterator it = m_values.find(key);
-        if (it == m_values.end())
-            return Values();
+Type const &Type::merge(Registry &registry) const {
+    RecursionStack stack;
+    return merge(registry, stack);
+}
+Type const *Type::try_merge(Registry &registry, RecursionStack &stack) const {
+    RecursionStack::iterator it = stack.find(this);
+    if (it != stack.end())
         return it->second;
+
+    Type const *old_type = registry.get(getName());
+    if (old_type) {
+        if (old_type->do_compare(*this, true, stack)) {
+            stack.insert(make_pair(this, old_type));
+            return old_type;
+        } else
+            throw DefinitionMismatch(getName());
     }
+    return 0;
+}
+Type const &Type::merge(Registry &registry, RecursionStack &stack) const {
+    Type const *old_type = try_merge(registry, stack);
+    if (old_type)
+        return *old_type;
 
-    void MetaData::set(std::string const& key, std::string const& value)
-    {
-        clear(key);
-        add(key, value);
-    }
+    Type *new_type = do_merge(registry, stack);
+    stack.insert(make_pair(this, new_type));
+    registry.add(new_type);
+    return *new_type;
+}
 
-    void MetaData::add(std::string const& key, std::string const& value)
-    {
-        m_values[key].insert(value);
-    }
-
-    void MetaData::clear(std::string const& key)
-    {
-        m_values.erase(key);
-    }
-
-    void MetaData::clear()
-    {
-        m_values.clear();
-    }
-
-    void MetaData::merge(MetaData const& metadata)
-    {
-        Map const& values = metadata.m_values;
-        for (Map::const_iterator it = values.begin(); it != values.end(); ++it)
-            m_values[it->first].insert(it->second.begin(), it->second.end());
-    }
-
-    bool OpaqueType::do_compare(Type const& other, bool equality, std::map<Type const*, Type const*>& stack) const
-    { return Type::do_compare(other, equality, stack) && getName() == other.getName(); }
-
-    Numeric::Numeric(std::string const& name, size_t size, NumericCategory category)
-        : Type(name, size, Type::Numeric), m_category(category) {}
-    Numeric::NumericCategory Numeric::getNumericCategory() const { return m_category; }
-    bool Numeric::do_compare(Type const& type, bool equality, RecursionStack& stack) const 
-    { return getSize() == type.getSize() && getCategory() == type.getCategory() && 
-	m_category == static_cast<Numeric const&>(type).m_category; }
-    Type* Numeric::do_merge(Registry& registry, RecursionStack& stack) const
-    { return new Numeric(*this); }
-
-    Indirect::Indirect(std::string const& name, size_t size, Category category, Type const& on)
-        : Type(name, size, category)
-        , m_indirection(on) {}
-    Type const& Indirect::getIndirection() const { return m_indirection; }
-    bool Indirect::do_compare(Type const& type, bool equality, RecursionStack& stack) const
-    { return Type::do_compare(type, equality, stack) &&
-        rec_compare(m_indirection, static_cast<Indirect const&>(type).m_indirection, equality, stack); }
-    std::set<Type const*> Indirect::dependsOn() const
-    {
-	std::set<Type const*> result;
-	result.insert(&getIndirection());
-	return result;
-    }
-    Type const& Indirect::merge(Registry& registry, RecursionStack& stack) const
-    {
-        Type const* old_type = try_merge(registry, stack);
-        if (old_type) return *old_type;
-        // First, make sure the indirection is already merged and then merge
-        // this type
-        getIndirection().merge(registry, stack);
-
-        return Type::merge(registry, stack);
-    }
-
-    void Indirect::modifiedDependencyAliases(Registry& registry) const
-    {
-        std::string full_name = getName();
-        set<string> aliases = registry.getAliasesOf(getIndirection());
-        for (set<string>::const_iterator alias_it = aliases.begin();
-                alias_it != aliases.end(); ++alias_it)
-        {
-            std::string alias_name = getIndirectTypeName(*alias_it);
-            if (!registry.has(alias_name, false))
-                registry.alias(full_name, alias_name, false);
-        }
-    }
-
-    bool Indirect::do_resize(Registry& registry, std::map<std::string, std::pair<size_t, size_t> >& new_sizes)
-    {
-        bool result = Type::do_resize(registry, new_sizes);
-        return registry.get_(getIndirection()).resize(registry, new_sizes) || result;
-    }
-
-    Compound::Compound(std::string const& name)
-        : Type(name, 0, Type::Compound) {}
-
-    Compound::FieldList const&  Compound::getFields() const { return m_fields; }
-    Field const* Compound::getField(const std::string& name) const 
-    {
-        for (FieldList::const_iterator it = m_fields.begin(); it != m_fields.end(); ++it)
-        {
-            if (it -> getName() == name)
-                return &(*it);
-        }
-        return 0;
-    }
-    unsigned int Compound::getTrailingPadding() const
-    {
-        if (m_fields.empty())
-            return getSize();
-
-        FieldList::const_iterator it = m_fields.begin();
-        FieldList::const_iterator const end = m_fields.end();
-
-        int max_offset = 0;
-        for (; it != end; ++it)
-        {
-            int offset = it->getOffset() + it->getType().getSize();
-            if (offset > max_offset)
-                max_offset = offset;
-        }
-        return getSize() - max_offset;
-    }
-    bool Compound::do_compare(Type const& type, bool equality, RecursionStack& stack) const
-    { 
-        if (type.getCategory() != Type::Compound)
-            return false;
-        if (equality && !Type::do_compare(type, true, stack))
-            return false;
-
-        Compound const& right_type = static_cast<Compound const&>(type);
-        if (m_fields.size() != right_type.getFields().size())
-            return false;
-
-        FieldList::const_iterator left_it = m_fields.begin(),
-            left_end = m_fields.end(),
-            right_it = right_type.getFields().begin();
-
-        while (left_it != left_end)
-        {
-            if (left_it->getName() != right_it->getName()
-                    || left_it->m_offset != right_it->m_offset
-                    || left_it->m_name != right_it->m_name)
-                return false;
-
-            if (!rec_compare(left_it->getType(), right_it->getType(), equality, stack))
-                return false;
-            ++left_it; ++right_it;
-        }
+bool
+Type::resize(Registry &registry,
+             std::map<std::string, std::pair<size_t, size_t> > &new_sizes) {
+    size_t old_size = getSize();
+    if (new_sizes.count(getName()))
         return true;
-    }
-
-    Field const& Compound::addField(const std::string& name, Type const& type, size_t offset) 
-    { return addField( Field(name, type), offset ); }
-    Field const& Compound::addField(Field const& field, size_t offset)
-    {
-        m_fields.push_back(field);
-        m_fields.back().setOffset(offset);
-	size_t old_size = getSize();
-	size_t new_size = offset + field.getType().getSize();
-	if (old_size < new_size)
-	    setSize(new_size);
-        return m_fields.back();
-    }
-    Type* Compound::do_merge(Registry& registry, RecursionStack& stack) const
-    {
-	auto_ptr<Compound> result(new Compound(getName()));
-        RecursionStack::iterator it = stack.insert(make_pair(this, result.get())).first;
-
-        try  {
-            for (FieldList::const_iterator it = m_fields.begin(); it != m_fields.end(); ++it)
-                result->addField(it->getName(), it->getType().merge(registry, stack), it->getOffset());
-        }
-        catch(...) {
-            stack.erase(it);
-            throw;
-        }
-
-        result->setSize(getSize());
-	return result.release();
-    }
-    std::set<Type const*> Compound::dependsOn() const
-    {
-	std::set<Type const*> result;
-        for (FieldList::const_iterator it = m_fields.begin(); it != m_fields.end(); ++it)
-	    result.insert(&(it->getType()));
-	return result;
-    }
-
-    bool Compound::do_resize(Registry& registry, std::map<std::string, std::pair<size_t, size_t> >& new_sizes)
-    {
-        size_t global_offset = 0;
-        for (FieldList::iterator it = m_fields.begin(); it != m_fields.end(); ++it)
-        {
-            it->setOffset(it->getOffset() + global_offset);
-
-            Type& field_type = registry.get_(it->getType());
-            if (field_type.resize(registry, new_sizes))
-            {
-                size_t old_size = new_sizes.find(field_type.getName())->second.first;
-                global_offset += field_type.getSize() - old_size;
-            }
-        }
-        if (global_offset != 0)
-        {
-            setSize(getSize() + global_offset);
-            return true;
-        }
+    else if (do_resize(registry, new_sizes)) {
+        new_sizes.insert(make_pair(getName(), make_pair(old_size, getSize())));
+        return true;
+    } else
         return false;
-    }
+}
 
-    void Compound::mergeMetaData(Type const& other) const
-    {
-        Type::mergeMetaData(other);
-        Compound const* other_compound = dynamic_cast<Compound const*>(&other);
-        if (other_compound)
-        {
-            for (FieldList::const_iterator it = m_fields.begin(); it != m_fields.end(); ++it)
-            {
-                Field const* other_field = other_compound->getField(it->getName());
-                if (other_field)
-                    it->mergeMetaData(*other_field);
-            }
-        }
-    }
-
-    Enum::AlreadyExists::AlreadyExists(Type const& type, std::string const& name)
-        : std::runtime_error("enumeration symbol " + name + " is already used in " + type.getName()) {}
-    Enum::SymbolNotFound::SymbolNotFound(Type const& type, std::string const& name)
-            : std::runtime_error("enumeration symbol " + name + " does not exist in " + type.getName()) {}
-    Enum::ValueNotFound::ValueNotFound(Type const& type, int value)
-            : std::runtime_error("no symbol associated with " + boost::lexical_cast<std::string>(value)  + " in " + type.getName()) {}
-
-    namespace
-    {
-        enum FindSizeOfEnum { EnumField };
-        BOOST_STATIC_ASSERT(( sizeof(FindSizeOfEnum) == sizeof(Enum::integral_type) ));
-    }
-    Enum::Enum(const std::string& name, Enum::integral_type initial_value)
-        : Type (name, sizeof(FindSizeOfEnum), Type::Enum)
-        , m_last_value(initial_value - 1) { }
-    Enum::ValueMap const& Enum::values() const { return m_values; }
-    bool Enum::do_compare(Type const& type, bool equality, RecursionStack& stack) const
-    {
-        Enum const& other_type = static_cast<Enum const&>(type);
-        if (!Type::do_compare(type, equality, stack))
-            return true;
-        if (equality)
-            return (m_values == other_type.m_values);
-        else
-        {
-            ValueMap const& other_values = other_type.m_values;
-            // returns true if +self+ is a subset of +type+
-            if (m_values.size() > other_values.size())
-                return false;
-            for (ValueMap::const_iterator it = m_values.begin(); it != m_values.end(); ++it)
-            {
-                ValueMap::const_iterator other_it = other_values.find(it->first);
-                if (other_it == other_values.end())
-                    return false;
-                if (other_it->second != it->second)
-                    return false;
-            }
+bool
+Type::do_resize(Registry &into,
+                std::map<std::string, std::pair<size_t, size_t> > &new_sizes) {
+    map<std::string, std::pair<size_t, size_t> >::const_iterator it =
+        new_sizes.find(getName());
+    if (it != new_sizes.end()) {
+        size_t new_size = it->second.second;
+        if (getSize() != new_size) {
+            setSize(new_size);
             return true;
         }
     }
+    return false;
+}
 
-    Enum::integral_type Enum::getNextValue() const { return m_last_value + 1; }
-    void Enum::add(std::string const& name, int value)
-    { 
-        std::pair<ValueMap::iterator, bool> inserted;
-        inserted = m_values.insert( make_pair(name, value) );
-        if (!inserted.second && inserted.first->second != value)
-            throw AlreadyExists(*this, name);
-        m_last_value = value;
-    }
-    Enum::integral_type  Enum::get(std::string const& name) const
-    {
-        ValueMap::const_iterator it = m_values.find(name);
-        if (it == m_values.end())
-            throw SymbolNotFound(*this, name);
-        else
-            return it->second;
-    }
-    std::string Enum::get(Enum::integral_type value) const
-    {
-        ValueMap::const_iterator it;
-        for (it = m_values.begin(); it != m_values.end(); ++it)
-        {
-            if (it->second == value)
-                return it->first;
-        }
-        throw ValueNotFound(*this, value);
-    }
-    std::list<std::string> Enum::names() const
-    {
-        list<string> ret;
-        ValueMap::const_iterator it;
-        for (it = m_values.begin(); it != m_values.end(); ++it)
-            ret.push_back(it->first);
-        return ret;
-    }
-    Type* Enum::do_merge(Registry& registry, RecursionStack& stack) const
-    { return new Enum(*this); }
+MetaData &Type::getMetaData() const { return *m_metadata; }
 
-    Array::Array(Type const& of, size_t new_dim)
-        : Indirect(getArrayName(of.getName(), new_dim), new_dim * of.getSize(), Type::Array, of)
-        , m_dimension(new_dim) { }
+MetaData::Values Type::getMetaData(std::string const &key) const {
+    return m_metadata->get(key);
+}
 
-    std::string Array::getIndirectTypeName(std::string const& inside_type_name) const
-    {
-        return Array::getArrayName(inside_type_name, getDimension());
-    }
+void Type::mergeMetaData(Type const &other) const {
+    m_metadata->merge(other.getMetaData());
+}
 
-    std::string Array::getArrayName(std::string const& name, size_t dim)
-    { 
-        std::ostringstream stream;
-        stream << name << '[' << dim << ']';
-        return stream.str();
-    }
-    size_t  Array::getDimension() const { return m_dimension; }
-    bool Array::do_compare(Type const& type, bool equality, RecursionStack& stack) const
-    {
-	if (!Type::do_compare(type, equality, stack))
-	    return false;
+MetaData::Map const &MetaData::get() const { return m_values; }
 
-	Array const& array = static_cast<Array const&>(type);
-	return (m_dimension == array.m_dimension) && Indirect::do_compare(type, true, stack);
-    }
-    Type* Array::do_merge(Registry& registry, RecursionStack& stack) const
-    {
-        // The pointed-to type has already been inserted in the repository by
-        // Indirect::merge, so we don't have to worry.
-        Type const& indirect_type = getIndirection().merge(registry, stack);
-        return new Array(indirect_type, m_dimension);
-    }
+MetaData::Values MetaData::get(std::string const &key) const {
+    Map::const_iterator it = m_values.find(key);
+    if (it == m_values.end())
+        return Values();
+    return it->second;
+}
 
-    bool Array::do_resize(Registry& registry, std::map<std::string, std::pair<size_t, size_t> >& new_sizes)
-    {
-        if (!Indirect::do_resize(registry, new_sizes))
+void MetaData::set(std::string const &key, std::string const &value) {
+    clear(key);
+    add(key, value);
+}
+
+void MetaData::add(std::string const &key, std::string const &value) {
+    m_values[key].insert(value);
+}
+
+void MetaData::clear(std::string const &key) { m_values.erase(key); }
+
+void MetaData::clear() { m_values.clear(); }
+
+void MetaData::merge(MetaData const &metadata) {
+    Map const &values = metadata.m_values;
+    for (Map::const_iterator it = values.begin(); it != values.end(); ++it)
+        m_values[it->first].insert(it->second.begin(), it->second.end());
+}
+
+bool OpaqueType::do_compare(Type const &other, bool equality,
+                            std::map<Type const *, Type const *> &stack) const {
+    return Type::do_compare(other, equality, stack) &&
+           getName() == other.getName();
+}
+
+Numeric::Numeric(std::string const &name, size_t size, NumericCategory category)
+    : Type(name, size, Type::Numeric), m_category(category) {}
+Numeric::NumericCategory Numeric::getNumericCategory() const {
+    return m_category;
+}
+bool Numeric::do_compare(Type const &type, bool equality,
+                         RecursionStack &stack) const {
+    return getSize() == type.getSize() && getCategory() == type.getCategory() &&
+           m_category == static_cast<Numeric const &>(type).m_category;
+}
+Type *Numeric::do_merge(Registry &registry, RecursionStack &stack) const {
+    return new Numeric(*this);
+}
+
+Indirect::Indirect(std::string const &name, size_t size, Category category,
+                   Type const &on)
+    : Type(name, size, category), m_indirection(on) {}
+Type const &Indirect::getIndirection() const { return m_indirection; }
+bool Indirect::do_compare(Type const &type, bool equality,
+                          RecursionStack &stack) const {
+    return Type::do_compare(type, equality, stack) &&
+           rec_compare(m_indirection,
+                       static_cast<Indirect const &>(type).m_indirection,
+                       equality, stack);
+}
+std::set<Type const *> Indirect::dependsOn() const {
+    std::set<Type const *> result;
+    result.insert(&getIndirection());
+    return result;
+}
+Type const &Indirect::merge(Registry &registry, RecursionStack &stack) const {
+    Type const *old_type = try_merge(registry, stack);
+    if (old_type)
+        return *old_type;
+    // First, make sure the indirection is already merged and then merge
+    // this type
+    getIndirection().merge(registry, stack);
+
+    return Type::merge(registry, stack);
+}
+
+void Indirect::modifiedDependencyAliases(Registry &registry) const {
+    std::string full_name = getName();
+    set<string> aliases = registry.getAliasesOf(getIndirection());
+    for (set<string>::const_iterator alias_it = aliases.begin();
+         alias_it != aliases.end(); ++alias_it) {
+        std::string alias_name = getIndirectTypeName(*alias_it);
+        if (!registry.has(alias_name, false))
+            registry.alias(full_name, alias_name, false);
+    }
+}
+
+bool Indirect::do_resize(
+    Registry &registry,
+    std::map<std::string, std::pair<size_t, size_t> > &new_sizes) {
+    bool result = Type::do_resize(registry, new_sizes);
+    return registry.get_(getIndirection()).resize(registry, new_sizes) ||
+           result;
+}
+
+Compound::Compound(std::string const &name) : Type(name, 0, Type::Compound) {}
+
+Compound::FieldList const &Compound::getFields() const { return m_fields; }
+Field const *Compound::getField(const std::string &name) const {
+    for (FieldList::const_iterator it = m_fields.begin(); it != m_fields.end();
+         ++it) {
+        if (it->getName() == name)
+            return &(*it);
+    }
+    return 0;
+}
+unsigned int Compound::getTrailingPadding() const {
+    if (m_fields.empty())
+        return getSize();
+
+    FieldList::const_iterator it = m_fields.begin();
+    FieldList::const_iterator const end = m_fields.end();
+
+    int max_offset = 0;
+    for (; it != end; ++it) {
+        int offset = it->getOffset() + it->getType().getSize();
+        if (offset > max_offset)
+            max_offset = offset;
+    }
+    return getSize() - max_offset;
+}
+bool Compound::do_compare(Type const &type, bool equality,
+                          RecursionStack &stack) const {
+    if (type.getCategory() != Type::Compound)
+        return false;
+    if (equality && !Type::do_compare(type, true, stack))
+        return false;
+
+    Compound const &right_type = static_cast<Compound const &>(type);
+    if (m_fields.size() != right_type.getFields().size())
+        return false;
+
+    FieldList::const_iterator left_it = m_fields.begin(),
+                              left_end = m_fields.end(),
+                              right_it = right_type.getFields().begin();
+
+    while (left_it != left_end) {
+        if (left_it->getName() != right_it->getName() ||
+            left_it->m_offset != right_it->m_offset ||
+            left_it->m_name != right_it->m_name)
             return false;
 
-        setSize(getDimension() * getIndirection().getSize());
+        if (!rec_compare(left_it->getType(), right_it->getType(), equality,
+                         stack))
+            return false;
+        ++left_it;
+        ++right_it;
+    }
+    return true;
+}
+
+Field const &Compound::addField(const std::string &name, Type const &type,
+                                size_t offset) {
+    return addField(Field(name, type), offset);
+}
+Field const &Compound::addField(Field const &field, size_t offset) {
+    m_fields.push_back(field);
+    m_fields.back().setOffset(offset);
+    size_t old_size = getSize();
+    size_t new_size = offset + field.getType().getSize();
+    if (old_size < new_size)
+        setSize(new_size);
+    return m_fields.back();
+}
+Type *Compound::do_merge(Registry &registry, RecursionStack &stack) const {
+    auto_ptr<Compound> result(new Compound(getName()));
+    RecursionStack::iterator it =
+        stack.insert(make_pair(this, result.get())).first;
+
+    try {
+        for (FieldList::const_iterator it = m_fields.begin();
+             it != m_fields.end(); ++it)
+            result->addField(it->getName(),
+                             it->getType().merge(registry, stack),
+                             it->getOffset());
+    } catch (...) {
+        stack.erase(it);
+        throw;
+    }
+
+    result->setSize(getSize());
+    return result.release();
+}
+std::set<Type const *> Compound::dependsOn() const {
+    std::set<Type const *> result;
+    for (FieldList::const_iterator it = m_fields.begin(); it != m_fields.end();
+         ++it)
+        result.insert(&(it->getType()));
+    return result;
+}
+
+bool Compound::do_resize(
+    Registry &registry,
+    std::map<std::string, std::pair<size_t, size_t> > &new_sizes) {
+    size_t global_offset = 0;
+    for (FieldList::iterator it = m_fields.begin(); it != m_fields.end();
+         ++it) {
+        it->setOffset(it->getOffset() + global_offset);
+
+        Type &field_type = registry.get_(it->getType());
+        if (field_type.resize(registry, new_sizes)) {
+            size_t old_size =
+                new_sizes.find(field_type.getName())->second.first;
+            global_offset += field_type.getSize() - old_size;
+        }
+    }
+    if (global_offset != 0) {
+        setSize(getSize() + global_offset);
         return true;
     }
+    return false;
+}
 
-    Pointer::Pointer(const Type& on)
-        : Indirect( getPointerName(on.getName()), sizeof(int *), Type::Pointer, on) {}
-    std::string Pointer::getPointerName(std::string const& base)
-    { return base + '*'; }
-    std::string Pointer::getIndirectTypeName(std::string const& inside_type_name) const
-    {
-        return Pointer::getPointerName(inside_type_name);
+void Compound::mergeMetaData(Type const &other) const {
+    Type::mergeMetaData(other);
+    Compound const *other_compound = dynamic_cast<Compound const *>(&other);
+    if (other_compound) {
+        for (FieldList::const_iterator it = m_fields.begin();
+             it != m_fields.end(); ++it) {
+            Field const *other_field = other_compound->getField(it->getName());
+            if (other_field)
+                it->mergeMetaData(*other_field);
+        }
     }
+}
 
-    Type* Pointer::do_merge(Registry& registry, RecursionStack& stack) const
-    {
-        // The pointed-to type has already been inserted in the repository by
-        // Indirect::merge, so we don't have to worry.
-        Type const& indirect_type = getIndirection().merge(registry, stack);
-        return new Pointer(indirect_type);
+Enum::AlreadyExists::AlreadyExists(Type const &type, std::string const &name)
+    : std::runtime_error("enumeration symbol " + name + " is already used in " +
+                         type.getName()) {}
+Enum::SymbolNotFound::SymbolNotFound(Type const &type, std::string const &name)
+    : std::runtime_error("enumeration symbol " + name + " does not exist in " +
+                         type.getName()) {}
+Enum::ValueNotFound::ValueNotFound(Type const &type, int value)
+    : std::runtime_error("no symbol associated with " +
+                         boost::lexical_cast<std::string>(value) + " in " +
+                         type.getName()) {}
+
+namespace {
+enum FindSizeOfEnum { EnumField };
+BOOST_STATIC_ASSERT((sizeof(FindSizeOfEnum) == sizeof(Enum::integral_type)));
+}
+Enum::Enum(const std::string &name, Enum::integral_type initial_value)
+    : Type(name, sizeof(FindSizeOfEnum), Type::Enum),
+      m_last_value(initial_value - 1) {}
+Enum::ValueMap const &Enum::values() const { return m_values; }
+bool Enum::do_compare(Type const &type, bool equality,
+                      RecursionStack &stack) const {
+    Enum const &other_type = static_cast<Enum const &>(type);
+    if (!Type::do_compare(type, equality, stack))
+        return true;
+    if (equality)
+        return (m_values == other_type.m_values);
+    else {
+        ValueMap const &other_values = other_type.m_values;
+        // returns true if +self+ is a subset of +type+
+        if (m_values.size() > other_values.size())
+            return false;
+        for (ValueMap::const_iterator it = m_values.begin();
+             it != m_values.end(); ++it) {
+            ValueMap::const_iterator other_it = other_values.find(it->first);
+            if (other_it == other_values.end())
+                return false;
+            if (other_it->second != it->second)
+                return false;
+        }
+        return true;
     }
+}
 
-    Container::Container(std::string const& kind, std::string const& name, size_t size, Type const& of)
-        : Indirect( name, size, Type::Container, of )
-        , m_kind(kind) {}
-
-    std::string Container::kind() const { return m_kind; }
-
-    Container::AvailableContainers* Container::s_available_containers;
-    Container::AvailableContainers Container::availableContainers() {
-        if (!s_available_containers)
-            return Container::AvailableContainers();
-        return *s_available_containers;
+Enum::integral_type Enum::getNextValue() const { return m_last_value + 1; }
+void Enum::add(std::string const &name, int value) {
+    std::pair<ValueMap::iterator, bool> inserted;
+    inserted = m_values.insert(make_pair(name, value));
+    if (!inserted.second && inserted.first->second != value)
+        throw AlreadyExists(*this, name);
+    m_last_value = value;
+}
+Enum::integral_type Enum::get(std::string const &name) const {
+    ValueMap::const_iterator it = m_values.find(name);
+    if (it == m_values.end())
+        throw SymbolNotFound(*this, name);
+    else
+        return it->second;
+}
+std::string Enum::get(Enum::integral_type value) const {
+    ValueMap::const_iterator it;
+    for (it = m_values.begin(); it != m_values.end(); ++it) {
+        if (it->second == value)
+            return it->first;
     }
+    throw ValueNotFound(*this, value);
+}
+std::list<std::string> Enum::names() const {
+    list<string> ret;
+    ValueMap::const_iterator it;
+    for (it = m_values.begin(); it != m_values.end(); ++it)
+        ret.push_back(it->first);
+    return ret;
+}
+Type *Enum::do_merge(Registry &registry, RecursionStack &stack) const {
+    return new Enum(*this);
+}
 
-    void Container::registerContainer(std::string const& name, ContainerFactory factory)
-    {
-        if (s_available_containers == 0)
-            s_available_containers = new Container::AvailableContainers;
+Array::Array(Type const &of, size_t new_dim)
+    : Indirect(getArrayName(of.getName(), new_dim), new_dim * of.getSize(),
+               Type::Array, of),
+      m_dimension(new_dim) {}
 
-        (*s_available_containers)[name] = factory;
-    }
-    Container const& Container::createContainer(Registry& r, std::string const& name, Type const& on)
-    {
-        std::list<Type const*> temp;
-        temp.push_back(&on);
-        return createContainer(r, name, temp);
-    }
-    Container const& Container::createContainer(Registry& r, std::string const& name, std::list<Type const*> const& on)
-    {
-        AvailableContainers::const_iterator it = s_available_containers->find(name);
-        if (it == s_available_containers->end())
-            throw UnknownContainer(name);
-        return (*it->second)(r, on);
-    }
+std::string
+Array::getIndirectTypeName(std::string const &inside_type_name) const {
+    return Array::getArrayName(inside_type_name, getDimension());
+}
 
-    bool Container::do_compare(Type const& other, bool equality, RecursionStack& stack) const
-    {
-	if (!Type::do_compare(other, true, stack))
-	    return false;
+std::string Array::getArrayName(std::string const &name, size_t dim) {
+    std::ostringstream stream;
+    stream << name << '[' << dim << ']';
+    return stream.str();
+}
+size_t Array::getDimension() const { return m_dimension; }
+bool Array::do_compare(Type const &type, bool equality,
+                       RecursionStack &stack) const {
+    if (!Type::do_compare(type, equality, stack))
+        return false;
 
-	Container const& container = static_cast<Container const&>(other);
-	return (getFactory() == container.getFactory()) && Indirect::do_compare(other, true, stack);
-    }
+    Array const &array = static_cast<Array const &>(type);
+    return (m_dimension == array.m_dimension) &&
+           Indirect::do_compare(type, true, stack);
+}
+Type *Array::do_merge(Registry &registry, RecursionStack &stack) const {
+    // The pointed-to type has already been inserted in the repository by
+    // Indirect::merge, so we don't have to worry.
+    Type const &indirect_type = getIndirection().merge(registry, stack);
+    return new Array(indirect_type, m_dimension);
+}
 
-    Type* Container::do_merge(Registry& registry, RecursionStack& stack) const
-    {
-        // The pointed-to type has already been inserted in the repository by
-        // Indirect::merge, so we don't have to worry.
-        Type const& indirect_type = getIndirection().merge(registry, stack);
-        std::list<Type const*> on;
-        on.push_back(&indirect_type);
-        Container* result = const_cast<Container*>(&(*getFactory())(registry, on));
-        result->setSize(getSize());
-        return result;
-    }
+bool
+Array::do_resize(Registry &registry,
+                 std::map<std::string, std::pair<size_t, size_t> > &new_sizes) {
+    if (!Indirect::do_resize(registry, new_sizes))
+        return false;
 
-    bool Container::isRandomAccess() const { return false; }
-    void Container::setElement(void* ptr, int idx, Typelib::Value value) const
-    { throw std::logic_error("trying to use setElement on a container that is not random-access"); }
-    Typelib::Value Container::getElement(void* ptr, int idx) const
-    { throw std::logic_error("trying to use getElement on a container that is not random-access"); }
+    setSize(getDimension() * getIndirection().getSize());
+    return true;
+}
 
-    Field::Field(const std::string& name, const Type& type)
-        : m_name(name), m_type(type), m_offset(0), m_metadata(new MetaData) {}
-    Field::~Field()
-    {
-        delete m_metadata;
-    }
-    Field::Field(Field const& field)
-        : m_name(field.m_name)
-        , m_type(field.m_type)
-        , m_offset(field.m_offset)
-        , m_metadata(new MetaData(*field.m_metadata))
-    {
-    }
+Pointer::Pointer(const Type &on)
+    : Indirect(getPointerName(on.getName()), sizeof(int *), Type::Pointer, on) {
+}
+std::string Pointer::getPointerName(std::string const &base) {
+    return base + '*';
+}
+std::string
+Pointer::getIndirectTypeName(std::string const &inside_type_name) const {
+    return Pointer::getPointerName(inside_type_name);
+}
 
-    std::string Field::getName() const { return m_name; }
-    Type const& Field::getType() const { return m_type; }
-    size_t  Field::getOffset() const { return m_offset; }
-    void    Field::setOffset(size_t offset) { m_offset = offset; }
-    bool Field::operator == (Field const& field) const
-    { return m_offset == field.m_offset && m_name == field.m_name && m_type.isSame(field.m_type); }
-    MetaData& Field::getMetaData() const
-    { return *m_metadata; }
-    MetaData::Values Field::getMetaData(std::string const& key) const
-    { return m_metadata->get(key); }
-    void Field::mergeMetaData(Field const& field) const
-    { return m_metadata->merge(field.getMetaData()); }
+Type *Pointer::do_merge(Registry &registry, RecursionStack &stack) const {
+    // The pointed-to type has already been inserted in the repository by
+    // Indirect::merge, so we don't have to worry.
+    Type const &indirect_type = getIndirection().merge(registry, stack);
+    return new Pointer(indirect_type);
+}
 
+Container::Container(std::string const &kind, std::string const &name,
+                     size_t size, Type const &of)
+    : Indirect(name, size, Type::Container, of), m_kind(kind) {}
 
-    BadCategory::BadCategory(Type::Category found, int expected)
-        : TypeException("bad category: found " + lexical_cast<string>(found) + " expecting " + lexical_cast<string>(expected))
-        , found(found), expected(expected) {}
-    NullTypeFound::NullTypeFound()
-        : TypeException("null type found") { }
-    NullTypeFound::NullTypeFound(Type const& type)
-        : TypeException("null type " + type.getName() + " found") { }
+std::string Container::kind() const { return m_kind; }
+
+Container::AvailableContainers *Container::s_available_containers;
+Container::AvailableContainers Container::availableContainers() {
+    if (!s_available_containers)
+        return Container::AvailableContainers();
+    return *s_available_containers;
+}
+
+void Container::registerContainer(std::string const &name,
+                                  ContainerFactory factory) {
+    if (s_available_containers == 0)
+        s_available_containers = new Container::AvailableContainers;
+
+    (*s_available_containers)[name] = factory;
+}
+Container const &Container::createContainer(Registry &r,
+                                            std::string const &name,
+                                            Type const &on) {
+    std::list<Type const *> temp;
+    temp.push_back(&on);
+    return createContainer(r, name, temp);
+}
+Container const &Container::createContainer(Registry &r,
+                                            std::string const &name,
+                                            std::list<Type const *> const &on) {
+    AvailableContainers::const_iterator it = s_available_containers->find(name);
+    if (it == s_available_containers->end())
+        throw UnknownContainer(name);
+    return (*it->second)(r, on);
+}
+
+bool Container::do_compare(Type const &other, bool equality,
+                           RecursionStack &stack) const {
+    if (!Type::do_compare(other, true, stack))
+        return false;
+
+    Container const &container = static_cast<Container const &>(other);
+    return (getFactory() == container.getFactory()) &&
+           Indirect::do_compare(other, true, stack);
+}
+
+Type *Container::do_merge(Registry &registry, RecursionStack &stack) const {
+    // The pointed-to type has already been inserted in the repository by
+    // Indirect::merge, so we don't have to worry.
+    Type const &indirect_type = getIndirection().merge(registry, stack);
+    std::list<Type const *> on;
+    on.push_back(&indirect_type);
+    Container *result = const_cast<Container *>(&(*getFactory())(registry, on));
+    result->setSize(getSize());
+    return result;
+}
+
+bool Container::isRandomAccess() const { return false; }
+void Container::setElement(void *ptr, int idx, Typelib::Value value) const {
+    throw std::logic_error(
+        "trying to use setElement on a container that is not random-access");
+}
+Typelib::Value Container::getElement(void *ptr, int idx) const {
+    throw std::logic_error(
+        "trying to use getElement on a container that is not random-access");
+}
+
+Field::Field(const std::string &name, const Type &type)
+    : m_name(name), m_type(type), m_offset(0), m_metadata(new MetaData) {}
+Field::~Field() { delete m_metadata; }
+Field::Field(Field const &field)
+    : m_name(field.m_name), m_type(field.m_type), m_offset(field.m_offset),
+      m_metadata(new MetaData(*field.m_metadata)) {}
+
+std::string Field::getName() const { return m_name; }
+Type const &Field::getType() const { return m_type; }
+size_t Field::getOffset() const { return m_offset; }
+void Field::setOffset(size_t offset) { m_offset = offset; }
+bool Field::operator==(Field const &field) const {
+    return m_offset == field.m_offset && m_name == field.m_name &&
+           m_type.isSame(field.m_type);
+}
+MetaData &Field::getMetaData() const { return *m_metadata; }
+MetaData::Values Field::getMetaData(std::string const &key) const {
+    return m_metadata->get(key);
+}
+void Field::mergeMetaData(Field const &field) const {
+    return m_metadata->merge(field.getMetaData());
+}
+
+BadCategory::BadCategory(Type::Category found, int expected)
+    : TypeException("bad category: found " + lexical_cast<string>(found) +
+                    " expecting " + lexical_cast<string>(expected)),
+      found(found), expected(expected) {}
+NullTypeFound::NullTypeFound() : TypeException("null type found") {}
+NullTypeFound::NullTypeFound(Type const &type)
+    : TypeException("null type " + type.getName() + " found") {}
 };
-

--- a/typelib/typemodel.hh
+++ b/typelib/typemodel.hh
@@ -9,678 +9,698 @@
 #include <stdint.h>
 #include <stdexcept>
 
-namespace Typelib
-{
-    struct OutputStream;
-    struct InputStream;
+namespace Typelib {
+struct OutputStream;
+struct InputStream;
 
-    class Registry;
+class Registry;
 
-    class MetaData
-    {
-    public:
-        typedef std::set<std::string> Values;
-        typedef std::map<std::string, Values> Map;
-    private:
-        Map m_values;
-    public:
+class MetaData {
+  public:
+    typedef std::set<std::string> Values;
+    typedef std::map<std::string, Values> Map;
 
-        /** Returns the key => values map for all values stored in this metadata
-         * object
-         */
-        Map const& get() const;
+  private:
+    Map m_values;
 
-        /** Sets the metadata value for the given key to the given value,
-         * removing all previously known value(s) for that key
-         */
-        void set(std::string const& key, std::string const& value);
-
-        /** Adds a metadata value for the given key, Existing values are
-         * retained.
-         */
-        void add(std::string const& key, std::string const& value);
-
-        /** Clear all metadata entries that have this key
-         */
-        void clear(std::string const& key);
-
-        /** Clear all metadata entries
-         */
-        void clear();
-
-        /** Returns all metadata information with the given key associated with this type
-         */
-        Values get(std::string const& key) const;
-
-        /** Add all metadata entries that are in the given metadata set to the
-         * metadata of this type
-         */
-        void merge(MetaData const& metadata);
-    };
-
-    /** Base class for all type definitions */
-    class Type 
-    {
-    public:
-
-        enum Category
-        { 
-            NullType = 0,
-            Array  , 
-            Pointer, 
-            Numeric, 
-            Enum   ,
-            Compound,
-            Opaque,
-            Container
-        };
-        static const int ValidCategories = Compound + 1;
-        
-    private:
-        std::string m_name;
-
-        size_t      m_size;
-        Category    m_category;
-
-        //! This is kept as pointer so that it can be modified even if the Type
-        // object is const
-        MetaData*   m_metadata;
-
-	/** Checks that @c identifier is a valid type name */
-        static bool isValidIdentifier(const std::string& identifier);
-
-        Type& operator = (Type const& type);
-
-    protected:
-
-        // Creates a basic type from \c name, \c size and \c category
-        Type(const std::string& name, size_t size, Category category);
-
-    public:
-        virtual ~Type();
-        Type(Type const& type);
-
-        /** Changes the type name. Never use once the type has been added to a
-         * registry */
-        void setName    (const std::string& name);
-        /** Changes the type size. Don't use that unless you know what you are
-         * doing. In particular, don't use it once the type is used in a
-         * Compound.
-         */
-        void setSize    (size_t size);
-	/** The type full name (including namespace) */
-        std::string   getName() const;
-	/** The type name without the namespace */
-	std::string   getBasename() const;
-	/** The type namespace */
-	std::string   getNamespace() const;
-	/** Size in bytes of a value */
-        size_t        getSize() const;
-	/** The type category */
-        Category      getCategory() const;
-	/** true if this type is null */
-        bool          isNull() const;
-
-	/** The set of types this type depends upon
-         *
-         * This method returns the set of types that are directly depended-upon
-         * by this type
-         */
-	virtual std::set<Type const*> dependsOn() const = 0;
-
-        /** Called by the registry if one (or more) of this type's dependencies
-         * is aliased
-         *
-         * The default implementation does nothing. It is reimplemented in
-         * types for which the name is built from the dependencies' name
-         */
-        virtual void modifiedDependencyAliases(Registry& registry) const;
-
-        bool operator == (Type const& with) const;
-        bool operator != (Type const& with) const;
-
-	/** Deep check that \c other defines the same type than 
-	 * self. Basic checks on name, size and category are
-	 * performed by ==
-	 */
-	bool isSame(Type const& other) const;
-
-        /** Returns true if \c to can be used to manipulate a value that is
-         * described by \c from
-         */
-        bool canCastTo(Type const& to) const;
-
-        /** Merges this type into \c registry: creates a type equivalent to
-         * this one in the target registry, reusing possible equivalent types
-         * already present in +registry+.
-	 */
-	Type const& merge(Registry& registry) const;
-
-        /** Foreign => local mapping for merge() and isSame() */
-        typedef std::map<Type const*, Type const*> RecursionStack;
-
-        /** Base merge method. The default implementation should be fine for
-         * most types.
-         *
-         * Call try_merge to check if a type equivalent to *this exists in \c
-         * registry, and do_merge to create a copy of *this in \c registry.
-         */
-        virtual Type const& merge(Registry& registry, RecursionStack& stack) const;
-
-        /** Update this type to reflect a type resize. The default
-         * implementation will resize *this if it is listed in \c new_sizes.
-         * new_sizes gets updated with the types that are modified.
-         *
-         * This is not to be called directly. Only use Registry::resize().
-         *
-         * @return true if this type has been modified, and false otherwise.
-         */
-        virtual bool resize(Registry& registry, std::map<std::string, std::pair<size_t, size_t> >& new_sizes);
-
-        /** Returns the number of bytes that are unused at the end of the
-         * compound */
-        virtual unsigned int getTrailingPadding() const;
-
-        /** Returns the metadata for this type
-         */
-        MetaData& getMetaData() const;
-
-        /** Returns the metadata values declared for this particular key
-         */
-        MetaData::Values getMetaData(std::string const& key) const;
-
-        /** Merge metadata information from the given type into this
-         */
-        virtual void mergeMetaData(Type const& other) const;
-
-    protected:
-        /** Method that is implemented by type definitions to compare *this with
-         * \c other.
-         *
-         * If \c equality is true, the method must check for strict equality. If
-         * it is false, it must check if \c other can be used to manipulate
-         * values of type \c *this.
-         *
-         * For instance, let's consider a compound that has padding bytes, and
-         * assume that *this and \c other have different padding (but are the
-         * same on every other aspects). do_compare should then return true if
-         * equality is false, and false if equality is true.
-         *
-         * It must use rec_compare to check for indirections (i.e. for
-         * recursive calls).
-         *
-         * The base definition compares the name, size and category of the
-         * types.
-         */
-	virtual bool do_compare(Type const& other, bool equality, std::map<Type const*, Type const*>& stack) const;
-
-        /** Called by do_compare to compare +left+ to +right+. This method takes
-         * into account potential loops in the recursion
-         *
-         * See do_compare for a description of the equality flag.
-         */
-        bool rec_compare(Type const& left, Type const& right, bool equality, RecursionStack& stack) const;
-
-        /** Checks if there is already a type with the same name and definition
-         * than *this in \c registry. If that is the case, returns it, otherwise
-         * returns NULL;
-         *
-         * If there is a type with the same name, but whose definition
-         * mismatches, throws DefinitionMismatch
-         */
-        Type const* try_merge(Registry& registry, RecursionStack& stack) const;
-
-        /** Called by Type::merge when the type does not exist in \c registry
-         * already. This method has to create a new type in registry that
-         * matches the type definition of *this.
-         *
-         * All types referenced by *this must be moved to their equivalent in \c
-         * registry.
-	 */
-	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const = 0;
-
-        /** Implementation of the actual resizing. Called by resize() */
-        virtual bool do_resize(Registry& into, std::map<std::string, std::pair<size_t, size_t> >& new_sizes);
-    };
-
-    class NullType : public Type
-    {
-    public:
-        NullType(std::string const& name) : Type(name, 0, Type::NullType ) {}
-	virtual std::set<Type const*> dependsOn() const { return std::set<Type const*>(); }
-
-    private:
-	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const { return new NullType(*this); }
-    };
-
-    /** This type is to be used when we want a field to be completely ignored,
-     * while being able to handle the rest of the system. Endianness swapping
-     * will for instance completely ignore this type.
+  public:
+    /** Returns the key => values map for all values stored in this metadata
+     * object
      */
-    class OpaqueType : public Type
-    {
-    public:
-        OpaqueType(std::string const& name, size_t size) : Type(name, size, Type::Opaque) {}
-	virtual std::set<Type const*> dependsOn() const { return std::set<Type const*>(); }
-	virtual bool do_compare(Type const& other, bool equality, std::map<Type const*, Type const*>& stack) const;
-	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const { return new OpaqueType(*this); }
-    };
+    Map const &get() const;
 
-    /** Numeric values (integer, unsigned integer and floating point) */
-    class Numeric : public Type
-    {
-    public:
-        enum NumericCategory
-        { 
-	    SInt = Type::ValidCategories, /// signed integer
-	    UInt,			  /// unsigned integer
-	    Float			  /// floating point
-	};
-        static const int ValidCategories = Float + 1;
-
-	/** The category of this numeric type */
-        NumericCategory getNumericCategory() const;
-
-    public:
-        /** Creates a basic type from \c name, \c size and \c category */
-        Numeric(const std::string& name, size_t size, NumericCategory category);
-
-	virtual std::set<Type const*> dependsOn() const { return std::set<Type const*>(); }
-
-    private:
-	virtual bool do_compare(Type const& other, bool equality, RecursionStack& stack) const;
-	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const;
-        NumericCategory m_category;
-    };
-
-    /** Enums are defined as name => integer static mappings */
-    class Enum : public Type
-    {
-    public:
-        typedef int integral_type;
-        typedef std::map<std::string, int> ValueMap;
-
-        class AlreadyExists : public std::runtime_error
-        {
-        public:
-            AlreadyExists(Type const& type, std::string const& name);
-        };
-        class SymbolNotFound : public std::runtime_error
-        {
-        public:
-            SymbolNotFound(Type const& type, std::string const& name);
-        };
-        class ValueNotFound : public std::runtime_error
-        {
-        public:
-            ValueNotFound(Type const& type, int value);
-        };
-        
-        Enum(const std::string& name, Enum::integral_type initial_value = 0);
-	/** Add a new definition */
-        void            add(std::string const& name, int value);
-	/** Gets the value for @c name 
-	 * @throws SymbolNotFound if @c name is not defined */
-        integral_type   get(std::string const& name) const;
-	/** Gets the name for @c value
-	 * @throws ValueNotFound if @c value is not defined in this enum */
-        std::string     get(integral_type value) const;
-        
-	/** The list of all names */
-        std::list<std::string> names() const;
-	/** The name => value map */
-        ValueMap const& values() const;
-
-	virtual std::set<Type const*> dependsOn() const { return std::set<Type const*>(); }
-
-        /** Returns the value the next inserted element should have (it is
-         * last_inserted_value + 1) */
-        Enum::integral_type getNextValue() const;
-
-    private:
-	virtual bool do_compare(Type const& other, bool equality, RecursionStack& stack) const;
-	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const;
-        integral_type m_last_value;
-        ValueMap m_values;
-    };
-
-    /** A field in a Compound type */
-    class Field
-    {
-        friend class Compound;
-
-        std::string m_name;
-        const Type& m_type;
-        size_t m_offset;
-        MetaData* m_metadata;
-
-    private:
-        Field& operator = (Field const& field);
-    protected:
-        void setOffset(size_t offset);
-
-    public:
-        Field(const std::string& name, Type const& base_type);
-        Field(Field const& field);
-        ~Field();
-
-	/** The field name */
-        std::string getName() const;
-	/** The field type */
-        const Type& getType() const;
-	/** The offset, in bytes, of this field w.r.t. the 
-	 * begginning of the parent value */
-        size_t getOffset() const;
-
-	bool operator == (Field const& field) const;
-
-        MetaData& getMetaData() const;
-        MetaData::Values getMetaData(std::string const& key) const;
-        void mergeMetaData(Field const& field) const;
-    };
-
-    /** Base class for types that are composed of other 
-     * types (structures and enums) */
-    class Compound : public Type
-    {
-    public:
-        typedef std::list<Field> FieldList;
-
-    public:
-        Compound(std::string const& name);
-
-	/** The list of all fields */
-        FieldList const&  getFields() const;
-	/** Get a field by its name
-	 * @return 0 if there is no @name field, or the Field object */
-        Field const*      getField(const std::string& name) const;
-	/** Add a new field */
-        Field const&      addField(const Field& field, size_t offset);
-	/** Add a new field */
-        Field const&      addField(const std::string& name, const Type& type, size_t offset);
-
-        /** Returns the number of bytes that are unused at the end of the
-         * compound */
-        unsigned int getTrailingPadding() const;
-
-	virtual std::set<Type const*> dependsOn() const;
-
-        /** Merge metadata from this other type, as well as the field metadata
-         * if applicable
-         */
-        void mergeMetaData(Type const& other) const;
-
-    private:
-	virtual bool do_compare(Type const& other, bool equality, RecursionStack& stack) const;
-	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const;
-        bool do_resize(Registry& registry, std::map<std::string, std::pair<size_t, size_t> >& new_sizes);
-        FieldList m_fields;
-    };
-
-    /** Base class for types with indirection (pointer, array) */
-    class Indirect : public Type
-    {
-    public:
-        static const int ValidIDs = Type::Pointer | Type::Array;
-
-    public:
-
-        Indirect(std::string const& name, size_t size, Category category, Type const& on);
-
-        void modifiedDependencyAliases(Registry& registry) const;
-
-        Type const& getIndirection() const;
-	virtual std::set<Type const*> dependsOn() const;
-
-        virtual Type const& merge(Registry& registry, RecursionStack& stack) const;
-
-    protected:
-	virtual bool do_compare(Type const& other, bool equality, RecursionStack& stack) const;
-        virtual bool do_resize(Registry& registry, std::map<std::string, std::pair<size_t, size_t> >& new_sizes);
-
-        /** Overloaded in subclasses to return the name of this type based on
-         * the name of the indirection
-         *
-         * This is solely used by modifiedDependencyAliases() to update the set
-         * of aliases for a given type
-         */
-        virtual std::string getIndirectTypeName(std::string const& inside_name) const = 0;
-
-    private:
-        Type const& m_indirection;
-    };
-
-    /** Unidimensional array types. As in C, the multi-dimensional arrays
-     * are defined as arrays-of-arrays
+    /** Sets the metadata value for the given key to the given value,
+     * removing all previously known value(s) for that key
      */
-    class Array : public Indirect
-    {
-    public:
+    void set(std::string const &key, std::string const &value);
 
-        Array(Type const& of, size_t dimension);
-        size_t getDimension() const;
-        static std::string getArrayName(std::string const& base, size_t new_dim);
+    /** Adds a metadata value for the given key, Existing values are
+     * retained.
+     */
+    void add(std::string const &key, std::string const &value);
 
-    protected:
-        virtual std::string getIndirectTypeName(std::string const& inside_name) const;
+    /** Clear all metadata entries that have this key
+     */
+    void clear(std::string const &key);
 
-    private:
-	virtual bool do_compare(Type const& other, bool equality, RecursionStack& stack) const;
-	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const;
-        virtual bool do_resize(Registry& into, std::map<std::string, std::pair<size_t, size_t> >& new_sizes);
-        size_t m_dimension;
+    /** Clear all metadata entries
+     */
+    void clear();
+
+    /** Returns all metadata information with the given key associated with this
+     * type
+     */
+    Values get(std::string const &key) const;
+
+    /** Add all metadata entries that are in the given metadata set to the
+     * metadata of this type
+     */
+    void merge(MetaData const &metadata);
+};
+
+/** Base class for all type definitions */
+class Type {
+  public:
+    enum Category {
+        NullType = 0,
+        Array,
+        Pointer,
+        Numeric,
+        Enum,
+        Compound,
+        Opaque,
+        Container
+    };
+    static const int ValidCategories = Compound + 1;
+
+  private:
+    std::string m_name;
+
+    size_t m_size;
+    Category m_category;
+
+    //! This is kept as pointer so that it can be modified even if the Type
+    // object is const
+    MetaData *m_metadata;
+
+    /** Checks that @c identifier is a valid type name */
+    static bool isValidIdentifier(const std::string &identifier);
+
+    Type &operator=(Type const &type);
+
+  protected:
+    // Creates a basic type from \c name, \c size and \c category
+    Type(const std::string &name, size_t size, Category category);
+
+  public:
+    virtual ~Type();
+    Type(Type const &type);
+
+    /** Changes the type name. Never use once the type has been added to a
+     * registry */
+    void setName(const std::string &name);
+    /** Changes the type size. Don't use that unless you know what you are
+     * doing. In particular, don't use it once the type is used in a
+     * Compound.
+     */
+    void setSize(size_t size);
+    /** The type full name (including namespace) */
+    std::string getName() const;
+    /** The type name without the namespace */
+    std::string getBasename() const;
+    /** The type namespace */
+    std::string getNamespace() const;
+    /** Size in bytes of a value */
+    size_t getSize() const;
+    /** The type category */
+    Category getCategory() const;
+    /** true if this type is null */
+    bool isNull() const;
+
+    /** The set of types this type depends upon
+     *
+     * This method returns the set of types that are directly depended-upon
+     * by this type
+     */
+    virtual std::set<Type const *> dependsOn() const = 0;
+
+    /** Called by the registry if one (or more) of this type's dependencies
+     * is aliased
+     *
+     * The default implementation does nothing. It is reimplemented in
+     * types for which the name is built from the dependencies' name
+     */
+    virtual void modifiedDependencyAliases(Registry &registry) const;
+
+    bool operator==(Type const &with) const;
+    bool operator!=(Type const &with) const;
+
+    /** Deep check that \c other defines the same type than
+     * self. Basic checks on name, size and category are
+     * performed by ==
+     */
+    bool isSame(Type const &other) const;
+
+    /** Returns true if \c to can be used to manipulate a value that is
+     * described by \c from
+     */
+    bool canCastTo(Type const &to) const;
+
+    /** Merges this type into \c registry: creates a type equivalent to
+     * this one in the target registry, reusing possible equivalent types
+     * already present in +registry+.
+     */
+    Type const &merge(Registry &registry) const;
+
+    /** Foreign => local mapping for merge() and isSame() */
+    typedef std::map<Type const *, Type const *> RecursionStack;
+
+    /** Base merge method. The default implementation should be fine for
+     * most types.
+     *
+     * Call try_merge to check if a type equivalent to *this exists in \c
+     * registry, and do_merge to create a copy of *this in \c registry.
+     */
+    virtual Type const &merge(Registry &registry, RecursionStack &stack) const;
+
+    /** Update this type to reflect a type resize. The default
+     * implementation will resize *this if it is listed in \c new_sizes.
+     * new_sizes gets updated with the types that are modified.
+     *
+     * This is not to be called directly. Only use Registry::resize().
+     *
+     * @return true if this type has been modified, and false otherwise.
+     */
+    virtual bool
+    resize(Registry &registry,
+           std::map<std::string, std::pair<size_t, size_t> > &new_sizes);
+
+    /** Returns the number of bytes that are unused at the end of the
+     * compound */
+    virtual unsigned int getTrailingPadding() const;
+
+    /** Returns the metadata for this type
+     */
+    MetaData &getMetaData() const;
+
+    /** Returns the metadata values declared for this particular key
+     */
+    MetaData::Values getMetaData(std::string const &key) const;
+
+    /** Merge metadata information from the given type into this
+     */
+    virtual void mergeMetaData(Type const &other) const;
+
+  protected:
+    /** Method that is implemented by type definitions to compare *this with
+     * \c other.
+     *
+     * If \c equality is true, the method must check for strict equality. If
+     * it is false, it must check if \c other can be used to manipulate
+     * values of type \c *this.
+     *
+     * For instance, let's consider a compound that has padding bytes, and
+     * assume that *this and \c other have different padding (but are the
+     * same on every other aspects). do_compare should then return true if
+     * equality is false, and false if equality is true.
+     *
+     * It must use rec_compare to check for indirections (i.e. for
+     * recursive calls).
+     *
+     * The base definition compares the name, size and category of the
+     * types.
+     */
+    virtual bool do_compare(Type const &other, bool equality,
+                            std::map<Type const *, Type const *> &stack) const;
+
+    /** Called by do_compare to compare +left+ to +right+. This method takes
+     * into account potential loops in the recursion
+     *
+     * See do_compare for a description of the equality flag.
+     */
+    bool rec_compare(Type const &left, Type const &right, bool equality,
+                     RecursionStack &stack) const;
+
+    /** Checks if there is already a type with the same name and definition
+     * than *this in \c registry. If that is the case, returns it, otherwise
+     * returns NULL;
+     *
+     * If there is a type with the same name, but whose definition
+     * mismatches, throws DefinitionMismatch
+     */
+    Type const *try_merge(Registry &registry, RecursionStack &stack) const;
+
+    /** Called by Type::merge when the type does not exist in \c registry
+     * already. This method has to create a new type in registry that
+     * matches the type definition of *this.
+     *
+     * All types referenced by *this must be moved to their equivalent in \c
+     * registry.
+     */
+    virtual Type *do_merge(Registry &registry, RecursionStack &stack) const = 0;
+
+    /** Implementation of the actual resizing. Called by resize() */
+    virtual bool
+    do_resize(Registry &into,
+              std::map<std::string, std::pair<size_t, size_t> > &new_sizes);
+};
+
+class NullType : public Type {
+  public:
+    NullType(std::string const &name) : Type(name, 0, Type::NullType) {}
+    virtual std::set<Type const *> dependsOn() const {
+        return std::set<Type const *>();
+    }
+
+  private:
+    virtual Type *do_merge(Registry &registry, RecursionStack &stack) const {
+        return new NullType(*this);
+    }
+};
+
+/** This type is to be used when we want a field to be completely ignored,
+ * while being able to handle the rest of the system. Endianness swapping
+ * will for instance completely ignore this type.
+ */
+class OpaqueType : public Type {
+  public:
+    OpaqueType(std::string const &name, size_t size)
+        : Type(name, size, Type::Opaque) {}
+    virtual std::set<Type const *> dependsOn() const {
+        return std::set<Type const *>();
+    }
+    virtual bool do_compare(Type const &other, bool equality,
+                            std::map<Type const *, Type const *> &stack) const;
+    virtual Type *do_merge(Registry &registry, RecursionStack &stack) const {
+        return new OpaqueType(*this);
+    }
+};
+
+/** Numeric values (integer, unsigned integer and floating point) */
+class Numeric : public Type {
+  public:
+    enum NumericCategory {
+        SInt = Type::ValidCategories, /// signed integer
+        UInt,                         /// unsigned integer
+        Float                         /// floating point
+    };
+    static const int ValidCategories = Float + 1;
+
+    /** The category of this numeric type */
+    NumericCategory getNumericCategory() const;
+
+  public:
+    /** Creates a basic type from \c name, \c size and \c category */
+    Numeric(const std::string &name, size_t size, NumericCategory category);
+
+    virtual std::set<Type const *> dependsOn() const {
+        return std::set<Type const *>();
+    }
+
+  private:
+    virtual bool do_compare(Type const &other, bool equality,
+                            RecursionStack &stack) const;
+    virtual Type *do_merge(Registry &registry, RecursionStack &stack) const;
+    NumericCategory m_category;
+};
+
+/** Enums are defined as name => integer static mappings */
+class Enum : public Type {
+  public:
+    typedef int integral_type;
+    typedef std::map<std::string, int> ValueMap;
+
+    class AlreadyExists : public std::runtime_error {
+      public:
+        AlreadyExists(Type const &type, std::string const &name);
+    };
+    class SymbolNotFound : public std::runtime_error {
+      public:
+        SymbolNotFound(Type const &type, std::string const &name);
+    };
+    class ValueNotFound : public std::runtime_error {
+      public:
+        ValueNotFound(Type const &type, int value);
     };
 
-    /** Pointer types */
-    class Pointer : public Indirect
-    {
-    public:
-        Pointer(Type const& on);
-        static std::string getPointerName(std::string const& base);
+    Enum(const std::string &name, Enum::integral_type initial_value = 0);
+    /** Add a new definition */
+    void add(std::string const &name, int value);
+    /** Gets the value for @c name
+     * @throws SymbolNotFound if @c name is not defined */
+    integral_type get(std::string const &name) const;
+    /** Gets the name for @c value
+     * @throws ValueNotFound if @c value is not defined in this enum */
+    std::string get(integral_type value) const;
 
-    protected:
-        virtual std::string getIndirectTypeName(std::string const& inside_name) const;
+    /** The list of all names */
+    std::list<std::string> names() const;
+    /** The name => value map */
+    ValueMap const &values() const;
 
-    private:
-	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const;
+    virtual std::set<Type const *> dependsOn() const {
+        return std::set<Type const *>();
+    }
+
+    /** Returns the value the next inserted element should have (it is
+     * last_inserted_value + 1) */
+    Enum::integral_type getNextValue() const;
+
+  private:
+    virtual bool do_compare(Type const &other, bool equality,
+                            RecursionStack &stack) const;
+    virtual Type *do_merge(Registry &registry, RecursionStack &stack) const;
+    integral_type m_last_value;
+    ValueMap m_values;
+};
+
+/** A field in a Compound type */
+class Field {
+    friend class Compound;
+
+    std::string m_name;
+    const Type &m_type;
+    size_t m_offset;
+    MetaData *m_metadata;
+
+  private:
+    Field &operator=(Field const &field);
+
+  protected:
+    void setOffset(size_t offset);
+
+  public:
+    Field(const std::string &name, Type const &base_type);
+    Field(Field const &field);
+    ~Field();
+
+    /** The field name */
+    std::string getName() const;
+    /** The field type */
+    const Type &getType() const;
+    /** The offset, in bytes, of this field w.r.t. the
+     * begginning of the parent value */
+    size_t getOffset() const;
+
+    bool operator==(Field const &field) const;
+
+    MetaData &getMetaData() const;
+    MetaData::Values getMetaData(std::string const &key) const;
+    void mergeMetaData(Field const &field) const;
+};
+
+/** Base class for types that are composed of other
+ * types (structures and enums) */
+class Compound : public Type {
+  public:
+    typedef std::list<Field> FieldList;
+
+  public:
+    Compound(std::string const &name);
+
+    /** The list of all fields */
+    FieldList const &getFields() const;
+    /** Get a field by its name
+     * @return 0 if there is no @name field, or the Field object */
+    Field const *getField(const std::string &name) const;
+    /** Add a new field */
+    Field const &addField(const Field &field, size_t offset);
+    /** Add a new field */
+    Field const &addField(const std::string &name, const Type &type,
+                          size_t offset);
+
+    /** Returns the number of bytes that are unused at the end of the
+     * compound */
+    unsigned int getTrailingPadding() const;
+
+    virtual std::set<Type const *> dependsOn() const;
+
+    /** Merge metadata from this other type, as well as the field metadata
+     * if applicable
+     */
+    void mergeMetaData(Type const &other) const;
+
+  private:
+    virtual bool do_compare(Type const &other, bool equality,
+                            RecursionStack &stack) const;
+    virtual Type *do_merge(Registry &registry, RecursionStack &stack) const;
+    bool
+    do_resize(Registry &registry,
+              std::map<std::string, std::pair<size_t, size_t> > &new_sizes);
+    FieldList m_fields;
+};
+
+/** Base class for types with indirection (pointer, array) */
+class Indirect : public Type {
+  public:
+    static const int ValidIDs = Type::Pointer | Type::Array;
+
+  public:
+    Indirect(std::string const &name, size_t size, Category category,
+             Type const &on);
+
+    void modifiedDependencyAliases(Registry &registry) const;
+
+    Type const &getIndirection() const;
+    virtual std::set<Type const *> dependsOn() const;
+
+    virtual Type const &merge(Registry &registry, RecursionStack &stack) const;
+
+  protected:
+    virtual bool do_compare(Type const &other, bool equality,
+                            RecursionStack &stack) const;
+    virtual bool
+    do_resize(Registry &registry,
+              std::map<std::string, std::pair<size_t, size_t> > &new_sizes);
+
+    /** Overloaded in subclasses to return the name of this type based on
+     * the name of the indirection
+     *
+     * This is solely used by modifiedDependencyAliases() to update the set
+     * of aliases for a given type
+     */
+    virtual std::string
+    getIndirectTypeName(std::string const &inside_name) const = 0;
+
+  private:
+    Type const &m_indirection;
+};
+
+/** Unidimensional array types. As in C, the multi-dimensional arrays
+ * are defined as arrays-of-arrays
+ */
+class Array : public Indirect {
+  public:
+    Array(Type const &of, size_t dimension);
+    size_t getDimension() const;
+    static std::string getArrayName(std::string const &base, size_t new_dim);
+
+  protected:
+    virtual std::string
+    getIndirectTypeName(std::string const &inside_name) const;
+
+  private:
+    virtual bool do_compare(Type const &other, bool equality,
+                            RecursionStack &stack) const;
+    virtual Type *do_merge(Registry &registry, RecursionStack &stack) const;
+    virtual bool
+    do_resize(Registry &into,
+              std::map<std::string, std::pair<size_t, size_t> > &new_sizes);
+    size_t m_dimension;
+};
+
+/** Pointer types */
+class Pointer : public Indirect {
+  public:
+    Pointer(Type const &on);
+    static std::string getPointerName(std::string const &base);
+
+  protected:
+    virtual std::string
+    getIndirectTypeName(std::string const &inside_name) const;
+
+  private:
+    virtual Type *do_merge(Registry &registry, RecursionStack &stack) const;
+};
+
+struct UnknownContainer : public std::runtime_error {
+    UnknownContainer(std::string const &name)
+        : std::runtime_error("unknown container " + name) {}
+};
+
+class ValueVisitor;
+class Value;
+
+/** Base type for variable-length sets */
+class Container : public Indirect {
+    std::string m_kind;
+
+  protected:
+    struct DeleteIfPredicate {
+        virtual bool should_delete(Value const &v) = 0;
     };
 
-    struct UnknownContainer : public std::runtime_error
-    {
-        UnknownContainer(std::string const& name)
-            : std::runtime_error("unknown container " + name) {}
+    virtual void delete_if_impl(void *ptr, DeleteIfPredicate &pred) const = 0;
+
+  private:
+    template <typename Pred>
+    struct PredicateWrapper : public DeleteIfPredicate {
+        Pred pred;
+
+        PredicateWrapper(Pred pred) : pred(pred) {}
+
+        virtual bool should_delete(Value const &v) { return pred(v); };
     };
 
-    class ValueVisitor;
-    class Value;
+  public:
+    typedef std::vector<size_t> MarshalOps;
 
-    /** Base type for variable-length sets */
-    class Container : public Indirect
-    {
-        std::string m_kind;
+    Container(std::string const &kind, std::string const &name, size_t size,
+              Type const &of);
 
+    std::string kind() const;
+    virtual void init(void *ptr) const = 0;
+    virtual void destroy(void *ptr) const = 0;
+    virtual bool visit(void *ptr, ValueVisitor &visitor) const = 0;
 
-    protected:
-        struct DeleteIfPredicate
-        {
-            virtual bool should_delete(Value const& v) = 0;
-        };
+    /** If true, this is a random access container and both the
+     * getElement(int) and setElement(int) methods can be used
+     *
+     * Containers are not random-access by default
+     */
+    virtual bool isRandomAccess() const;
 
-        virtual void delete_if_impl(void* ptr, DeleteIfPredicate& pred) const = 0;
+    /** On random access containers, allows to access elements by their
+     * index
+     *
+     * Random access containers are containers for which isRandomAccess()
+     * returns true.
+     *
+     * Throws std::logic_error on containers that are not random access
+     */
+    virtual Typelib::Value getElement(void *ptr, int idx) const;
 
-    private:
-        template<typename Pred>
-        struct PredicateWrapper : public DeleteIfPredicate
-        {
-            Pred pred;
+    /** On random access containers, allows to set an element's value by its
+     * index
+     *
+     * Random access containers are containers for which isRandomAccess()
+     * returns true.
+     *
+     * Throws std::logic_error on containers that are not random access
+     */
+    virtual void setElement(void *ptr, int idx, Typelib::Value value) const;
 
-            PredicateWrapper(Pred pred)
-                : pred(pred) {}
+    /** Removes all elements from this container
+     */
+    virtual void clear(void *ptr) const = 0;
 
-            virtual bool should_delete(Value const& v)
-            {
-                return pred(v);
-            };
-        };
+    /** Pushes the given element \c v into the container at +ptr+
+     */
+    virtual void push(void *ptr, Value v) const = 0;
 
+    /** Removes the element equal to \c in \c ptr.
+     *
+     * @return true if \c has been found in \c ptr, false otherwise.
+     */
+    virtual bool erase(void *ptr, Value v) const = 0;
 
-    public:
-        typedef std::vector<size_t> MarshalOps;
+    /** Called to check if +ptr+ and +other+, which are containers of the
+     * same type, actually contain the same data
+     *
+     * @return true if the two containers have the same data, false otherwise
+     */
+    virtual bool compare(void *ptr, void *other) const = 0;
 
-        Container(std::string const& kind, std::string const& name, size_t size, Type const& of);
+    /** Called to copy the contents of +src+ into +dst+, which are both
+     * containers of the same type.
+     */
+    virtual void copy(void *dst, void *src) const = 0;
 
-        std::string kind() const;
-        virtual void init(void* ptr) const = 0;
-        virtual void destroy(void* ptr) const = 0;
-        virtual bool visit(void* ptr, ValueVisitor& visitor) const = 0;
+    /** Called to return the natural size of the container, i.e. the size it
+     * has on this particular machine. This can be different than getSize()
+     * in case of registries generated on other machines.
+     */
+    virtual long getNaturalSize() const = 0;
 
-        /** If true, this is a random access container and both the
-         * getElement(int) and setElement(int) methods can be used
-         *
-         * Containers are not random-access by default
-         */
-        virtual bool isRandomAccess() const;
+    template <typename Pred> void delete_if(void *ptr, Pred pred) const {
+        PredicateWrapper<Pred> predicate(pred);
+        delete_if_impl(ptr, predicate);
+    }
 
-        /** On random access containers, allows to access elements by their
-         * index
-         *
-         * Random access containers are containers for which isRandomAccess()
-         * returns true.
-         *
-         * Throws std::logic_error on containers that are not random access
-         */
-        virtual Typelib::Value getElement(void* ptr, int idx) const;
+    virtual size_t getElementCount(void const *ptr) const = 0;
 
-        /** On random access containers, allows to set an element's value by its
-         * index
-         *
-         * Random access containers are containers for which isRandomAccess()
-         * returns true.
-         *
-         * Throws std::logic_error on containers that are not random access
-         */
-        virtual void setElement(void* ptr, int idx, Typelib::Value value) const;
+    /** The marshalling process calls this method so that the contents of
+     * the container are dumped into the provided buffer.
+     *
+     * In the marshalled stream, all containers are dumped as
+     *   <element-count [64 bits]> <elements>
+     *
+     * @arg container_ptr the pointer to the container data
+     * @arg element_count the count of elements in the container. This is
+     *   passed here to avoid costly computations: getElementCount is already
+     *   called by the marshalling code itself.
+     * @arg stream the stream that will be used to dump the data
+     * @arg begin the marshalling code that describes the marshalling process
+     *for one element
+     * @arg end end of the marshalling code that describes the marshalling
+     *process for one element
+     * @return the marshalling process should end at the first FLAG_END found in
+     *[begin, end)
+     *   (with nesting taken into account). The returned value is the iterator
+     *on this FLAG_END element
+     *   (i.e. *retval == FLAG_END is a postcondition of this method)
+     */
+    virtual MarshalOps::const_iterator
+    dump(void const *container_ptr, size_t element_count, OutputStream &stream,
+         MarshalOps::const_iterator const begin,
+         MarshalOps::const_iterator const end) const = 0;
 
-        /** Removes all elements from this container
-         */
-        virtual void clear(void* ptr) const = 0;
+    /** The marshalling process calls this method so that the contents of
+     * the container are loaded from the provided buffer.
+     *
+     * In the marshalled stream, all containers are dumped as
+     *   <element-count [64 bits]> <elements>
+     *
+     * @arg container_ptr the pointer to the container data
+     * @arg element_count the count of elements in the container, loaded from
+     *the stream.
+     * @arg stream the stream from which the data will be read
+     * @arg in_offset the offset in \c buffer of the first element of the
+     *container
+     * @arg begin the marshalling code that describes the loading process for
+     *one element
+     * @arg end end of the marshalling code that describes the loading process
+     *for one element
+     * @return the marshalling process should end at the first FLAG_END found in
+     *[begin, end)
+     *   (with nesting taken into account). The first element of the returned
+     *value is the iterator on this FLAG_END element
+     *   (i.e. *retval == FLAG_END is a postcondition of this method). The
+     *second element is the new value of \c in_offset
+     */
+    virtual MarshalOps::const_iterator
+    load(void *container_ptr, size_t element_count, InputStream &stream,
+         MarshalOps::const_iterator const begin,
+         MarshalOps::const_iterator const end) const = 0;
 
-        /** Pushes the given element \c v into the container at +ptr+
-         */
-        virtual void push(void* ptr, Value v) const = 0;
+    typedef Container const &(*ContainerFactory)(
+        Registry &r, std::list<Type const *> const &base_type);
+    typedef std::map<std::string, ContainerFactory> AvailableContainers;
 
-        /** Removes the element equal to \c in \c ptr.
-         *
-         * @return true if \c has been found in \c ptr, false otherwise.
-         */
-        virtual bool erase(void* ptr, Value v) const = 0;
+    static AvailableContainers availableContainers();
+    static void registerContainer(std::string const &name,
+                                  ContainerFactory factory);
+    static Container const &
+    createContainer(Registry &r, std::string const &name, Type const &on);
+    static Container const &createContainer(Registry &r,
+                                            std::string const &name,
+                                            std::list<Type const *> const &on);
 
-        /** Called to check if +ptr+ and +other+, which are containers of the
-         * same type, actually contain the same data
-         *
-         * @return true if the two containers have the same data, false otherwise
-         */
-        virtual bool compare(void* ptr, void* other) const = 0;
+  protected:
+    virtual bool do_compare(Type const &other, bool equality,
+                            RecursionStack &stack) const;
+    virtual ContainerFactory getFactory() const = 0;
+    Type *do_merge(Registry &registry, RecursionStack &stack) const;
 
-        /** Called to copy the contents of +src+ into +dst+, which are both
-         * containers of the same type.
-         */
-        virtual void copy(void* dst, void* src) const = 0;
+  private:
+    static AvailableContainers *s_available_containers;
+};
 
-        /** Called to return the natural size of the container, i.e. the size it
-         * has on this particular machine. This can be different than getSize()
-         * in case of registries generated on other machines.
-         */
-        virtual long getNaturalSize() const = 0;
+struct TypeException : public std::runtime_error {
+    TypeException(std::string const &msg) : std::runtime_error(msg) {}
+};
 
-        template<typename Pred>
-        void delete_if(void* ptr, Pred pred) const
-        {
-            PredicateWrapper<Pred> predicate(pred);
-            delete_if_impl(ptr, predicate);
-        }
+struct BadCategory : public TypeException {
+    Type::Category const found;
+    int const expected;
 
-        virtual size_t getElementCount(void const* ptr) const = 0;
+    BadCategory(Type::Category found, int expected);
+};
 
-        /** The marshalling process calls this method so that the contents of
-         * the container are dumped into the provided buffer.
-         *
-         * In the marshalled stream, all containers are dumped as
-         *   <element-count [64 bits]> <elements>
-         *
-         * @arg container_ptr the pointer to the container data
-         * @arg element_count the count of elements in the container. This is
-         *   passed here to avoid costly computations: getElementCount is already
-         *   called by the marshalling code itself.
-         * @arg stream the stream that will be used to dump the data
-         * @arg begin the marshalling code that describes the marshalling process for one element
-         * @arg end end of the marshalling code that describes the marshalling process for one element
-         * @return the marshalling process should end at the first FLAG_END found in [begin, end)
-         *   (with nesting taken into account). The returned value is the iterator on this FLAG_END element
-         *   (i.e. *retval == FLAG_END is a postcondition of this method)
-         */
-        virtual MarshalOps::const_iterator dump(
-            void const* container_ptr, size_t element_count,
-            OutputStream& stream,
-            MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const = 0;
-
-        /** The marshalling process calls this method so that the contents of
-         * the container are loaded from the provided buffer.
-         *
-         * In the marshalled stream, all containers are dumped as
-         *   <element-count [64 bits]> <elements>
-         *
-         * @arg container_ptr the pointer to the container data
-         * @arg element_count the count of elements in the container, loaded from the stream.
-         * @arg stream the stream from which the data will be read
-         * @arg in_offset the offset in \c buffer of the first element of the container
-         * @arg begin the marshalling code that describes the loading process for one element
-         * @arg end end of the marshalling code that describes the loading process for one element
-         * @return the marshalling process should end at the first FLAG_END found in [begin, end)
-         *   (with nesting taken into account). The first element of the returned value is the iterator on this FLAG_END element
-         *   (i.e. *retval == FLAG_END is a postcondition of this method). The second element is the new value of \c in_offset
-         */
-        virtual MarshalOps::const_iterator load(
-            void* container_ptr, size_t element_count,
-            InputStream& stream,
-            MarshalOps::const_iterator const begin, MarshalOps::const_iterator const end) const = 0;
-
-        typedef Container const& (*ContainerFactory)(Registry& r, std::list<Type const*> const& base_type);
-        typedef std::map<std::string, ContainerFactory> AvailableContainers;
-
-        static AvailableContainers availableContainers();
-        static void registerContainer(std::string const& name, ContainerFactory factory);
-        static Container const& createContainer(Registry& r, std::string const& name, Type const& on);
-        static Container const& createContainer(Registry& r, std::string const& name, std::list<Type const*> const& on);
-
-    protected:
-	virtual bool do_compare(Type const& other, bool equality, RecursionStack& stack) const;
-        virtual ContainerFactory getFactory() const = 0;
-        Type* do_merge(Registry& registry, RecursionStack& stack) const;
-
-    private:
-        static AvailableContainers* s_available_containers;
-    };
-
-    struct TypeException : public std::runtime_error
-    {
-        TypeException(std::string const& msg) : std::runtime_error(msg) { }
-    };
-
-    struct BadCategory : public TypeException
-    {
-        Type::Category const found;
-        int            const expected;
-
-        BadCategory(Type::Category found, int expected);
-    };
-
-    struct NullTypeFound : public TypeException
-    {
-        NullTypeFound();
-        NullTypeFound(Type const& type);
-    };
+struct NullTypeFound : public TypeException {
+    NullTypeFound();
+    NullTypeFound(Type const &type);
+};
 };
 
 #endif
-

--- a/typelib/typename.cc
+++ b/typelib/typename.cc
@@ -6,294 +6,282 @@ using namespace std;
 using namespace boost;
 using namespace Typelib;
 
-namespace
-{
-    typedef std::string::value_type   NamespaceMarkType;
-    static const char*                NamespaceMarkString = "/";
+namespace {
+typedef std::string::value_type NamespaceMarkType;
+static const char *NamespaceMarkString = "/";
 
-    struct NameSeparator : public char_separator<NamespaceMarkType>
-    {
-        NameSeparator()
-            : char_separator<NamespaceMarkType>(NamespaceMarkString, "", boost::keep_empty_tokens) {}
-    };
-    typedef boost::tokenizer<NameSeparator> NameTokenizer;
-    
-    // helper function which checks that \c identifier does contain
-    // only valid characters. Note that identifier is supposed
-    // to be a normalized name, so that it cannot be empty
-    bool isValidIdentifier(const string& identifier)
-    {
-        if (identifier.empty())   return false;
+struct NameSeparator : public char_separator<NamespaceMarkType> {
+    NameSeparator()
+        : char_separator<NamespaceMarkType>(NamespaceMarkString, "",
+                                            boost::keep_empty_tokens) {}
+};
+typedef boost::tokenizer<NameSeparator> NameTokenizer;
 
-        const int length(identifier.length());
-        for (int i = 0; i < length; ++i)
-        {
-            string::value_type c(identifier[i]);
-            if (c != '_' && c != ' ' && !isalnum(c) && c != '<' && c != '>')
-                return false;
-        }
+// helper function which checks that \c identifier does contain
+// only valid characters. Note that identifier is supposed
+// to be a normalized name, so that it cannot be empty
+bool isValidIdentifier(const string &identifier) {
+    if (identifier.empty())
+        return false;
 
-        return true;
+    const int length(identifier.length());
+    for (int i = 0; i < length; ++i) {
+        string::value_type c(identifier[i]);
+        if (c != '_' && c != ' ' && !isalnum(c) && c != '<' && c != '>')
+            return false;
     }
+
+    return true;
+}
 }
 
-namespace Typelib
-{
-    bool isAbsoluteName(const string& identifier)
-    {
-        if (identifier.empty()) return false;
-        return identifier[0] == NamespaceMark;
-    }
+namespace Typelib {
+bool isAbsoluteName(const string &identifier) {
+    if (identifier.empty())
+        return false;
+    return identifier[0] == NamespaceMark;
+}
 
-    static bool isValidTypeBasename(std::string s, bool absolute, bool accept_integers)
-    {
-        if (accept_integers && s.find_first_not_of("0123456789") == string::npos)
-            return true;
-
-        int pos = 0;
-        if (absolute && s[0] != '/')
-            return false;
-
-        if (s[0] == '/')
-            ++pos;
-
-        size_t modifiers = s.find_first_of("*[");
-        if (modifiers != string::npos)
-            return isValidIdentifier(string(s, pos, modifiers - pos));
-        else
-            return isValidIdentifier(string(s, pos));
-
-    }
-
-    std::list<std::string> splitTypename(std::string const& name)
-    {
-        unsigned int start_pos = 0;
-        if (name[0] == '/')
-            start_pos++;
-
-        int template_level = 0;
-        std::list<std::string> result;
-        for (unsigned int i = start_pos; i < name.length(); ++i)
-        {
-            if (name[i] == '/')
-            {
-                if (template_level == 0)
-                {
-                    result.push_back(string(name, start_pos, i - start_pos));
-                    start_pos = i + 1;
-                }
-            }
-            else if (name[i] == '<')
-                template_level++;
-            else if (name[i] == '>')
-                template_level--;
-        }
-        if (start_pos < name.length())
-            result.push_back(string(name, start_pos, name.length() - start_pos));
-
-        return result;
-    }
-
-    static pair<bool, int> isValidTypename(std::string const& s, int pos, bool absolute, bool accept_integers)
-    {
-        unsigned int start_pos = pos;
-        if (s[pos] == '/')
-            pos++;
-
-        for (unsigned int i = pos; i < s.length(); ++i)
-        {
-            if (s[i] == '/')
-            {
-                if (!isValidTypeBasename(string(s, start_pos, i - start_pos), absolute, accept_integers))
-                    return make_pair(false, i);
-                start_pos = i;
-            }
-            else if (s[i] == '<')
-            {
-                if (!isValidTypeBasename(string(s, start_pos, i - start_pos), absolute, accept_integers))
-                    return make_pair(false, i);
-
-                while (s[i] != '>')
-                {
-                    pair<bool, int> valid_arg = isValidTypename(s, i + 1, true, true);
-                    i = valid_arg.second;
-
-                    if (!valid_arg.first)
-                        return valid_arg;
-                    else if (i == s.length() || (s[i] != ',' && s[i] != '>'))
-                        return make_pair(false, i);
-                }
-
-                start_pos = i + 1;
-                if (i + 1 < s.length())
-                {
-                    if (s[i + 1] == '/')
-                        i++;
-                    else if (s[i + 1] != '>' && s[i + 1] != '[' && s[i + 1] != ',')
-                        return make_pair(false, i + 1);
-                }
-            }
-            else if (s[i] == '[')
-            {
-                // start_pos == i if we are parsing an array of templates
-                if (start_pos != i && !isValidTypeBasename(string(s, start_pos, i - start_pos), absolute, accept_integers))
-                    return make_pair(false, i);
-
-                if (i + 1 == s.length())
-                    return make_pair(false, i);
-
-                start_pos = i + 1;
-            }
-            else if (s[i] == ']')
-            {
-                if (start_pos == i)
-                    return make_pair(false, start_pos);
-                if (string(s, start_pos, i - start_pos).find_first_not_of("0123456789") != string::npos)
-                    return make_pair(false, start_pos);
-
-                start_pos = i + 1;
-                if (i + 1 < s.length())
-                {
-                    if (s[i + 1] == '/')
-                        i++;
-                    else if (s[i + 1] != '>' && s[i + 1] != '[')
-                        return make_pair(false, i + 1);
-                }
-            }
-            else if (s[i] == '>' || s[i] == ',')
-            {
-                if (!isValidTypeBasename(string(s, start_pos, i - start_pos), true, true))
-                    return make_pair(false, i);
-                return make_pair(true, i);
-            }
-        }
-
-        if (start_pos != s.length())
-            return make_pair(isValidTypeBasename(string(s, start_pos, s.length() - start_pos), absolute, accept_integers), s.length());
-        else return make_pair(true, s.length());
-    }
-
-    bool isValidTypename(const std::string& name, bool absolute)
-    {
-        if (name.empty())
-            return false;
-        return isValidTypename(name, 0, absolute, false).first;
-    }
-
-    bool isValidNamespace(const string& name, bool absolute)
-    {
-        if (name.empty()) return false;
-        if (absolute && name[0] != NamespaceMark) return false;
-
-        NameTokenizer tokenizer(name);
-
-        NameTokenizer::const_iterator it = tokenizer.begin();
-        for (; it != tokenizer.end(); ++it)
-        {
-            if (!isValidIdentifier(*it))
-                return false;
-        }
-
+static bool isValidTypeBasename(std::string s, bool absolute,
+                                bool accept_integers) {
+    if (accept_integers && s.find_first_not_of("0123456789") == string::npos)
         return true;
+
+    int pos = 0;
+    if (absolute && s[0] != '/')
+        return false;
+
+    if (s[0] == '/')
+        ++pos;
+
+    size_t modifiers = s.find_first_of("*[");
+    if (modifiers != string::npos)
+        return isValidIdentifier(string(s, pos, modifiers - pos));
+    else
+        return isValidIdentifier(string(s, pos));
+}
+
+std::list<std::string> splitTypename(std::string const &name) {
+    unsigned int start_pos = 0;
+    if (name[0] == '/')
+        start_pos++;
+
+    int template_level = 0;
+    std::list<std::string> result;
+    for (unsigned int i = start_pos; i < name.length(); ++i) {
+        if (name[i] == '/') {
+            if (template_level == 0) {
+                result.push_back(string(name, start_pos, i - start_pos));
+                start_pos = i + 1;
+            }
+        } else if (name[i] == '<')
+            template_level++;
+        else if (name[i] == '>')
+            template_level--;
     }
+    if (start_pos < name.length())
+        result.push_back(string(name, start_pos, name.length() - start_pos));
 
-    bool isInNamespace(const string& type, const std::string& nspace, bool recursive)
-    {
-        std::string normalized_nspace( getNormalizedNamespace(nspace) );
-        const int   length (normalized_nspace.length());
+    return result;
+}
 
-        bool begins_with = string(type, 0, length) == normalized_nspace;
-        if (!begins_with) return false;
-        if (recursive)    return true; 
-        std::string remainder(type, length, string::npos);
-        return splitTypename(remainder).size() == 1;
-    }
+static pair<bool, int> isValidTypename(std::string const &s, int pos,
+                                       bool absolute, bool accept_integers) {
+    unsigned int start_pos = pos;
+    if (s[pos] == '/')
+        pos++;
 
-    std::string getNormalizedNamespace(const std::string& name)
-    {
-        if (name.empty()) return NamespaceMarkString;
-        if (name[name.size() - 1] != NamespaceMark) return name + NamespaceMark;
-        return name;
-    }
+    for (unsigned int i = pos; i < s.length(); ++i) {
+        if (s[i] == '/') {
+            if (!isValidTypeBasename(string(s, start_pos, i - start_pos),
+                                     absolute, accept_integers))
+                return make_pair(false, i);
+            start_pos = i;
+        } else if (s[i] == '<') {
+            if (!isValidTypeBasename(string(s, start_pos, i - start_pos),
+                                     absolute, accept_integers))
+                return make_pair(false, i);
 
-    std::string getTypename(const std::string& name)
-    {
-        list<string> split = splitTypename(name);
-        if (split.empty())
-            return std::string();
-        return split.back();
-    }
+            while (s[i] != '>') {
+                pair<bool, int> valid_arg =
+                    isValidTypename(s, i + 1, true, true);
+                i = valid_arg.second;
 
-    std::string getRelativeName(std::string const& name, std::string const& ns)
-    {
-	size_t size = ns.length();
-	if (*ns.rbegin() != '/')
-	    size += 1;
-	return std::string(name, size, string::npos);
-    }
+                if (!valid_arg.first)
+                    return valid_arg;
+                else if (i == s.length() || (s[i] != ',' && s[i] != '>'))
+                    return make_pair(false, i);
+            }
 
-    std::string getMinimalPathTo(std::string const& full_name, std::string const& ns)
-    {
-        string type_ns = getNamespace(full_name);
-        if (isInNamespace(full_name, ns, true))
-            return getRelativeName(getNamespace(full_name), ns);
-        else if (ns.find(type_ns) != string::npos || ns.find(full_name) != string::npos) // need an absolute path
-            return type_ns;
+            start_pos = i + 1;
+            if (i + 1 < s.length()) {
+                if (s[i + 1] == '/')
+                    i++;
+                else if (s[i + 1] != '>' && s[i + 1] != '[' && s[i + 1] != ',')
+                    return make_pair(false, i + 1);
+            }
+        } else if (s[i] == '[') {
+            // start_pos == i if we are parsing an array of templates
+            if (start_pos != i &&
+                !isValidTypeBasename(string(s, start_pos, i - start_pos),
+                                     absolute, accept_integers))
+                return make_pair(false, i);
 
-        list<string> tok1(splitTypename(type_ns));
-        list<string> tok2(splitTypename(ns));
-        list<string>::const_iterator it1 = tok1.begin();
-        list<string>::const_iterator it2 = tok2.begin();
-        std::vector<std::string> common_tokens;
+            if (i + 1 == s.length())
+                return make_pair(false, i);
 
-        // Filter out the common NS parts
-        std::string ns1, ns2;
-        for (; it1 != tok1.end() && it2 != tok2.end(); ++it1, ++it2)
-        {
-            ns1 = *it1;
-            ns2 = *it2;
-            int value = ns1.compare(ns2);
-            if (value) break;
-            common_tokens.push_back(ns1);
+            start_pos = i + 1;
+        } else if (s[i] == ']') {
+            if (start_pos == i)
+                return make_pair(false, start_pos);
+            if (string(s, start_pos, i - start_pos)
+                    .find_first_not_of("0123456789") != string::npos)
+                return make_pair(false, start_pos);
+
+            start_pos = i + 1;
+            if (i + 1 < s.length()) {
+                if (s[i + 1] == '/')
+                    i++;
+                else if (s[i + 1] != '>' && s[i + 1] != '[')
+                    return make_pair(false, i + 1);
+            }
+        } else if (s[i] == '>' || s[i] == ',') {
+            if (!isValidTypeBasename(string(s, start_pos, i - start_pos), true,
+                                     true))
+                return make_pair(false, i);
+            return make_pair(true, i);
         }
-
-        if (common_tokens.empty())
-            return type_ns;
-
-        // Build the remainder of both namespaces, and verify that the remainder
-        // of the type is unambiguous. If it is, go back in it1 until it is not.
-        // We already checked the case where the full path is ambiguous
-        std::string result = *it1;
-        list<string>::const_iterator remainder_it = it1;
-        for (++remainder_it; remainder_it != tok1.end(); ++remainder_it)
-            result += Typelib::NamespaceMarkString + *remainder_it;
-
-        while (!common_tokens.empty() && ns.find(result) != string::npos)
-        {
-            result = common_tokens.back() + Typelib::NamespaceMarkString + result;
-            common_tokens.pop_back();
-        }
-        if (common_tokens.empty())
-            return type_ns;
-        else if (result.empty())
-            return result;
-        else
-            return result + Typelib::NamespaceMarkString;
     }
 
-    std::string getNamespace(const std::string& name)
-    {
-        list<string> split = splitTypename(name);
-        if (split.empty())
-            return "/";
-        split.pop_back();
+    if (start_pos != s.length())
+        return make_pair(
+            isValidTypeBasename(string(s, start_pos, s.length() - start_pos),
+                                absolute, accept_integers),
+            s.length());
+    else
+        return make_pair(true, s.length());
+}
 
-        std::string result;
-        for (list<string>::const_iterator it = split.begin(); it != split.end(); ++it)
-            result += "/" + *it;
+bool isValidTypename(const std::string &name, bool absolute) {
+    if (name.empty())
+        return false;
+    return isValidTypename(name, 0, absolute, false).first;
+}
 
-        result += "/";
+bool isValidNamespace(const string &name, bool absolute) {
+    if (name.empty())
+        return false;
+    if (absolute && name[0] != NamespaceMark)
+        return false;
+
+    NameTokenizer tokenizer(name);
+
+    NameTokenizer::const_iterator it = tokenizer.begin();
+    for (; it != tokenizer.end(); ++it) {
+        if (!isValidIdentifier(*it))
+            return false;
+    }
+
+    return true;
+}
+
+bool isInNamespace(const string &type, const std::string &nspace,
+                   bool recursive) {
+    std::string normalized_nspace(getNormalizedNamespace(nspace));
+    const int length(normalized_nspace.length());
+
+    bool begins_with = string(type, 0, length) == normalized_nspace;
+    if (!begins_with)
+        return false;
+    if (recursive)
+        return true;
+    std::string remainder(type, length, string::npos);
+    return splitTypename(remainder).size() == 1;
+}
+
+std::string getNormalizedNamespace(const std::string &name) {
+    if (name.empty())
+        return NamespaceMarkString;
+    if (name[name.size() - 1] != NamespaceMark)
+        return name + NamespaceMark;
+    return name;
+}
+
+std::string getTypename(const std::string &name) {
+    list<string> split = splitTypename(name);
+    if (split.empty())
+        return std::string();
+    return split.back();
+}
+
+std::string getRelativeName(std::string const &name, std::string const &ns) {
+    size_t size = ns.length();
+    if (*ns.rbegin() != '/')
+        size += 1;
+    return std::string(name, size, string::npos);
+}
+
+std::string getMinimalPathTo(std::string const &full_name,
+                             std::string const &ns) {
+    string type_ns = getNamespace(full_name);
+    if (isInNamespace(full_name, ns, true))
+        return getRelativeName(getNamespace(full_name), ns);
+    else if (ns.find(type_ns) != string::npos ||
+             ns.find(full_name) != string::npos) // need an absolute path
+        return type_ns;
+
+    list<string> tok1(splitTypename(type_ns));
+    list<string> tok2(splitTypename(ns));
+    list<string>::const_iterator it1 = tok1.begin();
+    list<string>::const_iterator it2 = tok2.begin();
+    std::vector<std::string> common_tokens;
+
+    // Filter out the common NS parts
+    std::string ns1, ns2;
+    for (; it1 != tok1.end() && it2 != tok2.end(); ++it1, ++it2) {
+        ns1 = *it1;
+        ns2 = *it2;
+        int value = ns1.compare(ns2);
+        if (value)
+            break;
+        common_tokens.push_back(ns1);
+    }
+
+    if (common_tokens.empty())
+        return type_ns;
+
+    // Build the remainder of both namespaces, and verify that the remainder
+    // of the type is unambiguous. If it is, go back in it1 until it is not.
+    // We already checked the case where the full path is ambiguous
+    std::string result = *it1;
+    list<string>::const_iterator remainder_it = it1;
+    for (++remainder_it; remainder_it != tok1.end(); ++remainder_it)
+        result += Typelib::NamespaceMarkString + *remainder_it;
+
+    while (!common_tokens.empty() && ns.find(result) != string::npos) {
+        result = common_tokens.back() + Typelib::NamespaceMarkString + result;
+        common_tokens.pop_back();
+    }
+    if (common_tokens.empty())
+        return type_ns;
+    else if (result.empty())
         return result;
-    }
-};
+    else
+        return result + Typelib::NamespaceMarkString;
+}
 
+std::string getNamespace(const std::string &name) {
+    list<string> split = splitTypename(name);
+    if (split.empty())
+        return "/";
+    split.pop_back();
+
+    std::string result;
+    for (list<string>::const_iterator it = split.begin(); it != split.end();
+         ++it)
+        result += "/" + *it;
+
+    result += "/";
+    return result;
+}
+};

--- a/typelib/typename.hh
+++ b/typelib/typename.hh
@@ -5,66 +5,64 @@
 #include <list>
 #include <boost/tokenizer.hpp>
 
-namespace Typelib
-{
-    typedef std::string::value_type   NamespaceMarkType;
-    static const NamespaceMarkType    NamespaceMark = '/';
-    static const NamespaceMarkType    TemplateMark  = '<';
-    static const char*                NamespaceMarkString = "/";
+namespace Typelib {
+typedef std::string::value_type NamespaceMarkType;
+static const NamespaceMarkType NamespaceMark = '/';
+static const NamespaceMarkType TemplateMark = '<';
+static const char *NamespaceMarkString = "/";
 
-    struct NameSeparator : public boost::char_separator<NamespaceMarkType>
-    {
-        NameSeparator()
-            : boost::char_separator<NamespaceMarkType>(NamespaceMarkString, "") {}
-    };
-    typedef boost::tokenizer<NameSeparator> NameTokenizer;
+struct NameSeparator : public boost::char_separator<NamespaceMarkType> {
+    NameSeparator()
+        : boost::char_separator<NamespaceMarkType>(NamespaceMarkString, "") {}
+};
+typedef boost::tokenizer<NameSeparator> NameTokenizer;
 
-    
-    bool isAbsoluteName(const std::string& name);
-    bool isValidNamespace(const std::string& name, bool absolute);
-    bool isValidTypename(const std::string& name, bool absolute);
-    bool isInNamespace(const std::string& type, const std::string& nspace, bool recursive = false);
+bool isAbsoluteName(const std::string &name);
+bool isValidNamespace(const std::string &name, bool absolute);
+bool isValidTypename(const std::string &name, bool absolute);
+bool isInNamespace(const std::string &type, const std::string &nspace,
+                   bool recursive = false);
 
-    /** Splits a type name into its components. It is non-validating, i.e. is
-     * guaranteed to return a valid value only for names for which
-     * isValidTypename returns true
-     */
-    std::list<std::string> splitTypename(std::string const& name);
-    
-    /** Returns +name+ as a namespace name, valid to build an absolute type
-     * name by simple concatenation
-     *
-     * It is guaranteed to end with the NamespaceMark
-     */
-    std::string getNormalizedNamespace(const std::string& name);
-    /** Removes the namespace part of \c full_name and returns it */
-    std::string getTypename (const std::string& full_name);
-    /** Returns the normalized namespace part of \c full_name. The returned
-     * namespace name starts and ends with the namespace separator '/'. */
-    std::string getNamespace(const std::string& full_name);
-    /** Returns the relative part of +name+, relative to the given namespace.
-     * The type name must be included in the namespace. Use
-     * getMinimalPathTo to generate the minimal namespace specification reaching
-     * a type from a namespace.
-     *
-     * The returned name does not have any leading namespace separator. */
-    std::string getRelativeName(std::string const& full_name, std::string const& ns);
-    /** Computes the minimal namespace specification needed to reach a type from
-     * a namespace. The specification takes into account possible ambiguities,
-     * i.e.
-     *
-     *   getMinimalPathTo("/A/A/Type", "/A/B/A")
-     *
-     * will return  "/A/A/Type" as "A/Type" would be ambiguous.
-     */
-    std::string getMinimalPathTo(std::string const& full_name, std::string const& ns);
-    /** Returns true if \c name1 is either in a more in-depth namespace than
-     * name2 (i.e. name2 == /A/B/class and name1 == /A/B/C/class2 or if 
-     * name2 < name1 (lexicographic sort). Otherwise, returns false
-     */
-    bool nameSort(std::string const& name1, std::string const& name2);
+/** Splits a type name into its components. It is non-validating, i.e. is
+ * guaranteed to return a valid value only for names for which
+ * isValidTypename returns true
+ */
+std::list<std::string> splitTypename(std::string const &name);
+
+/** Returns +name+ as a namespace name, valid to build an absolute type
+ * name by simple concatenation
+ *
+ * It is guaranteed to end with the NamespaceMark
+ */
+std::string getNormalizedNamespace(const std::string &name);
+/** Removes the namespace part of \c full_name and returns it */
+std::string getTypename(const std::string &full_name);
+/** Returns the normalized namespace part of \c full_name. The returned
+ * namespace name starts and ends with the namespace separator '/'. */
+std::string getNamespace(const std::string &full_name);
+/** Returns the relative part of +name+, relative to the given namespace.
+ * The type name must be included in the namespace. Use
+ * getMinimalPathTo to generate the minimal namespace specification reaching
+ * a type from a namespace.
+ *
+ * The returned name does not have any leading namespace separator. */
+std::string getRelativeName(std::string const &full_name,
+                            std::string const &ns);
+/** Computes the minimal namespace specification needed to reach a type from
+ * a namespace. The specification takes into account possible ambiguities,
+ * i.e.
+ *
+ *   getMinimalPathTo("/A/A/Type", "/A/B/A")
+ *
+ * will return  "/A/A/Type" as "A/Type" would be ambiguous.
+ */
+std::string getMinimalPathTo(std::string const &full_name,
+                             std::string const &ns);
+/** Returns true if \c name1 is either in a more in-depth namespace than
+ * name2 (i.e. name2 == /A/B/class and name1 == /A/B/C/class2 or if
+ * name2 < name1 (lexicographic sort). Otherwise, returns false
+ */
+bool nameSort(std::string const &name1, std::string const &name2);
 };
 
 #endif
-
-

--- a/typelib/typevisitor.cc
+++ b/typelib/typevisitor.cc
@@ -1,67 +1,60 @@
 #include "typevisitor.hh"
 #include <cassert>
 
-namespace Typelib
-{
-    bool TypeVisitor::visit_ ( NullType const& type )
-    { throw NullTypeFound(type); }
-    bool TypeVisitor::visit_ (OpaqueType const& type)
-    { return true; }
-    bool TypeVisitor::visit_  (Numeric const& type)
-    { return true; }
-    bool TypeVisitor::visit_  (Enum const& type)
-    { return true; }
+namespace Typelib {
+bool TypeVisitor::visit_(NullType const &type) { throw NullTypeFound(type); }
+bool TypeVisitor::visit_(OpaqueType const &type) { return true; }
+bool TypeVisitor::visit_(Numeric const &type) { return true; }
+bool TypeVisitor::visit_(Enum const &type) { return true; }
 
-    bool TypeVisitor::visit_  (Pointer const& type)
-    { return dispatch(type.getIndirection()); }
-    bool TypeVisitor::visit_  (Array const& type)
-    { return dispatch(type.getIndirection()); }
-    bool TypeVisitor::visit_  (Container const& type)
-    { return dispatch(type.getIndirection()); }
-
-    bool TypeVisitor::visit_  (Compound const& type)                 
-    {  
-        typedef Compound::FieldList Fields;
-        Fields const& fields(type.getFields());
-        Fields::const_iterator const end = fields.end();
-        
-        for (Fields::const_iterator it = fields.begin(); it != end; ++it)
-        {
-            if (! visit_(type, *it))
-                return false;
-        }
-        return true;
-    }
-    bool TypeVisitor::visit_  (Compound const& type, Field const& field)   
-    { return dispatch(field.getType()); }
-
-    bool TypeVisitor::dispatch(Type const& type)
-    {
-        switch(type.getCategory())
-        {
-            case Type::NullType:
-                return visit_ ( dynamic_cast<NullType const&>(type) );
-            case Type::Numeric:
-                return visit_( dynamic_cast<Numeric const&>(type) );
-            case Type::Enum:
-                return visit_( dynamic_cast<Enum const&>(type) );
-            case Type::Array:
-                return visit_( dynamic_cast<Array const&>(type) );
-            case Type::Pointer:
-                return visit_( dynamic_cast<Pointer const&>(type) );
-            case Type::Opaque:
-                return visit_( dynamic_cast<OpaqueType const&>(type) );
-            case Type::Compound:
-                return visit_( dynamic_cast<Compound const&>(type) );
-            case Type::Container:
-                return visit_( dynamic_cast<Container const&>(type) );
-        }
-        // Never reached
-        assert(false);
-	return false; // to shut up gcc
-    }
-
-    void TypeVisitor::apply(Type const& type)
-    { dispatch(type); }
+bool TypeVisitor::visit_(Pointer const &type) {
+    return dispatch(type.getIndirection());
+}
+bool TypeVisitor::visit_(Array const &type) {
+    return dispatch(type.getIndirection());
+}
+bool TypeVisitor::visit_(Container const &type) {
+    return dispatch(type.getIndirection());
 }
 
+bool TypeVisitor::visit_(Compound const &type) {
+    typedef Compound::FieldList Fields;
+    Fields const &fields(type.getFields());
+    Fields::const_iterator const end = fields.end();
+
+    for (Fields::const_iterator it = fields.begin(); it != end; ++it) {
+        if (!visit_(type, *it))
+            return false;
+    }
+    return true;
+}
+bool TypeVisitor::visit_(Compound const &type, Field const &field) {
+    return dispatch(field.getType());
+}
+
+bool TypeVisitor::dispatch(Type const &type) {
+    switch (type.getCategory()) {
+    case Type::NullType:
+        return visit_(dynamic_cast<NullType const &>(type));
+    case Type::Numeric:
+        return visit_(dynamic_cast<Numeric const &>(type));
+    case Type::Enum:
+        return visit_(dynamic_cast<Enum const &>(type));
+    case Type::Array:
+        return visit_(dynamic_cast<Array const &>(type));
+    case Type::Pointer:
+        return visit_(dynamic_cast<Pointer const &>(type));
+    case Type::Opaque:
+        return visit_(dynamic_cast<OpaqueType const &>(type));
+    case Type::Compound:
+        return visit_(dynamic_cast<Compound const &>(type));
+    case Type::Container:
+        return visit_(dynamic_cast<Container const &>(type));
+    }
+    // Never reached
+    assert(false);
+    return false; // to shut up gcc
+}
+
+void TypeVisitor::apply(Type const &type) { dispatch(type); }
+}

--- a/typelib/typevisitor.hh
+++ b/typelib/typevisitor.hh
@@ -3,49 +3,48 @@
 
 #include "typemodel.hh"
 
-namespace Typelib
-{
-    class UnsupportedType : public TypeException  
-    {
-    public:
-        Type const& type;
-	std::string const reason;
-        UnsupportedType(Type const& type_) 
-            : TypeException("type " + type_.getName() + " not supported"), type(type_) {}
-        UnsupportedType(Type const& type_, std::string const& reason_) 
-            : TypeException("type " + type_.getName() + " not supported: " + reason_), type(type_), reason(reason_) {}
-	~UnsupportedType() throw() { }
-    };
-    
-    /** Base class for type visitors 
-     * Given a Type object, TypeVisitor::apply dispatches the
-     * casted type to the appropriate visit_ method
-     *
-     * The default visit_ methods either do nothing or visits the
-     * types recursively (for arrays, pointers and compound types) 
-     */
-    class TypeVisitor
-    {
-    protected:
-        bool dispatch(Type const& type);
+namespace Typelib {
+class UnsupportedType : public TypeException {
+  public:
+    Type const &type;
+    std::string const reason;
+    UnsupportedType(Type const &type_)
+        : TypeException("type " + type_.getName() + " not supported"),
+          type(type_) {}
+    UnsupportedType(Type const &type_, std::string const &reason_)
+        : TypeException("type " + type_.getName() + " not supported: " +
+                        reason_),
+          type(type_), reason(reason_) {}
+    ~UnsupportedType() throw() {}
+};
 
-        virtual bool visit_ (NullType const& type);
-        virtual bool visit_ (OpaqueType const& type);
-        virtual bool visit_ (Numeric const& type);
-        virtual bool visit_ (Enum const& type);
+/** Base class for type visitors
+ * Given a Type object, TypeVisitor::apply dispatches the
+ * casted type to the appropriate visit_ method
+ *
+ * The default visit_ methods either do nothing or visits the
+ * types recursively (for arrays, pointers and compound types)
+ */
+class TypeVisitor {
+  protected:
+    bool dispatch(Type const &type);
 
-        virtual bool visit_ (Pointer const& type);
-        virtual bool visit_ (Array const& type);
-        virtual bool visit_ (Container const& type);
+    virtual bool visit_(NullType const &type);
+    virtual bool visit_(OpaqueType const &type);
+    virtual bool visit_(Numeric const &type);
+    virtual bool visit_(Enum const &type);
 
-        virtual bool visit_ (Compound const& type);
-        virtual bool visit_ (Compound const& type, Field const& field);
-       
-    public:
-        virtual ~TypeVisitor() {}
-        void apply(Type const& type);
-    };
+    virtual bool visit_(Pointer const &type);
+    virtual bool visit_(Array const &type);
+    virtual bool visit_(Container const &type);
+
+    virtual bool visit_(Compound const &type);
+    virtual bool visit_(Compound const &type, Field const &field);
+
+  public:
+    virtual ~TypeVisitor() {}
+    void apply(Type const &type);
+};
 }
 
 #endif
-

--- a/typelib/utilmm/bits/dummy.hh
+++ b/typelib/utilmm/bits/dummy.hh
@@ -2,79 +2,80 @@
  * $Id: dummy.hh 990 2005-09-14 15:17:04Z sjoyeux $
  */
 #ifndef UTILMM_SINGLETON_DUMMY_HEADER
-# define UTILMM_SINGLETON_DUMMY_HEADER
+#define UTILMM_SINGLETON_DUMMY_HEADER
 
-# include <string>
+#include <string>
 #include <boost/utility.hpp>
 
 #include "typelib/utilmm/bits/server_fwd.hh"
 
 namespace utilmm {
-  namespace singleton {
-    class dummy;
+namespace singleton {
+class dummy;
 
-    namespace details {
-      struct dummy_factory {
-        virtual ~dummy_factory() {};
-        virtual dummy* create() const = 0;
-      };
-    }
+namespace details {
+struct dummy_factory {
+    virtual ~dummy_factory(){};
+    virtual dummy *create() const = 0;
+};
+}
 
-    /** @brief base class for @c utilmm::singleton::wrapper
+/** @brief base class for @c utilmm::singleton::wrapper
+ *
+ * This class is the base class for all the singletons wrapper and
+ * the "public" interface to the singleton server.
+ *
+ * @author Frédéric Py <fpy@laas.fr>
+ * @ingroup singleton
+ * @ingroup intern
+ */
+class dummy : public ::boost::noncopyable {
+  protected:
+    /** @brief Default Constructor */
+    dummy();
+    /** @brief Destructor */
+    virtual ~dummy() = 0;
+
+    /** @brief Attach a new singleton.
      *
-     * This class is the base class for all the singletons wrapper and
-     * the "public" interface to the singleton server.
+     * @param name Internal id of the singleton.
+     * @param inst Candidate as singleton.
      *
-     * @author Frédéric Py <fpy@laas.fr>
-     * @ingroup singleton
-     * @ingroup intern
+     * This function called by @c wrapper::attach try to create a
+     * new singleton with @a name as unique id. If there's allready
+     * a singleton @a name then @a inst is deleted
      */
-    class dummy :public ::boost::noncopyable {
-    protected:
-      /** @brief Default Constructor */
-      dummy();
-      /** @brief Destructor */
-      virtual ~dummy() =0;
+    static void attach(std::string const &name,
+                       details::dummy_factory const &factory);
+    /** @brief Detach to a singleton
+     *
+     * @param name Internal id of a singleton
+     *
+     * This function called by wrapper::detach indicate to the
+     * singleton server that the singleton identified as @a name has
+     * lost one client.
+     */
+    static void detach(std::string const &name);
 
-      /** @brief Attach a new singleton.
-       *
-       * @param name Internal id of the singleton.
-       * @param inst Candidate as singleton.
-       *
-       * This function called by @c wrapper::attach try to create a
-       * new singleton with @a name as unique id. If there's allready
-       * a singleton @a name then @a inst is deleted
-       */
-      static void attach(std::string const &name, details::dummy_factory const& factory);
-      /** @brief Detach to a singleton
-       *
-       * @param name Internal id of a singleton
-       * 
-       * This function called by wrapper::detach indicate to the
-       * singleton server that the singleton identified as @a name has
-       * lost one client. 
-       */
-      static void detach(std::string const &name);
+    /** @brief Singleton generic access
+     *
+     * @param name Internal id of a singleton
+     *
+     * @return a pointer to the dummy wrapper of the singleton
+     * attached to @a name
+     */
+    static dummy *instance(std::string const &name);
 
-      /** @brief Singleton generic access
-       *
-       * @param name Internal id of a singleton
-       * 
-       * @return a pointer to the dummy wrapper of the singleton
-       * attached to @a name
-       */
-      static dummy *instance(std::string const &name);
+  private:
+    void incr_ref() const;
+    bool decr_ref() const;
 
-    private:
-      void incr_ref() const;
-      bool decr_ref() const;
+    mutable size_t ref_counter;
 
-      mutable size_t ref_counter;
+    friend class utilmm::singleton::server;
+}; // class utilmm::singleton::dummy
 
-      friend class utilmm::singleton::server;
-    }; // class utilmm::singleton::dummy
-
-  } // namespace utilmm::singleton
+} // namespace utilmm::singleton
 } // namespace utilmm
 
 #endif // UTILMM_SINGLETON_DUMMY_HEADER

--- a/typelib/utilmm/bits/server_fwd.hh
+++ b/typelib/utilmm/bits/server_fwd.hh
@@ -2,14 +2,14 @@
  * $Id: server_fwd.hh 953 2005-02-17 21:08:23Z fpy $
  */
 #ifndef UTILMM_SINGLETON_SERVER_FWD
-# define UTILMM_SINGLETON_SERVER_FWD
+#define UTILMM_SINGLETON_SERVER_FWD
 
 namespace utilmm {
-  namespace singleton {
+namespace singleton {
 
-    class server;
+class server;
 
-  } // namespace utilmm::singleton
+} // namespace utilmm::singleton
 } // namespace utilmm
 
 #endif // UTILMM_SINGLETON_SERVER_FWD
@@ -17,7 +17,7 @@ namespace utilmm {
 /** @file singleton/bits/server_fwd.hh
  * @brief Forward declaration of @c utilmm::singleton::server
  *
- * This header is the only description final library client 
+ * This header is the only description final library client
  * have about the @c utilmm::singleton::server class.
  *
  * @sa server.hh

--- a/typelib/utilmm/bits/wrapper.hh
+++ b/typelib/utilmm/bits/wrapper.hh
@@ -2,78 +2,76 @@
  * $Id: wrapper.hh 971 2005-04-08 16:31:47Z sjoyeux $
  */
 #ifndef UTILMM_SINGLETON_WRAPPER_HEADER
-# define UTILMM_SINGLETON_WRAPPER_HEADER
+#define UTILMM_SINGLETON_WRAPPER_HEADER
 
 #include "typelib/utilmm/bits/dummy.hh"
 
 namespace utilmm {
-  namespace singleton {
-    namespace details {
-        template<typename Ty>
-        class wrapper_factory;
-    }
+namespace singleton {
+namespace details {
+template <typename Ty> class wrapper_factory;
+}
 
-    /** @brief Wrapper for singleton instances
+/** @brief Wrapper for singleton instances
+ *
+ * This class offer the interface used by @c utilmm::singleton::use to
+ * manipulate the instance of type @c Ty
+ *
+ * @param Ty the type of the singleton instance
+ *
+ * @author Frédéric Py <fpy@laas.fr>
+ *
+ * @note All the mathods of this class are for internal use
+ * do not call them directly.
+ *
+ * @ingroup singleton
+ */
+template <typename Ty> class wrapper : private dummy {
+  public:
+    /** @brief New attachement to singleton
      *
-     * This class offer the interface used by @c utilmm::singleton::use to
-     * manipulate the instance of type @c Ty
+     * Indicates to the singleton server that there's a
+     * new client to the @c Ty singleton.
      *
-     * @param Ty the type of the singleton instance
-     *
-     * @author Frédéric Py <fpy@laas.fr>
-     *
-     * @note All the mathods of this class are for internal use
-     * do not call them directly.
-     * 
-     * @ingroup singleton
+     * @post The singleton @c Ty exist
      */
-    template<typename Ty>
-    class wrapper :private dummy {
-    public:
-      /** @brief New attachement to singleton
-       *
-       * Indicates to the singleton server that there's a
-       * new client to the @c Ty singleton.
-       *
-       * @post The singleton @c Ty exist
-       */
-      static void attach();
-      /** @brief Detachment to singleton
-       *
-       * Indicates  to the singleton server thet the singleton @c Ty
-       * has lost one client
-       *
-       * @pre The singleton @c Ty exist
-       * @post If there's no more client to singleton @c Ty then
-       * this one is destroyed
-       */
-      static void detach();
+    static void attach();
+    /** @brief Detachment to singleton
+     *
+     * Indicates  to the singleton server thet the singleton @c Ty
+     * has lost one client
+     *
+     * @pre The singleton @c Ty exist
+     * @post If there's no more client to singleton @c Ty then
+     * this one is destroyed
+     */
+    static void detach();
 
-      /** @brief Acces to the singleton
-       *
-       * @return A reference to singleton @c Ty instance.
-       *
-       * @pre singleton @c Ty exist
-       */
-      static Ty &instance();
+    /** @brief Acces to the singleton
+     *
+     * @return A reference to singleton @c Ty instance.
+     *
+     * @pre singleton @c Ty exist
+     */
+    static Ty &instance();
 
-    private:
-      wrapper();
-      ~wrapper();
+  private:
+    wrapper();
+    ~wrapper();
 
-      static std::string name();
+    static std::string name();
 
-      Ty value;
+    Ty value;
 
-      friend class details::wrapper_factory<Ty>;
-    }; // class utilmm::singleton::wrapper<>
+    friend class details::wrapper_factory<Ty>;
+}; // class utilmm::singleton::wrapper<>
 
-  } // namespace utilmm::singleton
+} // namespace utilmm::singleton
 } // namespace utilmm
 
-# define IN_UTILMM_SINGLETON_WRAPPER_HEADER
+#define IN_UTILMM_SINGLETON_WRAPPER_HEADER
 #include "typelib/utilmm/bits/wrapper.tcc"
-# undef IN_UTILMM_SINGLETON_WRAPPER_HEADER
+#undef IN_UTILMM_SINGLETON_WRAPPER_HEADER
 #endif // UTILMM_SINGLETON_WRAPPER_HEADER
 
 /** @file singleton/bits/wrapper.hh

--- a/typelib/utilmm/configset.cc
+++ b/typelib/utilmm/configset.cc
@@ -4,90 +4,75 @@
 using namespace std;
 using namespace utilmm;
 
-config_set::config_set(config_set* parent_)
-    : m_parent(parent_) {}
+config_set::config_set(config_set *parent_) : m_parent(parent_) {}
 
-config_set::~config_set()
-{ 
-    clear(); 
+config_set::~config_set() { clear(); }
+
+bool config_set::empty() const {
+    return m_values.empty() && m_children.empty();
 }
-    
-bool config_set::empty() const
-{ return m_values.empty() && m_children.empty(); }
-void config_set::clear() 
-{
+void config_set::clear() {
     m_values.clear();
-    while (!m_children.empty())
-    {
+    while (!m_children.empty()) {
         ChildMap::iterator it = m_children.begin();
         delete it->second;
         m_children.erase(it);
     }
 }
-    
-const config_set* config_set::parent() const { return m_parent; } 
-config_set* config_set::parent() { return m_parent; } 
-list<const config_set*> config_set::children(const std::string& name) const
-{
-    typedef list<const config_set *> SetList;
-    pair<ChildMap::const_iterator, ChildMap::const_iterator>
-        range = m_children.equal_range(name);
 
-    ChildMap::const_iterator
-        it = range.first,
-        end = range.second;
-    
+const config_set *config_set::parent() const { return m_parent; }
+config_set *config_set::parent() { return m_parent; }
+list<const config_set *> config_set::children(const std::string &name) const {
+    typedef list<const config_set *> SetList;
+    pair<ChildMap::const_iterator, ChildMap::const_iterator> range =
+        m_children.equal_range(name);
+
+    ChildMap::const_iterator it = range.first, end = range.second;
+
     SetList ret;
-    while (it != end)
-    {
-        ret.push_back(it -> second);
+    while (it != end) {
+        ret.push_back(it->second);
         ++it;
     }
     return ret;
 }
-config_set const& config_set::child(std::string const& name) const
-{
+config_set const &config_set::child(std::string const &name) const {
     static config_set empty_set;
     subsets every_child = children(name);
     if (every_child.empty())
-	return empty_set;
+        return empty_set;
     return *every_child.front();
 }
 
-bool config_set::exists(const std::string& name) const
-{
-    return 
-        m_values.find(name) != m_values.end()
-        || m_children.find(name) != m_children.end();
+bool config_set::exists(const std::string &name) const {
+    return m_values.find(name) != m_values.end() ||
+           m_children.find(name) != m_children.end();
 }
 
-void config_set::insert(std::string const& name, std::string const& value)
-{ m_values.insert( make_pair(name, value) ); }
-void config_set::insert(std::string const& name, std::list<std::string> const& value)
-{ 
+void config_set::insert(std::string const &name, std::string const &value) {
+    m_values.insert(make_pair(name, value));
+}
+void config_set::insert(std::string const &name,
+                        std::list<std::string> const &value) {
     list<string>::const_iterator it;
     for (it = value.begin(); it != value.end(); ++it)
         insert(name, *it);
 }
-void config_set::insert(std::string const& name, config_set const* child_)
-{ m_children.insert( make_pair(name, child_) ); }
-void config_set::set(std::string const& name, std::string const& value)
-{
+void config_set::insert(std::string const &name, config_set const *child_) {
+    m_children.insert(make_pair(name, child_));
+}
+void config_set::set(std::string const &name, std::string const &value) {
     m_values.erase(name);
     insert(name, value);
 }
-void config_set::set(std::string const& name, std::list<std::string> const& value)
-{
+void config_set::set(std::string const &name,
+                     std::list<std::string> const &value) {
     m_values.erase(name);
     insert(name, value);
 }
-void config_set::erase(std::string const& name)
-{ m_values.erase(name); }
+void config_set::erase(std::string const &name) { m_values.erase(name); }
 
-
-
-template<> bool config_set::convert(const std::string& value)
-{
+template <> bool config_set::convert(const std::string &value) {
     if (value == "true" || value == "1")
         return true;
     if (value == "false" || value == "0")
@@ -96,17 +81,18 @@ template<> bool config_set::convert(const std::string& value)
     throw boost::bad_lexical_cast();
 }
 
-template<>
-config_set::stringlist config_set::get(const std::string& name, stringlist const& defval, 
-        boost::enable_if< details::is_list<config_set::stringlist> >::type* dummy) const
-{
+template <>
+config_set::stringlist config_set::get(
+    const std::string &name, stringlist const &defval,
+    boost::enable_if<details::is_list<config_set::stringlist> >::type *dummy)
+    const {
     list<string> values;
-    for(ValueMap::const_iterator it = m_values.find(name); it != m_values.end() && it->first == name; ++it)
+    for (ValueMap::const_iterator it = m_values.find(name);
+         it != m_values.end() && it->first == name; ++it)
         values.push_back(it->second);
 
-    if(values.empty())
+    if (values.empty())
         return defval;
 
     return values;
 }
-

--- a/typelib/utilmm/configset.hh
+++ b/typelib/utilmm/configset.hh
@@ -9,142 +9,137 @@
 
 #include <list>
 
-namespace utilmm
-{
-    /* To discriminate between list and non-list get<> */
-    namespace details
-    {
-        template<typename T> struct is_list
-        { static const bool value = false; };
-        template<typename T> struct is_list< std::list<T> >
-        { static const bool value = true; };
-    }
+namespace utilmm {
+/* To discriminate between list and non-list get<> */
+namespace details {
+template <typename T> struct is_list { static const bool value = false; };
+template <typename T> struct is_list<std::list<T> > {
+    static const bool value = true;
+};
+}
 
-    /** A scope in configuration files */
-    class config_set 
-        : private boost::noncopyable
-    {
-        friend class ConfigFile;
+/** A scope in configuration files */
+class config_set : private boost::noncopyable {
+    friend class ConfigFile;
 
-    private:
-        typedef std::list<std::string> stringlist;
-        template<typename T>
-        static T convert(std::string const& value);
-        
-    protected:
-        config_set* m_parent;
-        typedef std::multimap<std::string, std::string> ValueMap;
-        ValueMap m_values;
-        typedef std::multimap<std::string, const config_set*> ChildMap;
-        ChildMap m_children;
+  private:
+    typedef std::list<std::string> stringlist;
+    template <typename T> static T convert(std::string const &value);
 
-    protected:
-        /** Clears this set */
-        void clear();
-        
-    public:
-        explicit config_set(config_set* parent = 0);
-        ~config_set();
-        
-        typedef std::list<const config_set*> subsets;
+  protected:
+    config_set *m_parent;
+    typedef std::multimap<std::string, std::string> ValueMap;
+    ValueMap m_values;
+    typedef std::multimap<std::string, const config_set *> ChildMap;
+    ChildMap m_children;
 
-	/** Checks if this set is empty (no child, no attributes) */
-	bool empty() const;
+  protected:
+    /** Clears this set */
+    void clear();
 
-        /** Tests for the existence of an attribute */
-        bool exists (const std::string& attribute) const;
-        
-        /** The parent config_set object
-         * @return the config_set object for our parent scope, or 0 if 
-         * this scope is top-level */
-        const config_set* parent() const;
-        config_set* parent();
+  public:
+    explicit config_set(config_set *parent = 0);
+    ~config_set();
 
-        /** Get the list of children named \c name */
-        std::list<const config_set*> children(const std::string& name) const;
-        /** Get the first child named \c name or an empty set */
-	config_set const& child(std::string const& name) const;
+    typedef std::list<const config_set *> subsets;
 
-	/** In a config_set object, all values are stored as lists of strings. This
-	 * method converts the stored value into the required type using the
-	 * associated config_set::convert template specialization (if it exists).
-	 *
-	 * If no value is stored under the given key, returns \c defval
-	 */
-        template<typename T> 
-        T get(std::string const& name, T const& defval = T(),
-                typename boost::enable_if< details::is_list<T> >::type *enabler = 0) const;
-	/** In a config_set object, all values are stored as lists of strings. This
-	 * method is a convenience method when only one value is stored for a given
-	 * key.  It converts the stored value into the required type using the
-	 * associated config_set::convert template specialization (if it exists).
-	 *
-	 * If no value is associated with the key, returns \c defval
-	 */
-        template<typename T> 
-        T get(std::string const& name, T const& defval = T(),
-                typename boost::disable_if< details::is_list<T> >::type *enabler = 0) const;
+    /** Checks if this set is empty (no child, no attributes) */
+    bool empty() const;
 
-        /** Replaces any value associated with \c name with the value provided.
-	 * See \c insert to append new values to already existing ones 
-	 */
-        void set(std::string const& name, std::string const& value);
-	/** Sets multiple values for this key. If some value was already
-	 * associated with \c name, the new value replaces it. See \c insert to
-	 * append new values to already existing ones. 
-	 */
-        void set(std::string const& name, std::list<std::string> const& value);
-        /** Appends the given value to the values already associated with \c name */
-        void insert(std::string const& name, std::string const& value);
-        /** Appends the given values to the valus already associated with \c name */
-        void insert(std::string const& name, std::list<std::string> const& value);
-        /** Add a child to this config_set */
-        void insert(std::string const& name, config_set const* value);
-        /** Remove the given option */
-        void erase(std::string const& name);
-    };
+    /** Tests for the existence of an attribute */
+    bool exists(const std::string &attribute) const;
 
-    namespace details {
-        typedef std::list<std::string> stringlist;
-    }
+    /** The parent config_set object
+     * @return the config_set object for our parent scope, or 0 if
+     * this scope is top-level */
+    const config_set *parent() const;
+    config_set *parent();
 
-    template<> bool config_set::convert(std::string const& value);
-    template<typename T> 
-    T config_set::convert(const std::string& value)
-    { return boost::lexical_cast<T>(value); }
+    /** Get the list of children named \c name */
+    std::list<const config_set *> children(const std::string &name) const;
+    /** Get the first child named \c name or an empty set */
+    config_set const &child(std::string const &name) const;
 
+    /** In a config_set object, all values are stored as lists of strings. This
+     * method converts the stored value into the required type using the
+     * associated config_set::convert template specialization (if it exists).
+     *
+     * If no value is stored under the given key, returns \c defval
+     */
+    template <typename T>
+    T get(std::string const &name, T const &defval = T(),
+          typename boost::enable_if<details::is_list<T> >::type *
+              enabler = 0) const;
+    /** In a config_set object, all values are stored as lists of strings. This
+     * method is a convenience method when only one value is stored for a given
+     * key.  It converts the stored value into the required type using the
+     * associated config_set::convert template specialization (if it exists).
+     *
+     * If no value is associated with the key, returns \c defval
+     */
+    template <typename T>
+    T get(std::string const &name, T const &defval = T(),
+          typename boost::disable_if<details::is_list<T> >::type *
+              enabler = 0) const;
 
-    template<>
-    config_set::stringlist config_set::get(std::string const& name,
-            config_set::stringlist const& defval,
-            boost::enable_if< details::is_list<config_set::stringlist> >::type *enabler) const;
+    /** Replaces any value associated with \c name with the value provided.
+     * See \c insert to append new values to already existing ones
+     */
+    void set(std::string const &name, std::string const &value);
+    /** Sets multiple values for this key. If some value was already
+     * associated with \c name, the new value replaces it. See \c insert to
+     * append new values to already existing ones.
+     */
+    void set(std::string const &name, std::list<std::string> const &value);
+    /** Appends the given value to the values already associated with \c name */
+    void insert(std::string const &name, std::string const &value);
+    /** Appends the given values to the valus already associated with \c name */
+    void insert(std::string const &name, std::list<std::string> const &value);
+    /** Add a child to this config_set */
+    void insert(std::string const &name, config_set const *value);
+    /** Remove the given option */
+    void erase(std::string const &name);
+};
 
-    template<typename T> 
-    T config_set::get(std::string const& name, T const& defval,
-            typename boost::enable_if< details::is_list<T> >::type *enabler) const
-    {
-        stringlist values = get< stringlist >(name);
-        if (values.empty())
-            return defval;
-        
-        T result;
-        for (stringlist::const_iterator it = values.begin(); it != values.end(); ++it)
-            result.push_back(convert<typename T::value_type>(*it));
+namespace details {
+typedef std::list<std::string> stringlist;
+}
 
-        return result;
-    }
+template <> bool config_set::convert(std::string const &value);
+template <typename T> T config_set::convert(const std::string &value) {
+    return boost::lexical_cast<T>(value);
+}
 
-    template<typename T>
-    T config_set::get(std::string const& name, T const& defval,
-            typename boost::disable_if< details::is_list<T> >::type *enabler) const
-    {   
-        std::list<T> deflist;
-        deflist.push_back(defval);
-        return get< std::list<T> >(name, deflist).front();
-    }
+template <>
+config_set::stringlist config_set::get(
+    std::string const &name, config_set::stringlist const &defval,
+    boost::enable_if<details::is_list<config_set::stringlist> >::type *enabler)
+    const;
+
+template <typename T>
+T config_set::get(
+    std::string const &name, T const &defval,
+    typename boost::enable_if<details::is_list<T> >::type *enabler) const {
+    stringlist values = get<stringlist>(name);
+    if (values.empty())
+        return defval;
+
+    T result;
+    for (stringlist::const_iterator it = values.begin(); it != values.end();
+         ++it)
+        result.push_back(convert<typename T::value_type>(*it));
+
+    return result;
+}
+
+template <typename T>
+T config_set::get(
+    std::string const &name, T const &defval,
+    typename boost::disable_if<details::is_list<T> >::type *enabler) const {
+    std::list<T> deflist;
+    deflist.push_back(defval);
+    return get<std::list<T> >(name, deflist).front();
+}
 }
 
 #endif
-
-
-

--- a/typelib/utilmm/singleton/bits/dummy.hh
+++ b/typelib/utilmm/singleton/bits/dummy.hh
@@ -2,79 +2,80 @@
  * $Id: dummy.hh 990 2005-09-14 15:17:04Z sjoyeux $
  */
 #ifndef UTILMM_SINGLETON_DUMMY_HEADER
-# define UTILMM_SINGLETON_DUMMY_HEADER
+#define UTILMM_SINGLETON_DUMMY_HEADER
 
-# include <string>
+#include <string>
 #include <boost/utility.hpp>
 
 #include "typelib/utilmm/singleton/bits/server_fwd.hh"
 
 namespace utilmm {
-  namespace singleton {
-    class dummy;
+namespace singleton {
+class dummy;
 
-    namespace details {
-      struct dummy_factory {
-        virtual ~dummy_factory() {};
-        virtual dummy* create() const = 0;
-      };
-    }
+namespace details {
+struct dummy_factory {
+    virtual ~dummy_factory(){};
+    virtual dummy *create() const = 0;
+};
+}
 
-    /** @brief base class for @c utilmm::singleton::wrapper
+/** @brief base class for @c utilmm::singleton::wrapper
+ *
+ * This class is the base class for all the singletons wrapper and
+ * the "public" interface to the singleton server.
+ *
+ * @author Frédéric Py <fpy@laas.fr>
+ * @ingroup singleton
+ * @ingroup intern
+ */
+class dummy : public ::boost::noncopyable {
+  protected:
+    /** @brief Default Constructor */
+    dummy();
+    /** @brief Destructor */
+    virtual ~dummy() = 0;
+
+    /** @brief Attach a new singleton.
      *
-     * This class is the base class for all the singletons wrapper and
-     * the "public" interface to the singleton server.
+     * @param name Internal id of the singleton.
+     * @param inst Candidate as singleton.
      *
-     * @author Frédéric Py <fpy@laas.fr>
-     * @ingroup singleton
-     * @ingroup intern
+     * This function called by @c wrapper::attach try to create a
+     * new singleton with @a name as unique id. If there's allready
+     * a singleton @a name then @a inst is deleted
      */
-    class dummy :public ::boost::noncopyable {
-    protected:
-      /** @brief Default Constructor */
-      dummy();
-      /** @brief Destructor */
-      virtual ~dummy() =0;
+    static void attach(std::string const &name,
+                       details::dummy_factory const &factory);
+    /** @brief Detach to a singleton
+     *
+     * @param name Internal id of a singleton
+     *
+     * This function called by wrapper::detach indicate to the
+     * singleton server that the singleton identified as @a name has
+     * lost one client.
+     */
+    static void detach(std::string const &name);
 
-      /** @brief Attach a new singleton.
-       *
-       * @param name Internal id of the singleton.
-       * @param inst Candidate as singleton.
-       *
-       * This function called by @c wrapper::attach try to create a
-       * new singleton with @a name as unique id. If there's allready
-       * a singleton @a name then @a inst is deleted
-       */
-      static void attach(std::string const &name, details::dummy_factory const& factory);
-      /** @brief Detach to a singleton
-       *
-       * @param name Internal id of a singleton
-       * 
-       * This function called by wrapper::detach indicate to the
-       * singleton server that the singleton identified as @a name has
-       * lost one client. 
-       */
-      static void detach(std::string const &name);
+    /** @brief Singleton generic access
+     *
+     * @param name Internal id of a singleton
+     *
+     * @return a pointer to the dummy wrapper of the singleton
+     * attached to @a name
+     */
+    static dummy *instance(std::string const &name);
 
-      /** @brief Singleton generic access
-       *
-       * @param name Internal id of a singleton
-       * 
-       * @return a pointer to the dummy wrapper of the singleton
-       * attached to @a name
-       */
-      static dummy *instance(std::string const &name);
+  private:
+    void incr_ref() const;
+    bool decr_ref() const;
 
-    private:
-      void incr_ref() const;
-      bool decr_ref() const;
+    mutable size_t ref_counter;
 
-      mutable size_t ref_counter;
+    friend class utilmm::singleton::server;
+}; // class utilmm::singleton::dummy
 
-      friend class utilmm::singleton::server;
-    }; // class utilmm::singleton::dummy
-
-  } // namespace utilmm::singleton
+} // namespace utilmm::singleton
 } // namespace utilmm
 
 #endif // UTILMM_SINGLETON_DUMMY_HEADER

--- a/typelib/utilmm/singleton/bits/server_fwd.hh
+++ b/typelib/utilmm/singleton/bits/server_fwd.hh
@@ -2,14 +2,14 @@
  * $Id: server_fwd.hh 953 2005-02-17 21:08:23Z fpy $
  */
 #ifndef UTILMM_SINGLETON_SERVER_FWD
-# define UTILMM_SINGLETON_SERVER_FWD
+#define UTILMM_SINGLETON_SERVER_FWD
 
 namespace utilmm {
-  namespace singleton {
+namespace singleton {
 
-    class server;
+class server;
 
-  } // namespace utilmm::singleton
+} // namespace utilmm::singleton
 } // namespace utilmm
 
 #endif // UTILMM_SINGLETON_SERVER_FWD
@@ -17,7 +17,7 @@ namespace utilmm {
 /** @file singleton/bits/server_fwd.hh
  * @brief Forward declaration of @c utilmm::singleton::server
  *
- * This header is the only description final library client 
+ * This header is the only description final library client
  * have about the @c utilmm::singleton::server class.
  *
  * @sa server.hh

--- a/typelib/utilmm/singleton/bits/wrapper.hh
+++ b/typelib/utilmm/singleton/bits/wrapper.hh
@@ -2,78 +2,76 @@
  * $Id: wrapper.hh 971 2005-04-08 16:31:47Z sjoyeux $
  */
 #ifndef UTILMM_SINGLETON_WRAPPER_HEADER
-# define UTILMM_SINGLETON_WRAPPER_HEADER
+#define UTILMM_SINGLETON_WRAPPER_HEADER
 
 #include "typelib/utilmm/singleton/bits/dummy.hh"
 
 namespace utilmm {
-  namespace singleton {
-    namespace details {
-        template<typename Ty>
-        class wrapper_factory;
-    }
+namespace singleton {
+namespace details {
+template <typename Ty> class wrapper_factory;
+}
 
-    /** @brief Wrapper for singleton instances
+/** @brief Wrapper for singleton instances
+ *
+ * This class offer the interface used by @c utilmm::singleton::use to
+ * manipulate the instance of type @c Ty
+ *
+ * @param Ty the type of the singleton instance
+ *
+ * @author Frédéric Py <fpy@laas.fr>
+ *
+ * @note All the mathods of this class are for internal use
+ * do not call them directly.
+ *
+ * @ingroup singleton
+ */
+template <typename Ty> class wrapper : private dummy {
+  public:
+    /** @brief New attachement to singleton
      *
-     * This class offer the interface used by @c utilmm::singleton::use to
-     * manipulate the instance of type @c Ty
+     * Indicates to the singleton server that there's a
+     * new client to the @c Ty singleton.
      *
-     * @param Ty the type of the singleton instance
-     *
-     * @author Frédéric Py <fpy@laas.fr>
-     *
-     * @note All the mathods of this class are for internal use
-     * do not call them directly.
-     * 
-     * @ingroup singleton
+     * @post The singleton @c Ty exist
      */
-    template<typename Ty>
-    class wrapper :private dummy {
-    public:
-      /** @brief New attachement to singleton
-       *
-       * Indicates to the singleton server that there's a
-       * new client to the @c Ty singleton.
-       *
-       * @post The singleton @c Ty exist
-       */
-      static void attach();
-      /** @brief Detachment to singleton
-       *
-       * Indicates  to the singleton server thet the singleton @c Ty
-       * has lost one client
-       *
-       * @pre The singleton @c Ty exist
-       * @post If there's no more client to singleton @c Ty then
-       * this one is destroyed
-       */
-      static void detach();
+    static void attach();
+    /** @brief Detachment to singleton
+     *
+     * Indicates  to the singleton server thet the singleton @c Ty
+     * has lost one client
+     *
+     * @pre The singleton @c Ty exist
+     * @post If there's no more client to singleton @c Ty then
+     * this one is destroyed
+     */
+    static void detach();
 
-      /** @brief Acces to the singleton
-       *
-       * @return A reference to singleton @c Ty instance.
-       *
-       * @pre singleton @c Ty exist
-       */
-      static Ty &instance();
+    /** @brief Acces to the singleton
+     *
+     * @return A reference to singleton @c Ty instance.
+     *
+     * @pre singleton @c Ty exist
+     */
+    static Ty &instance();
 
-    private:
-      wrapper();
-      ~wrapper();
+  private:
+    wrapper();
+    ~wrapper();
 
-      static std::string name();
+    static std::string name();
 
-      Ty value;
+    Ty value;
 
-      friend class details::wrapper_factory<Ty>;
-    }; // class utilmm::singleton::wrapper<>
+    friend class details::wrapper_factory<Ty>;
+}; // class utilmm::singleton::wrapper<>
 
-  } // namespace utilmm::singleton
+} // namespace utilmm::singleton
 } // namespace utilmm
 
-# define IN_UTILMM_SINGLETON_WRAPPER_HEADER
+#define IN_UTILMM_SINGLETON_WRAPPER_HEADER
 #include "typelib/utilmm/singleton/bits/wrapper.tcc"
-# undef IN_UTILMM_SINGLETON_WRAPPER_HEADER
+#undef IN_UTILMM_SINGLETON_WRAPPER_HEADER
 #endif // UTILMM_SINGLETON_WRAPPER_HEADER
 
 /** @file singleton/bits/wrapper.hh

--- a/typelib/utilmm/singleton/dummy.cc
+++ b/typelib/utilmm/singleton/dummy.cc
@@ -9,34 +9,30 @@ using namespace utilmm::singleton;
  * class utilmm::singleton::dummy
  */
 
-// structors 
-dummy::dummy()
-  :ref_counter(0ul) {}
+// structors
+dummy::dummy() : ref_counter(0ul) {}
 
 dummy::~dummy() {}
 
-// modifiers 
-void dummy::incr_ref() const {
-  ++ref_counter;
-}
+// modifiers
+void dummy::incr_ref() const { ++ref_counter; }
 
-bool dummy::decr_ref() const {
-  return (ref_counter--)<=1;
-}
+bool dummy::decr_ref() const { return (ref_counter--) <= 1; }
 
 // statics
-void dummy::attach(std::string const &name, details::dummy_factory const& inst) {
-  server::lock_type locker(server::sing_mtx);
-  server::instance().attach(name, inst);
+void dummy::attach(std::string const &name,
+                   details::dummy_factory const &inst) {
+    server::lock_type locker(server::sing_mtx);
+    server::instance().attach(name, inst);
 }
 
 void dummy::detach(std::string const &name) {
-  server::lock_type locker(server::sing_mtx);
-  if( server::instance().detach(name) )
-    delete server::the_instance;
+    server::lock_type locker(server::sing_mtx);
+    if (server::instance().detach(name))
+        delete server::the_instance;
 }
 
 dummy *dummy::instance(std::string const &name) {
-  server::lock_type locker(server::sing_mtx);
-  return server::instance().get(name);
+    server::lock_type locker(server::sing_mtx);
+    return server::instance().get(name);
 }

--- a/typelib/utilmm/singleton/server.cc
+++ b/typelib/utilmm/singleton/server.cc
@@ -8,52 +8,50 @@ using namespace std;
 using namespace utilmm::singleton;
 using boost::recursive_mutex;
 
-server* utilmm::singleton::server::the_instance = 0;
+server *utilmm::singleton::server::the_instance = 0;
 
 boost::recursive_mutex utilmm::singleton::server::sing_mtx;
 
 /*
  * class utilmm::singleton::server
  */
-// structors 
-server::server() {
-  the_instance = this;
-}
+// structors
+server::server() { the_instance = this; }
 
-server::~server() {
-  the_instance = 0;
-}
+server::~server() { the_instance = 0; }
 
 // modifiers
-void server::attach(std::string const &name, details::dummy_factory const& factory) {
-  single_map::iterator it = singletons.find(name);
-  if (it == singletons.end())
-    it = singletons.insert( single_map::value_type(name, factory.create()) ).first;
+void server::attach(std::string const &name,
+                    details::dummy_factory const &factory) {
+    single_map::iterator it = singletons.find(name);
+    if (it == singletons.end())
+        it = singletons.insert(single_map::value_type(name, factory.create()))
+                 .first;
 
-  it->second->incr_ref();
+    it->second->incr_ref();
 }
 
 bool server::detach(std::string const &name) {
-  single_map::iterator i = singletons.find(name);
+    single_map::iterator i = singletons.find(name);
 
-  if( i->second->decr_ref() ) {
-    dummy *to_del = i->second;
+    if (i->second->decr_ref()) {
+        dummy *to_del = i->second;
 
-    singletons.erase(i);
-    delete to_del;
-    return singletons.empty();
-  }
-  return false;
+        singletons.erase(i);
+        delete to_del;
+        return singletons.empty();
+    }
+    return false;
 }
 
-// observers 
+// observers
 dummy *server::get(std::string const &name) const {
-  return singletons.find(name)->second;
+    return singletons.find(name)->second;
 }
 
 // statics
 server &server::instance() {
-  if( 0==the_instance )
-    new server;
-  return *the_instance;
+    if (0 == the_instance)
+        new server;
+    return *the_instance;
 }

--- a/typelib/utilmm/singleton/server.hh
+++ b/typelib/utilmm/singleton/server.hh
@@ -2,68 +2,68 @@
  * $Id: server.hh 970 2005-04-08 16:30:46Z sjoyeux $
  */
 #ifndef UTILMM_SINGLETON_SERVER_HEADER
-# define UTILMM_SINGLETON_SERVER_HEADER
+#define UTILMM_SINGLETON_SERVER_HEADER
 
-# include <map>
+#include <map>
 
-# include "boost/thread/recursive_mutex.hpp"
+#include "boost/thread/recursive_mutex.hpp"
 
-# include "typelib/utilmm/singleton/bits/dummy.hh"
+#include "typelib/utilmm/singleton/bits/dummy.hh"
 
 namespace utilmm {
-  namespace singleton {
+namespace singleton {
 
-    /** @brief Singleton server
-     *
-     * The central server for singleton instances.
-     *
-     * @ingroup singleton
-     * @ingroup intern
-     *
-     * @author Frédéric Py <fpy@laas.fr>
-     */
-    class server :public ::boost::noncopyable {
-    private:
-      server();
-      ~server();
+/** @brief Singleton server
+ *
+ * The central server for singleton instances.
+ *
+ * @ingroup singleton
+ * @ingroup intern
+ *
+ * @author Frédéric Py <fpy@laas.fr>
+ */
+class server : public ::boost::noncopyable {
+  private:
+    server();
+    ~server();
 
-      static server &instance();
-      
-      void attach(std::string const &name, details::dummy_factory const& factory);
-      bool detach(std::string const &name);
+    static server &instance();
 
-      dummy *get(std::string const &name) const;
+    void attach(std::string const &name, details::dummy_factory const &factory);
+    bool detach(std::string const &name);
 
-      typedef std::map<std::string, dummy *> single_map;
+    dummy *get(std::string const &name) const;
 
-      single_map singletons;
+    typedef std::map<std::string, dummy *> single_map;
 
-      static server *the_instance;
+    single_map singletons;
 
-      typedef boost::recursive_mutex mutex_type;
-      typedef mutex_type::scoped_lock lock_type;
+    static server *the_instance;
 
-      static mutex_type sing_mtx;
+    typedef boost::recursive_mutex mutex_type;
+    typedef mutex_type::scoped_lock lock_type;
 
-      friend class utilmm::singleton::dummy;
-    }; // class utilmm::singleton::server
+    static mutex_type sing_mtx;
 
-  } // namespace utilmm::singleton
+    friend class utilmm::singleton::dummy;
+}; // class utilmm::singleton::server
+
+} // namespace utilmm::singleton
 } // namespace utilmm
 
 #endif // UTILMM_SINGLETON_SERVER_HEADER
-/** @file src/singleton/server.hh
- * @brief Definition of @c utilmm::singleton::server
- *
- * This private header defines the @c utilmm::singleton::server class.
- *
- * @author Frédéric Py <fpy@laas.fr>
- * @ingroup intern
- * @ingroup singleton
- */
+       /** @file src/singleton/server.hh
+        * @brief Definition of @c utilmm::singleton::server
+        *
+        * This private header defines the @c utilmm::singleton::server class.
+        *
+        * @author Frédéric Py <fpy@laas.fr>
+        * @ingroup intern
+        * @ingroup singleton
+        */
 
 /** @defgroup intern Library internal utilities
  * @brief This group include all the component
  * of the library only used for the internal implementation
- * of the library. 
+ * of the library.
  */

--- a/typelib/utilmm/singleton/use.hh
+++ b/typelib/utilmm/singleton/use.hh
@@ -2,96 +2,95 @@
  * $Id: use.hh 957 2005-03-07 16:01:20Z sjoyeux $
  */
 #ifndef UTILMM_SINGLETON_USE_HEADER
-#  define UTILMM_SINGLETON_USE_HEADER
+#define UTILMM_SINGLETON_USE_HEADER
 
 namespace utilmm {
-  /** @brief Singleton manipulation
-   *
-   * This namespace include all the classes used to manipulate
-   * singletons.
-   *
-   * @ingroup singleton
-   */
-  namespace singleton {
-
-    /** @brief Access point to singleton.
-     *
-     * This class is the used to acces to a singleton
-     * with type @c Ty . It also manage the singleton life time
-     * indicating to the @c server that this singleton has a
-     * new client.
-     *
-     * @author Frédéric Py <fpy@laas.fr>
-     *
-     * @ingroup singleton
-     */
-    template<typename Ty>
-    struct use {
-      /** @brief Constructor
-       *
-       * Create a new instance and eventually create the
-       * singleton. This constructor will indicate to
-       * server that thze singleton @c Ty has a new client.
-       * If it is the first client then the sezrver will
-       * create the singleton @c Ty.
-       */
-      use();
-      /** @brief Copy constructor
-       *
-       * This constructor only indicate to server that there's a
-       * new client to sinbgleton @c Ty.
-       */
-      use(use const &other);
-      
-      /** @brief Destructor
-       *
-       * Indicate to server that singlerton @c Ty has lost one
-       * client if the number of client to @c Ty becomes null then
-       * the singleton is destroyed.
-       */
-      ~use();
-      
-      /** @brief Access to singleton
-       *
-       * @return A reference to the singleton @c Ty
-       */
-      Ty &instance() const;
-      
-      /** @brief Access to singleton
-       * @sa instance() const
-       */
-      Ty &operator* () const;
-      /** @brief Access to singleton
-       *
-       * This operator allow client to directly access to singlton's
-       * attributes.
-       * 
-       * @sa instance() const
-       */
-      Ty *operator->() const;      
-    }; // struct utilmm::singleton::use<>
-
-  } // namespace utilmm::singleton
-} // namespace utilmm
-
-# define IN_UTILMM_SINGLETON_USE_HEADER
-#include "typelib/utilmm/singleton/bits/use.tcc"
-# undef IN_UTILMM_SINGLETON_USE_HEADER
-#endif // UTILMM_SINGLETON_USE_HEADER
-/** @file singleton/use.hh
- * @brief Declararation of @c utilmm::singleton::use class
+/** @brief Singleton manipulation
  *
- * This header defclare the @c utilmm::singleton::use
- * class.
+ * This namespace include all the classes used to manipulate
+ * singletons.
  *
- * @author Frédéric Py <fpy@laas.fr>
  * @ingroup singleton
  */
+namespace singleton {
+
+/** @brief Access point to singleton.
+ *
+ * This class is the used to acces to a singleton
+ * with type @c Ty . It also manage the singleton life time
+ * indicating to the @c server that this singleton has a
+ * new client.
+ *
+ * @author Frédéric Py <fpy@laas.fr>
+ *
+ * @ingroup singleton
+ */
+template <typename Ty> struct use {
+    /** @brief Constructor
+     *
+     * Create a new instance and eventually create the
+     * singleton. This constructor will indicate to
+     * server that thze singleton @c Ty has a new client.
+     * If it is the first client then the sezrver will
+     * create the singleton @c Ty.
+     */
+    use();
+    /** @brief Copy constructor
+     *
+     * This constructor only indicate to server that there's a
+     * new client to sinbgleton @c Ty.
+     */
+    use(use const &other);
+
+    /** @brief Destructor
+     *
+     * Indicate to server that singlerton @c Ty has lost one
+     * client if the number of client to @c Ty becomes null then
+     * the singleton is destroyed.
+     */
+    ~use();
+
+    /** @brief Access to singleton
+     *
+     * @return A reference to the singleton @c Ty
+     */
+    Ty &instance() const;
+
+    /** @brief Access to singleton
+     * @sa instance() const
+     */
+    Ty &operator*() const;
+    /** @brief Access to singleton
+     *
+     * This operator allow client to directly access to singlton's
+     * attributes.
+     *
+     * @sa instance() const
+     */
+    Ty *operator->() const;
+}; // struct utilmm::singleton::use<>
+
+} // namespace utilmm::singleton
+} // namespace utilmm
+
+#define IN_UTILMM_SINGLETON_USE_HEADER
+#include "typelib/utilmm/singleton/bits/use.tcc"
+#undef IN_UTILMM_SINGLETON_USE_HEADER
+#endif // UTILMM_SINGLETON_USE_HEADER
+       /** @file singleton/use.hh
+        * @brief Declararation of @c utilmm::singleton::use class
+        *
+        * This header defclare the @c utilmm::singleton::use
+        * class.
+        *
+        * @author Frédéric Py <fpy@laas.fr>
+        * @ingroup singleton
+        */
 
 /** @defgroup singleton Singleton pattern design.
  *
  * @brief Implementation of designe pattern which can be compared to
- * phoenix singleton with advanced instance life management. 
+ * phoenix singleton with advanced instance life management.
  *
  * This module includes all the classes used to implement a phoenix
  * singleton pattern design supporting shared libraires.
@@ -125,7 +124,7 @@ namespace utilmm {
  * private:
  *   utilmm::singleton::use<bar> bar_s;
  *   int value;
- *   
+ *
  * public:
  *  foo():value(0) {}
  *  explicit foo(int v):value(v) {}
@@ -136,7 +135,7 @@ namespace utilmm {
  *    // or bar_s->send(value);
  *  }
  * };
- * 
+ *
  * @endcode
  *
  * @par Making a class a pure singleton
@@ -146,16 +145,16 @@ namespace utilmm {
  * this example :
  *
  * @code
- * #include "utilmm/singleton/wrapper_fwd.hh" 
+ * #include "utilmm/singleton/wrapper_fwd.hh"
  *
  * class pure_singleton {
- * public: 
- *  // [...] 
+ * public:
+ *  // [...]
  * private:
  *   pure_singleton();
  *   ~pure_singleton();
  *
- *  // [...] 
+ *  // [...]
  *
  *   friend class utilmm::singleton::wrapper<pure_singleton>;
  * };
@@ -164,5 +163,5 @@ namespace utilmm {
  * All the structors are defined as private then only firends
  * (ie @c utilmm::singleton::wrapper) can create and destroy
  * the instance then we have the guarantee that this class is
- * a pure phoenix singleton.  
+ * a pure phoenix singleton.
  */

--- a/typelib/utilmm/singleton/use_fwd.hh
+++ b/typelib/utilmm/singleton/use_fwd.hh
@@ -2,15 +2,14 @@
  * $Id: use_fwd.hh 949 2005-02-11 14:51:00Z fpy $
  */
 #ifndef UTILMM_SINGLETON_USE_FWD
-#  define UTILMM_SINGLETON_USE_FWD
+#define UTILMM_SINGLETON_USE_FWD
 
 namespace utilmm {
-  namespace singleton {
+namespace singleton {
 
-    template<typename Ty>
-    struct use;
+template <typename Ty> struct use;
 
-  } // namespace utilmm::singleton
+} // namespace utilmm::singleton
 } // namespace utilmm
 
 #endif // UTILMM_SINGLETON_USE_FWD

--- a/typelib/utilmm/singleton/wrapper_fwd.hh
+++ b/typelib/utilmm/singleton/wrapper_fwd.hh
@@ -2,15 +2,14 @@
  * $Id: wrapper_fwd.hh 949 2005-02-11 14:51:00Z fpy $
  */
 #ifndef UTILMM_SINGLETON_WRAPPER_FWD
-# define UTILMM_SINGLETON_WRAPPER_FWD
+#define UTILMM_SINGLETON_WRAPPER_FWD
 
 namespace utilmm {
-  namespace singleton {
+namespace singleton {
 
-    template<typename Ty>
-    class wrapper;
+template <typename Ty> class wrapper;
 
-  } // namespace utilmm::singleton
+} // namespace utilmm::singleton
 } // namespace utilmm
 
 #endif // UTILMM_SINGLETON_WRAPPER_FWD

--- a/typelib/value.cc
+++ b/typelib/value.cc
@@ -2,164 +2,145 @@
 
 #include "typevisitor.hh"
 
-namespace Typelib
-{
-    class ValueVisitor::TypeDispatch : public TypeVisitor
-    {
-        friend class ValueVisitor;
+namespace Typelib {
+class ValueVisitor::TypeDispatch : public TypeVisitor {
+    friend class ValueVisitor;
 
-        // The dispatching stack
-        std::list<uint8_t*> m_stack;
+    // The dispatching stack
+    std::list<uint8_t *> m_stack;
 
-        // The ValueVisitor object
-        ValueVisitor& m_visitor;
-    
-        template<typename T8, typename T16, typename T32, typename T64>
-        bool integer_cast(uint8_t* value, Type const& t)
-        {
-            switch(t.getSize())
-            {
-                case 1: return m_visitor.visit_(*reinterpret_cast<T8*>(value));
-                case 2: return m_visitor.visit_(*reinterpret_cast<T16*>(value));
-                case 4: return m_visitor.visit_(*reinterpret_cast<T32*>(value));
-                case 8: return m_visitor.visit_(*reinterpret_cast<T64*>(value));
-                default:
-                         throw UnsupportedType(t, "unsupported integer size");
-            };
-        }
+    // The ValueVisitor object
+    ValueVisitor &m_visitor;
 
-    protected:
-        virtual bool visit_ (Numeric const& type)
-        { 
-            uint8_t* value(m_stack.back());
-            switch(type.getNumericCategory())
-            {
-                case Numeric::SInt:
-                    return integer_cast<int8_t, int16_t, int32_t, int64_t>(value, type);
-                case Numeric::UInt:
-                    return integer_cast<uint8_t, uint16_t, uint32_t, uint64_t>(value, type);
-                case Numeric::Float:
-                    switch(type.getSize())
-                    {
-                        case sizeof(float):  return m_visitor.visit_(*reinterpret_cast<float*>(value));
-                        case sizeof(double): return m_visitor.visit_(*reinterpret_cast<double*>(value));
-                    }
+    template <typename T8, typename T16, typename T32, typename T64>
+    bool integer_cast(uint8_t *value, Type const &t) {
+        switch (t.getSize()) {
+        case 1:
+            return m_visitor.visit_(*reinterpret_cast<T8 *>(value));
+        case 2:
+            return m_visitor.visit_(*reinterpret_cast<T16 *>(value));
+        case 4:
+            return m_visitor.visit_(*reinterpret_cast<T32 *>(value));
+        case 8:
+            return m_visitor.visit_(*reinterpret_cast<T64 *>(value));
+        default:
+            throw UnsupportedType(t, "unsupported integer size");
+        };
+    }
+
+  protected:
+    virtual bool visit_(Numeric const &type) {
+        uint8_t *value(m_stack.back());
+        switch (type.getNumericCategory()) {
+        case Numeric::SInt:
+            return integer_cast<int8_t, int16_t, int32_t, int64_t>(value, type);
+        case Numeric::UInt:
+            return integer_cast<uint8_t, uint16_t, uint32_t, uint64_t>(value,
+                                                                       type);
+        case Numeric::Float:
+            switch (type.getSize()) {
+            case sizeof(float):
+                return m_visitor.visit_(*reinterpret_cast<float *>(value));
+            case sizeof(double):
+                return m_visitor.visit_(*reinterpret_cast<double *>(value));
             }
-	    throw UnsupportedType(type, "unsupported numeric category");
         }
-
-        virtual bool visit_ (Enum const& type)
-        { 
-            Enum::integral_type& v = *reinterpret_cast<Enum::integral_type*>(m_stack.back());
-            return m_visitor.visit_(v, type);
-        }
-
-        virtual bool visit_ (Container const& type)
-        {
-            Value v(m_stack.back(), type);
-            return m_visitor.visit_(v, type);
-        }
-
-        virtual bool visit_ (Pointer const& type)
-        {
-            Value v(m_stack.back(), type);
-            m_stack.push_back( *reinterpret_cast<uint8_t**>(m_stack.back()) );
-            bool ret = m_visitor.visit_(v, type);
-            m_stack.pop_back();
-            return ret;
-        }
-        virtual bool visit_ (Array const& type)
-        {
-            Value v(m_stack.back(), type);
-            return m_visitor.visit_(v, type);
-        }
-
-        virtual bool visit_ (Compound const& type)
-        {
-            Value v(m_stack.back(), type);
-            return m_visitor.visit_(v, type);
-        }
-
-        virtual bool visit_ (OpaqueType const& type)
-        {
-            Value v(m_stack.back(), type);
-            return m_visitor.visit_(v, type);
-        }
-
-        virtual bool visit_ (Compound const& type, Field const& field)
-        {
-            m_stack.push_back( m_stack.back() + field.getOffset() );
-            bool ret = m_visitor.visit_(Value(m_stack.back(), field.getType()), type, field);
-            m_stack.pop_back();
-            return ret;
-        }
-
-    public:
-        TypeDispatch(ValueVisitor& visitor)
-            : m_visitor(visitor) { }
-
-        void apply(Value value)
-        {
-            m_stack.clear();
-            m_stack.push_back( reinterpret_cast<uint8_t*>(value.getData()));
-            TypeVisitor::apply(value.getType());
-	    m_stack.pop_back();
-        }
-
-    };
-
-    bool ValueVisitor::visit_(Value const& v, Pointer const& t)
-    { return m_dispatcher->TypeVisitor::visit_(t); }
-    bool ValueVisitor::visit_(Value const& v, Array const& a) 
-    {
-	uint8_t*  base = static_cast<uint8_t*>(v.getData());
-	m_dispatcher->m_stack.push_back(base);
-	uint8_t*& element = m_dispatcher->m_stack.back();
-
-	Type const& array_type(a.getIndirection());
-	for (size_t i = 0; i < a.getDimension(); ++i)
-	{
-	    element = base + array_type.getSize() * i;
-	    if (! m_dispatcher->TypeVisitor::visit_(array_type))
-		break;
-	}
-
-	m_dispatcher->m_stack.pop_back();
-	return true;
-    }
-    bool ValueVisitor::visit_(Value const& v, Container const& c)
-    { return c.visit(v.getData(), *this); }
-    bool ValueVisitor::visit_(Value const&, Compound const& c) 
-    { return m_dispatcher->TypeVisitor::visit_(c); }
-    bool ValueVisitor::visit_(Value const&, Compound const& c, Field const& f) 
-    { return m_dispatcher->TypeVisitor::visit_(c, f); }
-    bool ValueVisitor::visit_(Enum::integral_type&, Enum const& e) 
-    { return m_dispatcher->TypeVisitor::visit_(e); }
-    bool ValueVisitor::visit_(Value const& v, OpaqueType const& t)
-    { return true; }
-    void ValueVisitor::dispatch(Value v)
-    {
-        m_dispatcher->m_stack.push_back(reinterpret_cast<uint8_t*>(v.getData()));
-        m_dispatcher->TypeVisitor::visit_(v.getType());
-        m_dispatcher->m_stack.pop_back();
+        throw UnsupportedType(type, "unsupported numeric category");
     }
 
+    virtual bool visit_(Enum const &type) {
+        Enum::integral_type &v =
+            *reinterpret_cast<Enum::integral_type *>(m_stack.back());
+        return m_visitor.visit_(v, type);
+    }
+
+    virtual bool visit_(Container const &type) {
+        Value v(m_stack.back(), type);
+        return m_visitor.visit_(v, type);
+    }
+
+    virtual bool visit_(Pointer const &type) {
+        Value v(m_stack.back(), type);
+        m_stack.push_back(*reinterpret_cast<uint8_t **>(m_stack.back()));
+        bool ret = m_visitor.visit_(v, type);
+        m_stack.pop_back();
+        return ret;
+    }
+    virtual bool visit_(Array const &type) {
+        Value v(m_stack.back(), type);
+        return m_visitor.visit_(v, type);
+    }
+
+    virtual bool visit_(Compound const &type) {
+        Value v(m_stack.back(), type);
+        return m_visitor.visit_(v, type);
+    }
+
+    virtual bool visit_(OpaqueType const &type) {
+        Value v(m_stack.back(), type);
+        return m_visitor.visit_(v, type);
+    }
+
+    virtual bool visit_(Compound const &type, Field const &field) {
+        m_stack.push_back(m_stack.back() + field.getOffset());
+        bool ret = m_visitor.visit_(Value(m_stack.back(), field.getType()),
+                                    type, field);
+        m_stack.pop_back();
+        return ret;
+    }
+
+  public:
+    TypeDispatch(ValueVisitor &visitor) : m_visitor(visitor) {}
+
+    void apply(Value value) {
+        m_stack.clear();
+        m_stack.push_back(reinterpret_cast<uint8_t *>(value.getData()));
+        TypeVisitor::apply(value.getType());
+        m_stack.pop_back();
+    }
+};
+
+bool ValueVisitor::visit_(Value const &v, Pointer const &t) {
+    return m_dispatcher->TypeVisitor::visit_(t);
+}
+bool ValueVisitor::visit_(Value const &v, Array const &a) {
+    uint8_t *base = static_cast<uint8_t *>(v.getData());
+    m_dispatcher->m_stack.push_back(base);
+    uint8_t *&element = m_dispatcher->m_stack.back();
+
+    Type const &array_type(a.getIndirection());
+    for (size_t i = 0; i < a.getDimension(); ++i) {
+        element = base + array_type.getSize() * i;
+        if (!m_dispatcher->TypeVisitor::visit_(array_type))
+            break;
+    }
+
+    m_dispatcher->m_stack.pop_back();
+    return true;
+}
+bool ValueVisitor::visit_(Value const &v, Container const &c) {
+    return c.visit(v.getData(), *this);
+}
+bool ValueVisitor::visit_(Value const &, Compound const &c) {
+    return m_dispatcher->TypeVisitor::visit_(c);
+}
+bool ValueVisitor::visit_(Value const &, Compound const &c, Field const &f) {
+    return m_dispatcher->TypeVisitor::visit_(c, f);
+}
+bool ValueVisitor::visit_(Enum::integral_type &, Enum const &e) {
+    return m_dispatcher->TypeVisitor::visit_(e);
+}
+bool ValueVisitor::visit_(Value const &v, OpaqueType const &t) { return true; }
+void ValueVisitor::dispatch(Value v) {
+    m_dispatcher->m_stack.push_back(reinterpret_cast<uint8_t *>(v.getData()));
+    m_dispatcher->TypeVisitor::visit_(v.getType());
+    m_dispatcher->m_stack.pop_back();
+}
 }
 
-namespace Typelib
-{
-    ValueVisitor::ValueVisitor(bool defval)
-       : m_defval(defval), m_dispatcher(new TypeDispatch(*this))
-    {
-    }
-    ValueVisitor::~ValueVisitor()
-    {
-	delete m_dispatcher;
-    }
-    void ValueVisitor::apply(Value v)
-    {
-        m_dispatcher->apply(v);
-    }
-
+namespace Typelib {
+ValueVisitor::ValueVisitor(bool defval)
+    : m_defval(defval), m_dispatcher(new TypeDispatch(*this)) {}
+ValueVisitor::~ValueVisitor() { delete m_dispatcher; }
+void ValueVisitor::apply(Value v) { m_dispatcher->apply(v); }
 }
-

--- a/typelib/value.hh
+++ b/typelib/value.hh
@@ -6,145 +6,133 @@
 #include "registry.hh"
 #include <boost/ref.hpp>
 
-namespace Typelib
-{
-    /** A Value object is raw data given through a void* pointer typed
-     * by a Type object
-     *
-     * There are two basic operations on value object:
-     * <ul>
-     *   <li> Typelib::value_cast typesafe cast from Value to a C type
-     *   <li> Typelib::value_get_field     gets a Value object for a field in a Compound
-     * </ul>
-     */
-    class Value
-    {
-        void*       m_data;
-        boost::reference_wrapper<Type const> m_type;
-        
-    public:
-        Value()
-            : m_data(0), m_type(Registry::null()) {}
+namespace Typelib {
+/** A Value object is raw data given through a void* pointer typed
+ * by a Type object
+ *
+ * There are two basic operations on value object:
+ * <ul>
+ *   <li> Typelib::value_cast typesafe cast from Value to a C type
+ *   <li> Typelib::value_get_field     gets a Value object for a field in a
+ *Compound
+ * </ul>
+ */
+class Value {
+    void *m_data;
+    boost::reference_wrapper<Type const> m_type;
 
-        Value(void* data, Type const& type)
-            : m_data(data), m_type(type) {}
+  public:
+    Value() : m_data(0), m_type(Registry::null()) {}
 
-	/** The raw data pointer */
-        void* getData() const { return m_data; }
-	/** The data type */
-        Type const& getType() const { return m_type; }
+    Value(void *data, Type const &type) : m_data(data), m_type(type) {}
 
-        bool operator == (Value const& with) const
-        { return (m_data == with.m_data) && (m_type.get() == with.m_type.get()); }
-        bool operator != (Value const& with) const
-        { return (m_data != with.m_data) || (m_type.get() != with.m_type.get()); }
-    };
+    /** The raw data pointer */
+    void *getData() const { return m_data; }
+    /** The data type */
+    Type const &getType() const { return m_type; }
 
-    /** A visitor object that can be used to discover the type
-     * of a Value object */
-    class ValueVisitor
-    {
-        class TypeDispatch;
-        friend class TypeDispatch;
-        bool m_defval;
+    bool operator==(Value const &with) const {
+        return (m_data == with.m_data) && (m_type.get() == with.m_type.get());
+    }
+    bool operator!=(Value const &with) const {
+        return (m_data != with.m_data) || (m_type.get() != with.m_type.get());
+    }
+};
 
-        TypeDispatch* m_dispatcher;
+/** A visitor object that can be used to discover the type
+ * of a Value object */
+class ValueVisitor {
+    class TypeDispatch;
+    friend class TypeDispatch;
+    bool m_defval;
 
-    protected:
-        virtual bool visit_ (int8_t  &) { return m_defval; }
-        virtual bool visit_ (uint8_t &) { return m_defval; }
-        virtual bool visit_ (int16_t &) { return m_defval; }
-        virtual bool visit_ (uint16_t&) { return m_defval; }
-        virtual bool visit_ (int32_t &) { return m_defval; }
-        virtual bool visit_ (uint32_t&) { return m_defval; }
-        virtual bool visit_ (int64_t &) { return m_defval; }
-        virtual bool visit_ (uint64_t&) { return m_defval; }
-        virtual bool visit_ (float   &) { return m_defval; }
-        virtual bool visit_ (double  &) { return m_defval; }
+    TypeDispatch *m_dispatcher;
 
-        virtual bool visit_ (Value const& v, OpaqueType const& t);
-        virtual bool visit_ (Value const& v, Pointer const& t);
-        virtual bool visit_ (Value const& v, Array const& a);
-        virtual bool visit_ (Value const& v, Container const& a);
-        virtual bool visit_ (Value const& v, Compound const& c); 
-        virtual bool visit_ (Value const& v, Compound const& c, Field const& f);
-        virtual bool visit_ (Enum::integral_type& v, Enum const& e);
+  protected:
+    virtual bool visit_(int8_t &) { return m_defval; }
+    virtual bool visit_(uint8_t &) { return m_defval; }
+    virtual bool visit_(int16_t &) { return m_defval; }
+    virtual bool visit_(uint16_t &) { return m_defval; }
+    virtual bool visit_(int32_t &) { return m_defval; }
+    virtual bool visit_(uint32_t &) { return m_defval; }
+    virtual bool visit_(int64_t &) { return m_defval; }
+    virtual bool visit_(uint64_t &) { return m_defval; }
+    virtual bool visit_(float &) { return m_defval; }
+    virtual bool visit_(double &) { return m_defval; }
 
-    public:
-        ValueVisitor(bool defval = false);
-        virtual ~ValueVisitor();
+    virtual bool visit_(Value const &v, OpaqueType const &t);
+    virtual bool visit_(Value const &v, Pointer const &t);
+    virtual bool visit_(Value const &v, Array const &a);
+    virtual bool visit_(Value const &v, Container const &a);
+    virtual bool visit_(Value const &v, Compound const &c);
+    virtual bool visit_(Value const &v, Compound const &c, Field const &f);
+    virtual bool visit_(Enum::integral_type &v, Enum const &e);
 
-        /** This is for internal use only. To visit a Value object, use apply */
-        virtual void dispatch(Value v);
+  public:
+    ValueVisitor(bool defval = false);
+    virtual ~ValueVisitor();
 
-        void apply(Value v);
-    };
+    /** This is for internal use only. To visit a Value object, use apply */
+    virtual void dispatch(Value v);
 
-    /** Raised by value_cast when the type of a Value object
-     * is not compatible with the wanted C type */
-    class BadValueCast : public std::exception {};
+    void apply(Value v);
+};
 
-    /** Exception raised if a non existent field is required */
-    class FieldNotFound : public BadValueCast 
-    {
-    public:
-        ~FieldNotFound() throw() {}
-        std::string const name;
-        FieldNotFound(std::string const& name_)
-            : name(name_) {}
-    };
+/** Raised by value_cast when the type of a Value object
+ * is not compatible with the wanted C type */
+class BadValueCast : public std::exception {};
 
-    /** Gets the object describing a given field 
-     * Throws FieldNotFound if the field is not a field of the base type */
-    class FieldGetter : public ValueVisitor
-    {
-        std::string m_name;
-        Value m_field;
+/** Exception raised if a non existent field is required */
+class FieldNotFound : public BadValueCast {
+  public:
+    ~FieldNotFound() throw() {}
+    std::string const name;
+    FieldNotFound(std::string const &name_) : name(name_) {}
+};
 
-        using ValueVisitor::visit_;
+/** Gets the object describing a given field
+ * Throws FieldNotFound if the field is not a field of the base type */
+class FieldGetter : public ValueVisitor {
+    std::string m_name;
+    Value m_field;
 
-        bool visit_(Compound const& type) { return true; }
-        bool visit_(Value const& value, Compound const&, Field const& field)
-        {
-            if (field.getName() == m_name)
-            {
-                m_field = value;
-                return false;
-            }
-            return true;
+    using ValueVisitor::visit_;
+
+    bool visit_(Compound const &type) { return true; }
+    bool visit_(Value const &value, Compound const &, Field const &field) {
+        if (field.getName() == m_name) {
+            m_field = value;
+            return false;
         }
-        
-    public:
-        FieldGetter()
-            : ValueVisitor(true) {}
-        Value apply(Value v, std::string const& name)
-        {
-            m_name = name;
-            m_field = Value();
-            ValueVisitor::apply(v);
-            if (! m_field.getData())
-                throw FieldNotFound(name);
-            return m_field;
-        }
-        
-    };
-
-    /** Get the Value object for a named field in @c v 
-     * @throws FieldNotFound if @name is not a field of the base type */
-    inline Value value_get_field(Value v, std::string const& name)
-    {
-        FieldGetter getter;
-        return getter.apply(v, name);
+        return true;
     }
 
-    /** Get the Value object for a named field in @c v 
-     * @throws FieldNotFound if @name is not a field of the base type */
-    inline Value value_get_field(void* ptr, Type const& type, std::string const& name)
-    {
-        Value v(ptr, type);
-        return value_get_field(v, name);
+  public:
+    FieldGetter() : ValueVisitor(true) {}
+    Value apply(Value v, std::string const &name) {
+        m_name = name;
+        m_field = Value();
+        ValueVisitor::apply(v);
+        if (!m_field.getData())
+            throw FieldNotFound(name);
+        return m_field;
     }
+};
+
+/** Get the Value object for a named field in @c v
+ * @throws FieldNotFound if @name is not a field of the base type */
+inline Value value_get_field(Value v, std::string const &name) {
+    FieldGetter getter;
+    return getter.apply(v, name);
+}
+
+/** Get the Value object for a named field in @c v
+ * @throws FieldNotFound if @name is not a field of the base type */
+inline Value value_get_field(void *ptr, Type const &type,
+                             std::string const &name) {
+    Value v(ptr, type);
+    return value_get_field(v, name);
+}
 }
 
 #endif
-

--- a/typelib/value_cast.hh
+++ b/typelib/value_cast.hh
@@ -4,53 +4,46 @@
 #include "value.hh"
 #include "normalized_numerics.hh"
 
-namespace Typelib
-{
-    /** This visitor checks that a given Value object
-     * is of the C type T. It either returns a reference to the
-     * typed value or throws BadValueCast
-     */
-    template<typename T>
-    class CastingVisitor : public ValueVisitor
-    {
-        bool m_found;
-        T    m_value;
+namespace Typelib {
+/** This visitor checks that a given Value object
+ * is of the C type T. It either returns a reference to the
+ * typed value or throws BadValueCast
+ */
+template <typename T> class CastingVisitor : public ValueVisitor {
+    bool m_found;
+    T m_value;
 
-        bool visit_( typename normalized_numeric_type<T>::type& v)
-        {
-            m_value = v;
-            m_found = true;
-            return false;
-        }
-         
-    public:
-        CastingVisitor()
-            : ValueVisitor(false), m_found(false), m_value() {};
-        T& apply(Value v)
-        {
-            m_found = false;
-            ValueVisitor::apply(v);
-            if (!m_found)
-                throw BadValueCast();
-
-            return m_value;
-        }
-    };
-
-    /** Casts a Value object to a given simple type T 
-     * @throws BadValueCast */
-    template<typename T>
-    T& value_cast(Value v)
-    {
-        CastingVisitor<T> caster;
-        return caster.apply(v);
+    bool visit_(typename normalized_numeric_type<T>::type &v) {
+        m_value = v;
+        m_found = true;
+        return false;
     }
 
-    /** Casts a pointer to a given simple type T using \c type as the type for \c *ptr 
-     * @throws BadValueCast */
-    template<typename T>
-    T& value_cast(void* ptr, Type const& type)
-    { return value_cast<T>(Value(ptr, type)); }
+  public:
+    CastingVisitor() : ValueVisitor(false), m_found(false), m_value(){};
+    T &apply(Value v) {
+        m_found = false;
+        ValueVisitor::apply(v);
+        if (!m_found)
+            throw BadValueCast();
+
+        return m_value;
+    }
+};
+
+/** Casts a Value object to a given simple type T
+ * @throws BadValueCast */
+template <typename T> T &value_cast(Value v) {
+    CastingVisitor<T> caster;
+    return caster.apply(v);
+}
+
+/** Casts a pointer to a given simple type T using \c type as the type for \c
+ * *ptr
+ * @throws BadValueCast */
+template <typename T> T &value_cast(void *ptr, Type const &type) {
+    return value_cast<T>(Value(ptr, type));
+}
 }
 
 #endif

--- a/typelib/value_ops.cc
+++ b/typelib/value_ops.cc
@@ -10,273 +10,249 @@ using namespace Typelib;
 using namespace boost;
 using namespace std;
 
-void Typelib::display(std::ostream& io, MemoryLayout::const_iterator const begin, MemoryLayout::const_iterator const end)
-{
+void Typelib::display(std::ostream &io,
+                      MemoryLayout::const_iterator const begin,
+                      MemoryLayout::const_iterator const end) {
     io << "displaying memory layout of size " << end - begin << "\n";
-    for (MemoryLayout::const_iterator it = begin; it != end; ++it)
-    {
-        switch(*it)
-        {
-            case MemLayout::FLAG_MEMCPY:
-            {
-                size_t size = *(++it);
-                io << "MEMCPY " << size << "\n";
-                break;
-            }
-            case MemLayout::FLAG_ARRAY:
-            {
-                size_t element_count = *(++it);
-                io << "ARRAY " << element_count << "\n";
-                break;
-            }
-            case MemLayout::FLAG_SKIP:
-            {
-                size_t size  = *(++it);
-                io << "SKIP " << size << "\n";
-                break;
-            }
-            case MemLayout::FLAG_CONTAINER:
-            {
-                Container const* type = reinterpret_cast<Container const*>(*(++it));
-                io << "CONTAINER " << type->getName() << "\n";
-                break;
-            }
-            case MemLayout::FLAG_END:
-            {
-                io << "END\n";
-                break;
-            }
-            default:
-            {
-                io << "in display(): unrecognized marshalling bytecode " << *it << " at " << (it - begin) << "\n";
-                throw UnknownLayoutBytecode();
-            }
+    for (MemoryLayout::const_iterator it = begin; it != end; ++it) {
+        switch (*it) {
+        case MemLayout::FLAG_MEMCPY: {
+            size_t size = *(++it);
+            io << "MEMCPY " << size << "\n";
+            break;
+        }
+        case MemLayout::FLAG_ARRAY: {
+            size_t element_count = *(++it);
+            io << "ARRAY " << element_count << "\n";
+            break;
+        }
+        case MemLayout::FLAG_SKIP: {
+            size_t size = *(++it);
+            io << "SKIP " << size << "\n";
+            break;
+        }
+        case MemLayout::FLAG_CONTAINER: {
+            Container const *type =
+                reinterpret_cast<Container const *>(*(++it));
+            io << "CONTAINER " << type->getName() << "\n";
+            break;
+        }
+        case MemLayout::FLAG_END: {
+            io << "END\n";
+            break;
+        }
+        default: {
+            io << "in display(): unrecognized marshalling bytecode " << *it
+               << " at " << (it - begin) << "\n";
+            throw UnknownLayoutBytecode();
+        }
         }
     }
-
 }
 
-
-tuple<size_t, MemoryLayout::const_iterator> ValueOps::dump(
-        boost::uint8_t const* data, size_t in_offset,
-        OutputStream& stream, MemoryLayout::const_iterator const begin, MemoryLayout::const_iterator const end)
-{
+tuple<size_t, MemoryLayout::const_iterator>
+ValueOps::dump(boost::uint8_t const *data, size_t in_offset,
+               OutputStream &stream, MemoryLayout::const_iterator const begin,
+               MemoryLayout::const_iterator const end) {
     MemoryLayout::const_iterator it;
-    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it)
-    {
-        switch(*it)
-        {
-            case MemLayout::FLAG_MEMCPY:
-            {
-                size_t size = *(++it);
-                stream.write(data + in_offset, size);
-                in_offset += size;
-                break;
+    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it) {
+        switch (*it) {
+        case MemLayout::FLAG_MEMCPY: {
+            size_t size = *(++it);
+            stream.write(data + in_offset, size);
+            in_offset += size;
+            break;
+        }
+        case MemLayout::FLAG_ARRAY: {
+            size_t element_count = *(++it);
+            MemoryLayout::const_iterator element_it = ++it;
+            if (element_count == 0)
+                it = MemLayout::skip_block(element_it, end);
+            else {
+                for (size_t i = 0; i < element_count; ++i)
+                    tie(in_offset, it) =
+                        dump(data, in_offset, stream, element_it, end);
             }
-            case MemLayout::FLAG_ARRAY:
-            {
-                size_t element_count = *(++it);
-                MemoryLayout::const_iterator element_it = ++it;
-                if (element_count == 0)
-                    it = MemLayout::skip_block(element_it, end);
-                else
-                {
-                    for (size_t i = 0; i < element_count; ++i)
-                        tie(in_offset, it) = dump(data, in_offset, stream, element_it, end);
-                }
 
-                if (it == end || *it != MemLayout::FLAG_END)
-                    throw std::runtime_error("error in the marshalling bytecode: array does not end with FLAG_END");
+            if (it == end || *it != MemLayout::FLAG_END)
+                throw std::runtime_error("error in the marshalling bytecode: "
+                                         "array does not end with FLAG_END");
 
-                break;
-            }
-            case MemLayout::FLAG_SKIP:
-            {
-                size_t size  = *(++it);
-                in_offset += size;
-                break;
-            }
-            case MemLayout::FLAG_CONTAINER:
-            {
-                Container const* type = reinterpret_cast<Container const*>(*(++it));
-                // First, dump the element count into the stream
-                void const* container_ptr  = data + in_offset;
-                in_offset += type->getSize();
+            break;
+        }
+        case MemLayout::FLAG_SKIP: {
+            size_t size = *(++it);
+            in_offset += size;
+            break;
+        }
+        case MemLayout::FLAG_CONTAINER: {
+            Container const *type =
+                reinterpret_cast<Container const *>(*(++it));
+            // First, dump the element count into the stream
+            void const *container_ptr = data + in_offset;
+            in_offset += type->getSize();
 
-                boost::uint64_t element_count = type->getElementCount(container_ptr);
-                stream.write(reinterpret_cast< boost::uint8_t* >(&element_count), sizeof(element_count));
+            boost::uint64_t element_count =
+                type->getElementCount(container_ptr);
+            stream.write(reinterpret_cast<boost::uint8_t *>(&element_count),
+                         sizeof(element_count));
 
-                if (element_count == 0)
-                    it = MemLayout::skip_block(++it, end);
-                else
-                    it = type->dump(container_ptr, element_count, stream, ++it, end);
+            if (element_count == 0)
+                it = MemLayout::skip_block(++it, end);
+            else
+                it =
+                    type->dump(container_ptr, element_count, stream, ++it, end);
 
-                if (it == end || *it != MemLayout::FLAG_END)
-                    throw std::runtime_error("error in bytecode while dumping: container does not end with FLAG_END");
-                break;
-            }
-            default:
-                throw UnknownLayoutBytecode();
+            if (it == end || *it != MemLayout::FLAG_END)
+                throw std::runtime_error("error in bytecode while dumping: "
+                                         "container does not end with "
+                                         "FLAG_END");
+            break;
+        }
+        default:
+            throw UnknownLayoutBytecode();
         }
     }
 
     return make_tuple(in_offset, it);
 }
 
-tuple<size_t, MemoryLayout::const_iterator> ValueOps::load(
-        boost::uint8_t* data, size_t out_offset,
-        InputStream& stream, MemoryLayout::const_iterator const begin, MemoryLayout::const_iterator const end)
-{
+tuple<size_t, MemoryLayout::const_iterator>
+ValueOps::load(boost::uint8_t *data, size_t out_offset, InputStream &stream,
+               MemoryLayout::const_iterator const begin,
+               MemoryLayout::const_iterator const end) {
     MemoryLayout::const_iterator it;
-    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it)
-    {
-        switch(*it)
-        {
-            case MemLayout::FLAG_MEMCPY:
-            {
-                size_t size = *(++it);
-                stream.read(data + out_offset, size);
-                out_offset += size;
-                break;
+    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it) {
+        switch (*it) {
+        case MemLayout::FLAG_MEMCPY: {
+            size_t size = *(++it);
+            stream.read(data + out_offset, size);
+            out_offset += size;
+            break;
+        }
+        case MemLayout::FLAG_ARRAY: {
+            size_t element_count = *(++it);
+            MemoryLayout::const_iterator element_it = ++it;
+
+            if (element_count == 0)
+                it = MemLayout::skip_block(element_it, end);
+            else {
+                for (size_t i = 0; i < element_count; ++i)
+                    tie(out_offset, it) =
+                        load(data, out_offset, stream, element_it, end);
             }
-            case MemLayout::FLAG_ARRAY:
-            {
-                size_t element_count = *(++it);
-                MemoryLayout::const_iterator element_it = ++it;
 
-                if (element_count == 0)
-                    it = MemLayout::skip_block(element_it, end);
-                else
-                {
-                    for (size_t i = 0; i < element_count; ++i)
-                        tie(out_offset, it) =
-                            load(data, out_offset, stream, element_it, end);
-                }
+            if (*it != MemLayout::FLAG_END)
+                throw std::runtime_error("bytecode error in load(): array does "
+                                         "not end with FLAG_END");
 
-                if (*it != MemLayout::FLAG_END)
-                    throw std::runtime_error("bytecode error in load(): array does not end with FLAG_END");
+            break;
+        }
+        case MemLayout::FLAG_SKIP: {
+            size_t size = *(++it);
+            out_offset += size;
+            break;
+        }
+        case MemLayout::FLAG_CONTAINER: {
+            Container const *type =
+                reinterpret_cast<Container const *>(*(++it));
+            void *container_ptr = data + out_offset;
+            out_offset += type->getSize();
 
-                break;
+            boost::uint64_t element_count;
+            stream.read(reinterpret_cast<boost::uint8_t *>(&element_count),
+                        sizeof(boost::uint64_t));
+            if (element_count == 0)
+                it = MemLayout::skip_block(++it, end);
+            else {
+                it =
+                    type->load(container_ptr, element_count, stream, ++it, end);
             }
-            case MemLayout::FLAG_SKIP:
-            {
-                size_t size  = *(++it);
-                out_offset += size;
-                break;
-            }
-            case MemLayout::FLAG_CONTAINER:
-            {
-                Container const* type = reinterpret_cast<Container const*>(*(++it));
-                void* container_ptr  = data + out_offset;
-                out_offset += type->getSize();
 
-                boost::uint64_t element_count;
-                stream.read(reinterpret_cast< boost::uint8_t* >(&element_count), sizeof( boost::uint64_t ));
-                if (element_count == 0)
-                    it = MemLayout::skip_block(++it, end);
-                else
-                {
-                    it = type->load(container_ptr, element_count, stream, ++it, end);
-                }
-
-                if (it == end || *it != MemLayout::FLAG_END)
-                    throw std::runtime_error("bytecode error in load(): container does not end with FLAG_END");
-                break;
-            }
-            default:
-                throw UnknownLayoutBytecode();
+            if (it == end || *it != MemLayout::FLAG_END)
+                throw std::runtime_error("bytecode error in load(): container "
+                                         "does not end with FLAG_END");
+            break;
+        }
+        default:
+            throw UnknownLayoutBytecode();
         }
     }
 
     return make_tuple(out_offset, it);
 }
 
-
-void Typelib::init(Value v)
-{
+void Typelib::init(Value v) {
     MemoryLayout ops = layout_of(v.getType(), true);
     init(v, ops);
 }
 
-void Typelib::init(Value v, MemoryLayout const& ops)
-{
-    boost::uint8_t* buffer = reinterpret_cast< boost::uint8_t* >(v.getData());
+void Typelib::init(Value v, MemoryLayout const &ops) {
+    boost::uint8_t *buffer = reinterpret_cast<boost::uint8_t *>(v.getData());
     init(buffer, ops);
 }
 
-void Typelib::init(boost::uint8_t* data, MemoryLayout const& ops)
-{
+void Typelib::init(boost::uint8_t *data, MemoryLayout const &ops) {
     ValueOps::init(data, ops.begin(), ops.end());
 }
 
-void Typelib::zero(Value v)
-{
+void Typelib::zero(Value v) {
     MemoryLayout ops = layout_of(v.getType(), true);
     zero(v, ops);
 }
 
-void Typelib::zero(Value v, MemoryLayout const& ops)
-{
-    boost::uint8_t* buffer = reinterpret_cast< boost::uint8_t* >(v.getData());
+void Typelib::zero(Value v, MemoryLayout const &ops) {
+    boost::uint8_t *buffer = reinterpret_cast<boost::uint8_t *>(v.getData());
     zero(buffer, ops);
 }
 
-void Typelib::zero(boost::uint8_t* data, MemoryLayout const& ops)
-{
+void Typelib::zero(boost::uint8_t *data, MemoryLayout const &ops) {
     ValueOps::zero(data, ops.begin(), ops.end());
 }
 
-void Typelib::destroy(Value v)
-{
-    boost::uint8_t* buffer = reinterpret_cast< boost::uint8_t* >(v.getData());
+void Typelib::destroy(Value v) {
+    boost::uint8_t *buffer = reinterpret_cast<boost::uint8_t *>(v.getData());
     MemoryLayout ops = layout_of(v.getType(), true);
     destroy(buffer, ops);
 }
 
-void Typelib::destroy(Value v, MemoryLayout const& ops)
-{
-    destroy(reinterpret_cast< boost::uint8_t* >(v.getData()), ops);
+void Typelib::destroy(Value v, MemoryLayout const &ops) {
+    destroy(reinterpret_cast<boost::uint8_t *>(v.getData()), ops);
 }
 
-void Typelib::destroy(boost::uint8_t* data, MemoryLayout const& ops)
-{
+void Typelib::destroy(boost::uint8_t *data, MemoryLayout const &ops) {
     ValueOps::destroy(data, ops.begin(), ops.end());
 }
 
-void Typelib::copy(Value dst, Value src)
-{
+void Typelib::copy(Value dst, Value src) {
     if (dst.getType() != src.getType())
         throw std::runtime_error("requested copy with incompatible types");
 
     copy(dst.getData(), src.getData(), src.getType());
 }
 
-void Typelib::copy(void* dst, void* src, Type const& type)
-{
-    if (dst == src)
-    {
+void Typelib::copy(void *dst, void *src, Type const &type) {
+    if (dst == src) {
         // same object, nothing to do
         return;
     }
 
-    boost::uint8_t* out_buffer = reinterpret_cast< boost::uint8_t* >(dst);
-    boost::uint8_t* in_buffer  = reinterpret_cast< boost::uint8_t* >(src);
+    boost::uint8_t *out_buffer = reinterpret_cast<boost::uint8_t *>(dst);
+    boost::uint8_t *in_buffer = reinterpret_cast<boost::uint8_t *>(src);
     MemoryLayout ops = layout_of(type);
     ValueOps::copy(out_buffer, in_buffer, ops.begin(), ops.end());
 }
 
-bool Typelib::compare(Value dst, Value src)
-{
+bool Typelib::compare(Value dst, Value src) {
     if (!dst.getType().canCastTo(src.getType()))
         return false;
 
     return compare(dst.getData(), src.getData(), dst.getType());
 }
 
-bool Typelib::compare(void* dst, void* src, Type const& type)
-{
-    boost::uint8_t* out_buffer = reinterpret_cast< boost::uint8_t* >(dst);
-    boost::uint8_t* in_buffer  = reinterpret_cast< boost::uint8_t* >(src);
+bool Typelib::compare(void *dst, void *src, Type const &type) {
+    boost::uint8_t *out_buffer = reinterpret_cast<boost::uint8_t *>(dst);
+    boost::uint8_t *in_buffer = reinterpret_cast<boost::uint8_t *>(src);
 
     MemoryLayout ret;
     MemLayout::Visitor visitor(ret);
@@ -288,270 +264,257 @@ bool Typelib::compare(void* dst, void* src, Type const& type)
     return is_equal;
 }
 
-tuple< boost::uint8_t*, MemoryLayout::const_iterator>
-    Typelib::ValueOps::zero(boost::uint8_t* buffer,
-        MemoryLayout::const_iterator begin,
-        MemoryLayout::const_iterator end)
-{
+tuple<boost::uint8_t *, MemoryLayout::const_iterator>
+Typelib::ValueOps::zero(boost::uint8_t *buffer,
+                        MemoryLayout::const_iterator begin,
+                        MemoryLayout::const_iterator end) {
 
     MemoryLayout::const_iterator it;
-    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it)
-    {
-        switch(*it)
-        {
-            case MemLayout::FLAG_MEMCPY:
-            case MemLayout::FLAG_SKIP:
-            {
-                size_t size = *(++it);
-                memset(buffer, 0, size);
-                buffer += size;
-                break;
-            }
+    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it) {
+        switch (*it) {
+        case MemLayout::FLAG_MEMCPY:
+        case MemLayout::FLAG_SKIP: {
+            size_t size = *(++it);
+            memset(buffer, 0, size);
+            buffer += size;
+            break;
+        }
 
-            case MemLayout::FLAG_ARRAY:
-            {
-                size_t element_count = *(++it);
-                MemoryLayout::const_iterator element_it = ++it;
-                for (size_t i = 0; i < element_count; ++i)
-                    tie(buffer, it) = zero(buffer, element_it, end);
+        case MemLayout::FLAG_ARRAY: {
+            size_t element_count = *(++it);
+            MemoryLayout::const_iterator element_it = ++it;
+            for (size_t i = 0; i < element_count; ++i)
+                tie(buffer, it) = zero(buffer, element_it, end);
 
-                if (it == end || *it != MemLayout::FLAG_END)
-                    throw std::runtime_error("error in the marshalling bytecode at array end");
-                break;
-            }
+            if (it == end || *it != MemLayout::FLAG_END)
+                throw std::runtime_error(
+                    "error in the marshalling bytecode at array end");
+            break;
+        }
 
-            case MemLayout::FLAG_CONTAINER:
-            {
-                Container const* type = reinterpret_cast<Container const*>(*(++it));
-                type->clear(buffer);
-                it = MemLayout::skip_block(++it, end);
-                buffer += type->getSize();
-                break;
-            }
+        case MemLayout::FLAG_CONTAINER: {
+            Container const *type =
+                reinterpret_cast<Container const *>(*(++it));
+            type->clear(buffer);
+            it = MemLayout::skip_block(++it, end);
+            buffer += type->getSize();
+            break;
+        }
 
-            default:
-                throw std::runtime_error("in zero(): unrecognized marshalling bytecode " + boost::lexical_cast<std::string>(*it));
+        default:
+            throw std::runtime_error(
+                "in zero(): unrecognized marshalling bytecode " +
+                boost::lexical_cast<std::string>(*it));
         }
     }
 
     return make_tuple(buffer, it);
 }
-tuple< boost::uint8_t*, MemoryLayout::const_iterator>
-    Typelib::ValueOps::init(uint8_t* buffer,
-        MemoryLayout::const_iterator begin,
-        MemoryLayout::const_iterator end)
-{
+tuple<boost::uint8_t *, MemoryLayout::const_iterator>
+Typelib::ValueOps::init(uint8_t *buffer, MemoryLayout::const_iterator begin,
+                        MemoryLayout::const_iterator end) {
 
     MemoryLayout::const_iterator it;
-    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it)
-    {
-        switch(*it)
-        {
-            case MemLayout::FLAG_MEMCPY:
-            case MemLayout::FLAG_SKIP:
-            {
-                buffer += *(++it);
-                break;
-            }
-
-            case MemLayout::FLAG_ARRAY:
-            {
-                size_t element_count = *(++it);
-                MemoryLayout::const_iterator element_it = ++it;
-                for (size_t i = 0; i < element_count; ++i)
-                    tie(buffer, it) = init(buffer, element_it, end);
-
-                if (it == end || *it != MemLayout::FLAG_END)
-                    throw std::runtime_error("error in the marshalling bytecode at array end");
-                break;
-            }
-
-            case MemLayout::FLAG_CONTAINER:
-            {
-                Container const* type = reinterpret_cast<Container const*>(*(++it));
-                type->init(buffer);
-                it = MemLayout::skip_block(++it, end);
-                buffer += type->getSize();
-                break;
-            }
-
-            default:
-                throw std::runtime_error("in init(): unrecognized marshalling bytecode " + boost::lexical_cast<std::string>(*it));
+    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it) {
+        switch (*it) {
+        case MemLayout::FLAG_MEMCPY:
+        case MemLayout::FLAG_SKIP: {
+            buffer += *(++it);
+            break;
         }
-    }
 
-    return make_tuple(buffer, it);
-}
+        case MemLayout::FLAG_ARRAY: {
+            size_t element_count = *(++it);
+            MemoryLayout::const_iterator element_it = ++it;
+            for (size_t i = 0; i < element_count; ++i)
+                tie(buffer, it) = init(buffer, element_it, end);
 
-tuple< boost::uint8_t*, MemoryLayout::const_iterator>
-    Typelib::ValueOps::destroy(boost::uint8_t* buffer,
-        MemoryLayout::const_iterator begin,
-        MemoryLayout::const_iterator end)
-{
-    MemoryLayout::const_iterator it;
-    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it)
-    {
-        switch(*it)
-        {
-            case MemLayout::FLAG_MEMCPY:
-            case MemLayout::FLAG_SKIP:
-            {
-                buffer += *(++it);
-                break;
-            }
+            if (it == end || *it != MemLayout::FLAG_END)
+                throw std::runtime_error(
+                    "error in the marshalling bytecode at array end");
+            break;
+        }
 
-            case MemLayout::FLAG_ARRAY:
-            {
-                size_t element_count = *(++it);
-                MemoryLayout::const_iterator element_it = ++it;
-                for (size_t i = 0; i < element_count; ++i)
-                    tie(buffer, it) = destroy(buffer, element_it, end);
+        case MemLayout::FLAG_CONTAINER: {
+            Container const *type =
+                reinterpret_cast<Container const *>(*(++it));
+            type->init(buffer);
+            it = MemLayout::skip_block(++it, end);
+            buffer += type->getSize();
+            break;
+        }
 
-                if (it == end || *it != MemLayout::FLAG_END)
-                    throw std::runtime_error("error in the marshalling bytecode at array end");
-                break;
-            }
-
-            case MemLayout::FLAG_CONTAINER:
-            {
-                Container const* type = reinterpret_cast<Container const*>(*(++it));
-                type->destroy(buffer);
-                it = MemLayout::skip_block(it, end);
-                buffer += type->getSize();
-                break;
-            }
-
-            default:
-                throw std::runtime_error("in destroy(): unrecognized marshalling bytecode " + boost::lexical_cast<std::string>(*it));
+        default:
+            throw std::runtime_error(
+                "in init(): unrecognized marshalling bytecode " +
+                boost::lexical_cast<std::string>(*it));
         }
     }
 
     return make_tuple(buffer, it);
 }
 
-tuple< boost::uint8_t*, boost::uint8_t*, MemoryLayout::const_iterator>
-    Typelib::ValueOps::copy(boost::uint8_t* out_buffer, boost::uint8_t* in_buffer,
-        MemoryLayout::const_iterator begin,
-        MemoryLayout::const_iterator end)
-{
+tuple<boost::uint8_t *, MemoryLayout::const_iterator>
+Typelib::ValueOps::destroy(boost::uint8_t *buffer,
+                           MemoryLayout::const_iterator begin,
+                           MemoryLayout::const_iterator end) {
+    MemoryLayout::const_iterator it;
+    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it) {
+        switch (*it) {
+        case MemLayout::FLAG_MEMCPY:
+        case MemLayout::FLAG_SKIP: {
+            buffer += *(++it);
+            break;
+        }
+
+        case MemLayout::FLAG_ARRAY: {
+            size_t element_count = *(++it);
+            MemoryLayout::const_iterator element_it = ++it;
+            for (size_t i = 0; i < element_count; ++i)
+                tie(buffer, it) = destroy(buffer, element_it, end);
+
+            if (it == end || *it != MemLayout::FLAG_END)
+                throw std::runtime_error(
+                    "error in the marshalling bytecode at array end");
+            break;
+        }
+
+        case MemLayout::FLAG_CONTAINER: {
+            Container const *type =
+                reinterpret_cast<Container const *>(*(++it));
+            type->destroy(buffer);
+            it = MemLayout::skip_block(it, end);
+            buffer += type->getSize();
+            break;
+        }
+
+        default:
+            throw std::runtime_error(
+                "in destroy(): unrecognized marshalling bytecode " +
+                boost::lexical_cast<std::string>(*it));
+        }
+    }
+
+    return make_tuple(buffer, it);
+}
+
+tuple<boost::uint8_t *, boost::uint8_t *, MemoryLayout::const_iterator>
+Typelib::ValueOps::copy(boost::uint8_t *out_buffer, boost::uint8_t *in_buffer,
+                        MemoryLayout::const_iterator begin,
+                        MemoryLayout::const_iterator end) {
 
     MemoryLayout::const_iterator it;
-    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it)
-    {
-        switch(*it)
-        {
-            case MemLayout::FLAG_MEMCPY:
-            {
-                size_t size = *(++it);
-                memcpy(out_buffer, in_buffer, size);
-                out_buffer += size;
-                in_buffer  += size;
-                break;
-            }
-            case MemLayout::FLAG_SKIP:
-            {
-                size_t size = *(++it);
-                out_buffer += size;
-                in_buffer  += size;
-                break;
-            }
-            case MemLayout::FLAG_ARRAY:
-            {
-                size_t element_count = *(++it);
-                MemoryLayout::const_iterator element_it = ++it;
-                for (size_t i = 0; i < element_count; ++i)
-                    tie(out_buffer, in_buffer, it) =
-                        copy(out_buffer, in_buffer, element_it, end);
+    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it) {
+        switch (*it) {
+        case MemLayout::FLAG_MEMCPY: {
+            size_t size = *(++it);
+            memcpy(out_buffer, in_buffer, size);
+            out_buffer += size;
+            in_buffer += size;
+            break;
+        }
+        case MemLayout::FLAG_SKIP: {
+            size_t size = *(++it);
+            out_buffer += size;
+            in_buffer += size;
+            break;
+        }
+        case MemLayout::FLAG_ARRAY: {
+            size_t element_count = *(++it);
+            MemoryLayout::const_iterator element_it = ++it;
+            for (size_t i = 0; i < element_count; ++i)
+                tie(out_buffer, in_buffer, it) =
+                    copy(out_buffer, in_buffer, element_it, end);
 
-                if (it == end || *it != MemLayout::FLAG_END)
-                    throw std::runtime_error("error in the marshalling bytecode at array end");
-                break;
-            }
-            case MemLayout::FLAG_CONTAINER:
-            {
-                Container const* type = reinterpret_cast<Container const*>(*(++it));
-                type->copy(out_buffer, in_buffer);
-                it = MemLayout::skip_block(it, end);
-                out_buffer += type->getSize();
-                in_buffer  += type->getSize();
-                break;
-            }
-            default:
-                throw std::runtime_error("in copy(): unrecognized marshalling bytecode " + boost::lexical_cast<std::string>(*it));
+            if (it == end || *it != MemLayout::FLAG_END)
+                throw std::runtime_error(
+                    "error in the marshalling bytecode at array end");
+            break;
+        }
+        case MemLayout::FLAG_CONTAINER: {
+            Container const *type =
+                reinterpret_cast<Container const *>(*(++it));
+            type->copy(out_buffer, in_buffer);
+            it = MemLayout::skip_block(it, end);
+            out_buffer += type->getSize();
+            in_buffer += type->getSize();
+            break;
+        }
+        default:
+            throw std::runtime_error(
+                "in copy(): unrecognized marshalling bytecode " +
+                boost::lexical_cast<std::string>(*it));
         }
     }
 
     return make_tuple(out_buffer, in_buffer, it);
 }
 
-tuple<bool, boost::uint8_t*, boost::uint8_t*, MemoryLayout::const_iterator>
-    Typelib::ValueOps::compare(boost::uint8_t* out_buffer, boost::uint8_t* in_buffer,
-        MemoryLayout::const_iterator begin,
-        MemoryLayout::const_iterator end)
-{
+tuple<bool, boost::uint8_t *, boost::uint8_t *, MemoryLayout::const_iterator>
+Typelib::ValueOps::compare(boost::uint8_t *out_buffer,
+                           boost::uint8_t *in_buffer,
+                           MemoryLayout::const_iterator begin,
+                           MemoryLayout::const_iterator end) {
 
     MemoryLayout::const_iterator it;
-    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it)
-    {
-        switch(*it)
-        {
-            case MemLayout::FLAG_MEMCPY:
-            {
-                size_t size = *(++it);
-                if (memcmp(out_buffer, in_buffer, size))
-                    return make_tuple(false, (boost::uint8_t*)0, (boost::uint8_t*)0, end);
+    for (it = begin; it != end && *it != MemLayout::FLAG_END; ++it) {
+        switch (*it) {
+        case MemLayout::FLAG_MEMCPY: {
+            size_t size = *(++it);
+            if (memcmp(out_buffer, in_buffer, size))
+                return make_tuple(false, (boost::uint8_t *)0,
+                                  (boost::uint8_t *)0, end);
 
-                out_buffer += size;
-                in_buffer  += size;
-                break;
+            out_buffer += size;
+            in_buffer += size;
+            break;
+        }
+        case MemLayout::FLAG_SKIP: {
+            size_t size = *(++it);
+            out_buffer += size;
+            in_buffer += size;
+            break;
+        }
+        case MemLayout::FLAG_ARRAY: {
+            size_t element_count = *(++it);
+            MemoryLayout::const_iterator element_it = ++it;
+            for (size_t i = 0; i < element_count; ++i) {
+                bool is_equal;
+                tie(is_equal, out_buffer, in_buffer, it) =
+                    compare(out_buffer, in_buffer, element_it, end);
+                if (!is_equal)
+                    return make_tuple(false, (boost::uint8_t *)0,
+                                      (boost::uint8_t *)0, end);
             }
-            case MemLayout::FLAG_SKIP:
-            {
-                size_t size = *(++it);
-                out_buffer += size;
-                in_buffer  += size;
-                break;
-            }
-            case MemLayout::FLAG_ARRAY:
-            {
-                size_t element_count = *(++it);
-                MemoryLayout::const_iterator element_it = ++it;
-                for (size_t i = 0; i < element_count; ++i)
-                {
-                    bool is_equal;
-                    tie(is_equal, out_buffer, in_buffer, it) =
-                        compare(out_buffer, in_buffer, element_it, end);
-                    if (!is_equal)
-                        return make_tuple(false, (boost::uint8_t*)0, (boost::uint8_t*)0, end);
-                }
 
-                if (it == end || *it != MemLayout::FLAG_END)
-                    throw std::runtime_error("error in the marshalling bytecode at array end");
-                break;
-            }
-            case MemLayout::FLAG_CONTAINER:
-            {
-                Container const* type = reinterpret_cast<Container const*>(*(++it));
-                if (!type->compare(out_buffer, in_buffer))
-                    return make_tuple(false, (boost::uint8_t*)0, (boost::uint8_t*)0, end);
+            if (it == end || *it != MemLayout::FLAG_END)
+                throw std::runtime_error(
+                    "error in the marshalling bytecode at array end");
+            break;
+        }
+        case MemLayout::FLAG_CONTAINER: {
+            Container const *type =
+                reinterpret_cast<Container const *>(*(++it));
+            if (!type->compare(out_buffer, in_buffer))
+                return make_tuple(false, (boost::uint8_t *)0,
+                                  (boost::uint8_t *)0, end);
 
-                it = MemLayout::skip_block(it, end);
-                out_buffer += type->getSize();
-                in_buffer  += type->getSize();
-                break;
-            }
-            default:
-                throw std::runtime_error("in compare(): unrecognized marshalling bytecode " + boost::lexical_cast<std::string>(*it));
+            it = MemLayout::skip_block(it, end);
+            out_buffer += type->getSize();
+            in_buffer += type->getSize();
+            break;
+        }
+        default:
+            throw std::runtime_error(
+                "in compare(): unrecognized marshalling bytecode " +
+                boost::lexical_cast<std::string>(*it));
         }
     }
     return make_tuple(true, out_buffer, in_buffer, it);
 }
 
-
-
-std::vector< boost::uint8_t > Typelib::dump(Value v)
-{
-    std::vector< boost::uint8_t > buffer;
+std::vector<boost::uint8_t> Typelib::dump(Value v) {
+    std::vector<boost::uint8_t> buffer;
     dump(v, buffer);
     return buffer;
 }
@@ -559,30 +522,27 @@ std::vector< boost::uint8_t > Typelib::dump(Value v)
 /*--------------------------------------------------
  * Dump support to std::vector< boost::uint8_t >
  */
-struct VectorOutputStream : public OutputStream
-{
-    std::vector< boost::uint8_t >& buffer;
-    VectorOutputStream(std::vector< boost::uint8_t >& buffer)
-        : buffer(buffer) {}
+struct VectorOutputStream : public OutputStream {
+    std::vector<boost::uint8_t> &buffer;
+    VectorOutputStream(std::vector<boost::uint8_t> &buffer) : buffer(buffer) {}
 
-    void write(boost::uint8_t const* data, size_t size)
-    {
-        size_t out_index = buffer.size(); buffer.resize(out_index + size);
+    void write(boost::uint8_t const *data, size_t size) {
+        size_t out_index = buffer.size();
+        buffer.resize(out_index + size);
         memcpy(&buffer[out_index], data, size);
     }
 };
-void Typelib::dump(Value v, std::vector< boost::uint8_t >& buffer)
-{
+void Typelib::dump(Value v, std::vector<boost::uint8_t> &buffer) {
     VectorOutputStream stream(buffer);
     return dump(v, stream);
 }
-void Typelib::dump(Value v, std::vector< boost::uint8_t >& buffer, MemoryLayout const& ops)
-{
+void Typelib::dump(Value v, std::vector<boost::uint8_t> &buffer,
+                   MemoryLayout const &ops) {
     VectorOutputStream stream(buffer);
     return dump(v, stream, ops);
 }
-void Typelib::dump( boost::uint8_t const* v, std::vector< boost::uint8_t >& buffer, MemoryLayout const& ops)
-{
+void Typelib::dump(boost::uint8_t const *v, std::vector<boost::uint8_t> &buffer,
+                   MemoryLayout const &ops) {
     VectorOutputStream stream(buffer);
     return dump(v, stream, ops);
 }
@@ -590,118 +550,95 @@ void Typelib::dump( boost::uint8_t const* v, std::vector< boost::uint8_t >& buff
 /*--------------------------------------------------
  * Dump support to std::ostream
  */
-struct OstreamOutputStream : public OutputStream
-{
-    std::ostream& stream;
-    OstreamOutputStream(std::ostream& stream)
-        : stream(stream) {}
+struct OstreamOutputStream : public OutputStream {
+    std::ostream &stream;
+    OstreamOutputStream(std::ostream &stream) : stream(stream) {}
 
-    void write(boost::uint8_t const* data, size_t size)
-    {
-        stream.write(reinterpret_cast<char const*>(data), size);
+    void write(boost::uint8_t const *data, size_t size) {
+        stream.write(reinterpret_cast<char const *>(data), size);
     }
 };
-void Typelib::dump(Value v, std::ostream& ostream)
-{
+void Typelib::dump(Value v, std::ostream &ostream) {
     OstreamOutputStream stream(ostream);
     return dump(v, stream);
 }
-void Typelib::dump(Value v, std::ostream& ostream, MemoryLayout const& ops)
-{
+void Typelib::dump(Value v, std::ostream &ostream, MemoryLayout const &ops) {
     OstreamOutputStream stream(ostream);
     return dump(v, stream, ops);
 }
-void Typelib::dump(boost::uint8_t const* v, std::ostream& ostream, MemoryLayout const& ops)
-{
+void Typelib::dump(boost::uint8_t const *v, std::ostream &ostream,
+                   MemoryLayout const &ops) {
     OstreamOutputStream stream(ostream);
     return dump(v, stream, ops);
 }
-
 
 /*--------------------------------------------------
  * Dump support to std::ostream
  */
-struct FDOutputStream : public OutputStream
-{
+struct FDOutputStream : public OutputStream {
     int fd;
-    FDOutputStream(int fd)
-        : fd(fd) {}
+    FDOutputStream(int fd) : fd(fd) {}
 
-    void write(boost::uint8_t const* data, size_t size)
-    {
+    void write(boost::uint8_t const *data, size_t size) {
         ::write(fd, data, size);
     }
 };
-void Typelib::dump(Value v, int fd)
-{
+void Typelib::dump(Value v, int fd) {
     FDOutputStream stream(fd);
     return dump(v, stream);
 }
-void Typelib::dump(Value v, int fd, MemoryLayout const& ops)
-{
+void Typelib::dump(Value v, int fd, MemoryLayout const &ops) {
     FDOutputStream stream(fd);
     return dump(v, stream, ops);
 }
-void Typelib::dump(boost::uint8_t const* v, int fd, MemoryLayout const& ops)
-{
+void Typelib::dump(boost::uint8_t const *v, int fd, MemoryLayout const &ops) {
     FDOutputStream stream(fd);
     return dump(v, stream, ops);
 }
-
 
 /*--------------------------------------------------
  * Dump support to FILE
  */
-struct FileOutputStream : public OutputStream
-{
-    FILE* fd;
-    FileOutputStream(FILE* fd)
-        : fd(fd) {}
+struct FileOutputStream : public OutputStream {
+    FILE *fd;
+    FileOutputStream(FILE *fd) : fd(fd) {}
 
-    void write(boost::uint8_t const* data, size_t size)
-    {
+    void write(boost::uint8_t const *data, size_t size) {
         ::fwrite(data, size, 1, fd);
     }
 };
-void Typelib::dump(Value v, FILE* fd)
-{
+void Typelib::dump(Value v, FILE *fd) {
     FileOutputStream stream(fd);
     return dump(v, stream);
 }
-void Typelib::dump(Value v, FILE* fd, MemoryLayout const& ops)
-{
+void Typelib::dump(Value v, FILE *fd, MemoryLayout const &ops) {
     FileOutputStream stream(fd);
     return dump(v, stream, ops);
 }
-void Typelib::dump(boost::uint8_t const* v, FILE* fd, MemoryLayout const& ops)
-{
+void Typelib::dump(boost::uint8_t const *v, FILE *fd, MemoryLayout const &ops) {
     FileOutputStream stream(fd);
     return dump(v, stream, ops);
 }
-
 
 /*--------------------------------------------------
  * Dump support to a generic OutputStream instance
  */
-void Typelib::dump(Value v, OutputStream& stream)
-{
+void Typelib::dump(Value v, OutputStream &stream) {
     MemoryLayout ops;
     MemLayout::Visitor visitor(ops);
     visitor.apply(v.getType());
     return dump(v, stream, ops);
 }
-void Typelib::dump(Value v, OutputStream& stream, MemoryLayout const& ops)
-{
-    return dump(reinterpret_cast< boost::uint8_t* >(v.getData()), stream, ops);
+void Typelib::dump(Value v, OutputStream &stream, MemoryLayout const &ops) {
+    return dump(reinterpret_cast<boost::uint8_t *>(v.getData()), stream, ops);
 }
-void Typelib::dump(boost::uint8_t const* v, OutputStream& stream, MemoryLayout const& ops)
-{
-    MemoryLayout::const_iterator end = ValueOps::dump(
-            v, 0, stream, ops.begin(), ops.end()).get<1>();
+void Typelib::dump(boost::uint8_t const *v, OutputStream &stream,
+                   MemoryLayout const &ops) {
+    MemoryLayout::const_iterator end =
+        ValueOps::dump(v, 0, stream, ops.begin(), ops.end()).get<1>();
     if (end != ops.end())
         throw std::runtime_error("internal error in the marshalling process");
 }
-
 
 /*--------------------------------------------------
  * Dump support to char*
@@ -709,16 +646,14 @@ void Typelib::dump(boost::uint8_t const* v, OutputStream& stream, MemoryLayout c
  * It is not using the generic dump() methods as it will return 0 on buffer
  * overrun or marshalling error, instead of throwing an exception
  */
-struct ByteArrayOutputStream : public OutputStream
-{
-    boost::uint8_t* buffer;
-    unsigned int   buffer_size;
-    unsigned int   current;
-    ByteArrayOutputStream(boost::uint8_t* buffer, int buffer_size)
+struct ByteArrayOutputStream : public OutputStream {
+    boost::uint8_t *buffer;
+    unsigned int buffer_size;
+    unsigned int current;
+    ByteArrayOutputStream(boost::uint8_t *buffer, int buffer_size)
         : buffer(buffer), buffer_size(buffer_size), current(0) {}
 
-    void write(boost::uint8_t const* data, size_t size)
-    {
+    void write(boost::uint8_t const *data, size_t size) {
         if (current + size > buffer_size)
             throw std::exception();
 
@@ -726,27 +661,25 @@ struct ByteArrayOutputStream : public OutputStream
         current += size;
     }
 };
-int Typelib::dump(Value v, boost::uint8_t* buffer, unsigned int buffer_size)
-{
+int Typelib::dump(Value v, boost::uint8_t *buffer, unsigned int buffer_size) {
     MemoryLayout ops;
     MemLayout::Visitor visitor(ops);
     visitor.apply(v.getType());
     return dump(v, buffer, buffer_size, ops);
 }
 
-int Typelib::dump(Value v, boost::uint8_t* buffer, unsigned int buffer_size, MemoryLayout const& ops)
-{
-    return dump(reinterpret_cast< boost::uint8_t const* >(v.getData()), buffer, buffer_size, ops);
+int Typelib::dump(Value v, boost::uint8_t *buffer, unsigned int buffer_size,
+                  MemoryLayout const &ops) {
+    return dump(reinterpret_cast<boost::uint8_t const *>(v.getData()), buffer,
+                buffer_size, ops);
 }
-int Typelib::dump(boost::uint8_t const* v, boost::uint8_t* buffer, unsigned int buffer_size, MemoryLayout const& ops)
-{
+int Typelib::dump(boost::uint8_t const *v, boost::uint8_t *buffer,
+                  unsigned int buffer_size, MemoryLayout const &ops) {
     ByteArrayOutputStream stream(buffer, buffer_size);
     MemoryLayout::const_iterator end;
     try {
-        end = ValueOps::dump(
-                v, 0, stream, ops.begin(), ops.end()).get<1>();
-    }
-    catch(std::exception const& e) {
+        end = ValueOps::dump(v, 0, stream, ops.begin(), ops.end()).get<1>();
+    } catch (std::exception const &e) {
         std::cout << "failed to marshal: " << e.what() << std::endl;
         return 0;
     }
@@ -755,57 +688,47 @@ int Typelib::dump(boost::uint8_t const* v, boost::uint8_t* buffer, unsigned int 
     return stream.current;
 }
 
-
-
 /*--------------------------------------------------
  * Marshalling size calculations
  */
-struct ByteCounterStream : public OutputStream
-{
+struct ByteCounterStream : public OutputStream {
     size_t result;
-    ByteCounterStream()
-        : result(0) {}
+    ByteCounterStream() : result(0) {}
 
-    void write(boost::uint8_t const* data, size_t size)
-    { result += size; }
+    void write(boost::uint8_t const *data, size_t size) { result += size; }
 };
-size_t Typelib::getDumpSize(Value v)
-{ 
+size_t Typelib::getDumpSize(Value v) {
     MemoryLayout ops;
     MemLayout::Visitor visitor(ops);
     visitor.apply(v.getType());
     return getDumpSize(v, ops);
 }
-size_t Typelib::getDumpSize(Value v, MemoryLayout const& ops)
-{ return getDumpSize(reinterpret_cast< boost::uint8_t const* >(v.getData()), ops); }
-size_t Typelib::getDumpSize(boost::uint8_t const* v, MemoryLayout const& ops)
-{
+size_t Typelib::getDumpSize(Value v, MemoryLayout const &ops) {
+    return getDumpSize(reinterpret_cast<boost::uint8_t const *>(v.getData()),
+                       ops);
+}
+size_t Typelib::getDumpSize(boost::uint8_t const *v, MemoryLayout const &ops) {
     ByteCounterStream counter;
     ValueOps::dump(v, 0, counter, ops.begin(), ops.end());
     return counter.result;
 }
 
-
-
-
-
-
 /*--------------------------------------------------
  * Generic load support from InputStream
  */
-void Typelib::load(Value v, InputStream& stream)
-{
+void Typelib::load(Value v, InputStream &stream) {
     MemoryLayout ops = layout_of(v.getType());
     return load(v, stream, ops);
 }
-void Typelib::load(Value v, InputStream& stream, MemoryLayout const& ops)
-{ load(reinterpret_cast< boost::uint8_t* >(v.getData()), v.getType(), stream, ops); }
-void Typelib::load(boost::uint8_t* v, Type const& type, InputStream& stream, MemoryLayout const& ops)
-{
+void Typelib::load(Value v, InputStream &stream, MemoryLayout const &ops) {
+    load(reinterpret_cast<boost::uint8_t *>(v.getData()), v.getType(), stream,
+         ops);
+}
+void Typelib::load(boost::uint8_t *v, Type const &type, InputStream &stream,
+                   MemoryLayout const &ops) {
     MemoryLayout::const_iterator it;
     size_t out_offset;
-    tie(out_offset, it) =
-        ValueOps::load(v, 0, stream, ops.begin(), ops.end());
+    tie(out_offset, it) = ValueOps::load(v, 0, stream, ops.begin(), ops.end());
     if (it != ops.end())
         throw std::runtime_error("internal error in the memory layout");
 }
@@ -813,89 +736,99 @@ void Typelib::load(boost::uint8_t* v, Type const& type, InputStream& stream, Mem
 /*--------------------------------------------------
  * Load support from std::vector< boost::uint8_t >
  */
-struct VectorInputStream : public InputStream
-{
-    std::vector< boost::uint8_t > const& buffer;
+struct VectorInputStream : public InputStream {
+    std::vector<boost::uint8_t> const &buffer;
     size_t in_index;
 
-    VectorInputStream(std::vector< boost::uint8_t > const& buffer)
+    VectorInputStream(std::vector<boost::uint8_t> const &buffer)
         : buffer(buffer), in_index(0) {}
 
-    void read(boost::uint8_t* out_buffer, size_t size)
-    {
+    void read(boost::uint8_t *out_buffer, size_t size) {
         if (size + in_index > buffer.size())
-            throw std::runtime_error("error in load(): not enough data as input, expected at least " + lexical_cast<string>(size + in_index) + " bytes but got " + lexical_cast<string>(buffer.size()));
+            throw std::runtime_error("error in load(): not enough data as "
+                                     "input, expected at least " +
+                                     lexical_cast<string>(size + in_index) +
+                                     " bytes but got " +
+                                     lexical_cast<string>(buffer.size()));
 
         memcpy(&out_buffer[0], &buffer[in_index], size);
         in_index += size;
     }
 };
-void Typelib::load(Value v, std::vector< boost::uint8_t > const& buffer)
-{
+void Typelib::load(Value v, std::vector<boost::uint8_t> const &buffer) {
     MemoryLayout ops = layout_of(v.getType());
     return load(v, buffer, ops);
 }
-void Typelib::load(Value v, std::vector< boost::uint8_t > const& buffer, MemoryLayout const& ops)
-{ load(reinterpret_cast< boost::uint8_t* >(v.getData()), v.getType(), buffer, ops); }
-void Typelib::load(boost::uint8_t* v, Type const& type, std::vector< boost::uint8_t > const& buffer, MemoryLayout const& ops)
-{
+void Typelib::load(Value v, std::vector<boost::uint8_t> const &buffer,
+                   MemoryLayout const &ops) {
+    load(reinterpret_cast<boost::uint8_t *>(v.getData()), v.getType(), buffer,
+         ops);
+}
+void Typelib::load(boost::uint8_t *v, Type const &type,
+                   std::vector<boost::uint8_t> const &buffer,
+                   MemoryLayout const &ops) {
     MemoryLayout::const_iterator it;
     VectorInputStream stream(buffer);
 
     size_t out_offset;
-    tie(out_offset, it) =
-        ValueOps::load(v, 0, stream, ops.begin(), ops.end());
+    tie(out_offset, it) = ValueOps::load(v, 0, stream, ops.begin(), ops.end());
     if (it != ops.end())
         throw std::runtime_error("internal error in the memory layout");
-    if (stream.in_index != buffer.size() && stream.in_index + type.getTrailingPadding() != buffer.size())
-        throw std::runtime_error("parts of the provided buffer has not been used (used " + 
-                lexical_cast<string>(stream.in_index) + " bytes, got " + lexical_cast<string>(buffer.size()) + "as input)");
+    if (stream.in_index != buffer.size() &&
+        stream.in_index + type.getTrailingPadding() != buffer.size())
+        throw std::runtime_error(
+            "parts of the provided buffer has not been used (used " +
+            lexical_cast<string>(stream.in_index) + " bytes, got " +
+            lexical_cast<string>(buffer.size()) + "as input)");
 }
-
-
-
 
 /*--------------------------------------------------
  * Load support from uint8_t*
  */
-struct ByteArrayInputStream : public InputStream
-{
-    boost::uint8_t const* buffer;
+struct ByteArrayInputStream : public InputStream {
+    boost::uint8_t const *buffer;
     unsigned int buffer_size;
     unsigned int in_index;
 
-    ByteArrayInputStream(boost::uint8_t const* buffer, int buffer_size)
+    ByteArrayInputStream(boost::uint8_t const *buffer, int buffer_size)
         : buffer(buffer), buffer_size(buffer_size), in_index(0) {}
 
-    void read(boost::uint8_t* out_buffer, size_t size)
-    {
+    void read(boost::uint8_t *out_buffer, size_t size) {
         if (size + in_index > buffer_size)
-            throw std::runtime_error("error in load(): not enough data as input, expected at least " + lexical_cast<string>(size + in_index) + " bytes but got " + lexical_cast<string>(buffer_size));
+            throw std::runtime_error("error in load(): not enough data as "
+                                     "input, expected at least " +
+                                     lexical_cast<string>(size + in_index) +
+                                     " bytes but got " +
+                                     lexical_cast<string>(buffer_size));
 
         memcpy(&out_buffer[0], &buffer[in_index], size);
         in_index += size;
     }
 };
-void Typelib::load(Value v, boost::uint8_t const* buffer, unsigned int buffer_size)
-{
+void Typelib::load(Value v, boost::uint8_t const *buffer,
+                   unsigned int buffer_size) {
     MemoryLayout ops = layout_of(v.getType());
     return load(v, buffer, buffer_size, ops);
 }
-void Typelib::load(Value v, boost::uint8_t const* buffer, unsigned int buffer_size, MemoryLayout const& ops)
-{ load(reinterpret_cast< boost::uint8_t* >(v.getData()), v.getType(), buffer, buffer_size, ops); }
-void Typelib::load(boost::uint8_t* v, Type const& type, boost::uint8_t const* buffer, unsigned int buffer_size, MemoryLayout const& ops)
-{
+void Typelib::load(Value v, boost::uint8_t const *buffer,
+                   unsigned int buffer_size, MemoryLayout const &ops) {
+    load(reinterpret_cast<boost::uint8_t *>(v.getData()), v.getType(), buffer,
+         buffer_size, ops);
+}
+void Typelib::load(boost::uint8_t *v, Type const &type,
+                   boost::uint8_t const *buffer, unsigned int buffer_size,
+                   MemoryLayout const &ops) {
     MemoryLayout::const_iterator it;
     ByteArrayInputStream stream(buffer, buffer_size);
 
     size_t out_offset;
-    tie(out_offset, it) =
-        ValueOps::load(v, 0, stream, ops.begin(), ops.end());
+    tie(out_offset, it) = ValueOps::load(v, 0, stream, ops.begin(), ops.end());
     if (it != ops.end())
         throw std::runtime_error("internal error in the memory layout");
-    if (stream.in_index != buffer_size && stream.in_index + type.getTrailingPadding() != buffer_size)
-        throw std::runtime_error("parts of the provided buffer has not been used (used " + 
-                lexical_cast<string>(stream.in_index) + " bytes, got " + lexical_cast<string>(buffer_size) + "as input)");
+    if (stream.in_index != buffer_size &&
+        stream.in_index + type.getTrailingPadding() != buffer_size)
+        throw std::runtime_error(
+            "parts of the provided buffer has not been used (used " +
+            lexical_cast<string>(stream.in_index) + " bytes, got " +
+            lexical_cast<string>(buffer_size) + "as input)");
 }
-
-

--- a/typelib/value_ops.hh
+++ b/typelib/value_ops.hh
@@ -5,80 +5,82 @@
 #include <typelib/value.hh>
 #include <iosfwd>
 
-namespace Typelib
-{
-    void init(Value v);
-    void init(Value v, MemoryLayout const& ops);
-    void init(uint8_t* data, MemoryLayout const& ops);
+namespace Typelib {
+void init(Value v);
+void init(Value v, MemoryLayout const &ops);
+void init(uint8_t *data, MemoryLayout const &ops);
 
-    void zero(Value v);
-    void zero(Value v, MemoryLayout const& ops);
-    void zero(uint8_t* data, MemoryLayout const& ops);
+void zero(Value v);
+void zero(Value v, MemoryLayout const &ops);
+void zero(uint8_t *data, MemoryLayout const &ops);
 
-    void destroy(Value v);
-    void destroy(Value v, MemoryLayout const& ops);
-    void destroy(uint8_t* data, MemoryLayout const& ops);
+void destroy(Value v);
+void destroy(Value v, MemoryLayout const &ops);
+void destroy(uint8_t *data, MemoryLayout const &ops);
 
-    void copy(Value dst, Value src);
-    void copy(void* dst, void* src, Type const& type);
+void copy(Value dst, Value src);
+void copy(void *dst, void *src, Type const &type);
 
-    bool compare(Value dst, Value src);
-    bool compare(void* dst, void* src, Type const& type);
+bool compare(Value dst, Value src);
+bool compare(void *dst, void *src, Type const &type);
 
-    void display(std::ostream& io,
-            MemoryLayout::const_iterator const begin, MemoryLayout::const_iterator const end);
+void display(std::ostream &io, MemoryLayout::const_iterator const begin,
+             MemoryLayout::const_iterator const end);
 
-    std::vector<uint8_t> dump(Value v);
+std::vector<uint8_t> dump(Value v);
 
-    void dump(Value v, std::vector<uint8_t>& buffer);
-    void dump(Value v, std::vector<uint8_t>& buffer, MemoryLayout const& ops);
-    void dump(uint8_t const* v, std::vector<uint8_t>& buffer, MemoryLayout const& ops);
+void dump(Value v, std::vector<uint8_t> &buffer);
+void dump(Value v, std::vector<uint8_t> &buffer, MemoryLayout const &ops);
+void dump(uint8_t const *v, std::vector<uint8_t> &buffer,
+          MemoryLayout const &ops);
 
-    void dump(Value v, std::ostream& stream);
-    void dump(Value v, std::ostream& stream, MemoryLayout const& ops);
-    void dump(uint8_t const* v, std::ostream& stream, MemoryLayout const& ops);
+void dump(Value v, std::ostream &stream);
+void dump(Value v, std::ostream &stream, MemoryLayout const &ops);
+void dump(uint8_t const *v, std::ostream &stream, MemoryLayout const &ops);
 
-    void dump(Value v, int fd);
-    void dump(Value v, int fd, MemoryLayout const& ops);
-    void dump(uint8_t const* v, int fd, MemoryLayout const& ops);
+void dump(Value v, int fd);
+void dump(Value v, int fd, MemoryLayout const &ops);
+void dump(uint8_t const *v, int fd, MemoryLayout const &ops);
 
-    void dump(Value v, FILE* fd);
-    void dump(Value v, FILE* fd, MemoryLayout const& ops);
-    void dump(uint8_t const* v, FILE* fd, MemoryLayout const& ops);
+void dump(Value v, FILE *fd);
+void dump(Value v, FILE *fd, MemoryLayout const &ops);
+void dump(uint8_t const *v, FILE *fd, MemoryLayout const &ops);
 
-    int dump(Value v, uint8_t* buffer, unsigned int buffer_size);
-    int dump(Value v, uint8_t* buffer, unsigned int buffer_size, MemoryLayout const& ops);
-    int dump(uint8_t const* v, uint8_t* buffer, unsigned int buffer_size, MemoryLayout const& ops);
+int dump(Value v, uint8_t *buffer, unsigned int buffer_size);
+int dump(Value v, uint8_t *buffer, unsigned int buffer_size,
+         MemoryLayout const &ops);
+int dump(uint8_t const *v, uint8_t *buffer, unsigned int buffer_size,
+         MemoryLayout const &ops);
 
-    struct OutputStream
-    {
-        virtual void write(uint8_t const* data, size_t size) = 0;
-    };
-    void dump(Value v, OutputStream& stream);
-    void dump(Value v, OutputStream& stream, MemoryLayout const& ops);
-    void dump(uint8_t const* v, OutputStream& stream, MemoryLayout const& ops);
+struct OutputStream {
+    virtual void write(uint8_t const *data, size_t size) = 0;
+};
+void dump(Value v, OutputStream &stream);
+void dump(Value v, OutputStream &stream, MemoryLayout const &ops);
+void dump(uint8_t const *v, OutputStream &stream, MemoryLayout const &ops);
 
+size_t getDumpSize(Value v);
+size_t getDumpSize(Value v, MemoryLayout const &ops);
+size_t getDumpSize(uint8_t const *v, MemoryLayout const &ops);
 
-    size_t getDumpSize(Value v);
-    size_t getDumpSize(Value v, MemoryLayout const& ops);
-    size_t getDumpSize(uint8_t const* v, MemoryLayout const& ops);
+struct InputStream {
+    virtual void read(uint8_t *data, size_t size) = 0;
+};
+void load(Value v, InputStream &stream);
+void load(Value v, InputStream &stream, MemoryLayout const &ops);
+void load(uint8_t *v, Type const &type, InputStream &stream,
+          MemoryLayout const &ops);
 
-    struct InputStream
-    {
-        virtual void read(uint8_t* data, size_t size) = 0;
-    };
-    void load(Value v, InputStream& stream);
-    void load(Value v, InputStream& stream, MemoryLayout const& ops);
-    void load(uint8_t* v, Type const& type, InputStream& stream, MemoryLayout const& ops);
+void load(Value v, std::vector<uint8_t> const &buffer);
+void load(Value v, std::vector<uint8_t> const &buffer, MemoryLayout const &ops);
+void load(uint8_t *v, Type const &type, std::vector<uint8_t> const &buffer,
+          MemoryLayout const &ops);
 
-    void load(Value v, std::vector<uint8_t> const& buffer);
-    void load(Value v, std::vector<uint8_t> const& buffer, MemoryLayout const& ops);
-    void load(uint8_t* v, Type const& type, std::vector<uint8_t> const& buffer, MemoryLayout const& ops);
-
-    void load(Value v, uint8_t const* buffer, unsigned int buffer_size);
-    void load(Value v, uint8_t const* buffer, unsigned int buffer_size, MemoryLayout const& ops);
-    void load(uint8_t* v, Type const& type, uint8_t const* buffer, unsigned int buffer_size, MemoryLayout const& ops);
+void load(Value v, uint8_t const *buffer, unsigned int buffer_size);
+void load(Value v, uint8_t const *buffer, unsigned int buffer_size,
+          MemoryLayout const &ops);
+void load(uint8_t *v, Type const &type, uint8_t const *buffer,
+          unsigned int buffer_size, MemoryLayout const &ops);
 }
 
 #endif
-

--- a/typelib/value_ops_details.hh
+++ b/typelib/value_ops_details.hh
@@ -7,48 +7,40 @@
 
 #include <boost/tuple/tuple.hpp>
 
-namespace Typelib
-{
-    /** This namespace includes the basic methods needed to implement complex
-     * operations on Value objects (i.e. typed buffers)
-     */
-    namespace ValueOps
-    {
-        boost::tuple<size_t, MemoryLayout::const_iterator>
-            dump(uint8_t const* data, size_t in_offset,
-                OutputStream& stream, MemoryLayout::const_iterator const begin, MemoryLayout::const_iterator const end);
+namespace Typelib {
+/** This namespace includes the basic methods needed to implement complex
+ * operations on Value objects (i.e. typed buffers)
+ */
+namespace ValueOps {
+boost::tuple<size_t, MemoryLayout::const_iterator>
+dump(uint8_t const *data, size_t in_offset, OutputStream &stream,
+     MemoryLayout::const_iterator const begin,
+     MemoryLayout::const_iterator const end);
 
-        boost::tuple<size_t, MemoryLayout::const_iterator>
-            load(uint8_t* data, size_t out_offset,
-                InputStream& stream,
-                MemoryLayout::const_iterator const begin, MemoryLayout::const_iterator const end);
+boost::tuple<size_t, MemoryLayout::const_iterator>
+load(uint8_t *data, size_t out_offset, InputStream &stream,
+     MemoryLayout::const_iterator const begin,
+     MemoryLayout::const_iterator const end);
 
-        boost::tuple<bool, uint8_t*, uint8_t*, MemoryLayout::const_iterator>
-            compare(uint8_t* out_buffer, uint8_t* in_buffer,
-                    MemoryLayout::const_iterator it,
-                    MemoryLayout::const_iterator end);
-        boost::tuple<uint8_t*, uint8_t*, MemoryLayout::const_iterator>
-            copy(uint8_t* out_buffer, uint8_t* in_buffer,
-                    MemoryLayout::const_iterator it,
-                    MemoryLayout::const_iterator end);
-        boost::tuple<uint8_t*, MemoryLayout::const_iterator>
-            destroy(uint8_t* buffer,
-                    MemoryLayout::const_iterator it,
-                    MemoryLayout::const_iterator end);
-        boost::tuple<uint8_t*, MemoryLayout::const_iterator>
-            init(uint8_t* buffer,
-                    MemoryLayout::const_iterator it,
-                    MemoryLayout::const_iterator end);
-        boost::tuple<uint8_t*, MemoryLayout::const_iterator>
-            zero(uint8_t* buffer,
-                    MemoryLayout::const_iterator it,
-                    MemoryLayout::const_iterator end);
-        boost::tuple<size_t, MemoryLayout::const_iterator>
-            getDumpSize(uint8_t* buffer,
-                    MemoryLayout::const_iterator it,
-                    MemoryLayout::const_iterator end);
-    }
+boost::tuple<bool, uint8_t *, uint8_t *, MemoryLayout::const_iterator>
+compare(uint8_t *out_buffer, uint8_t *in_buffer,
+        MemoryLayout::const_iterator it, MemoryLayout::const_iterator end);
+boost::tuple<uint8_t *, uint8_t *, MemoryLayout::const_iterator>
+copy(uint8_t *out_buffer, uint8_t *in_buffer, MemoryLayout::const_iterator it,
+     MemoryLayout::const_iterator end);
+boost::tuple<uint8_t *, MemoryLayout::const_iterator>
+destroy(uint8_t *buffer, MemoryLayout::const_iterator it,
+        MemoryLayout::const_iterator end);
+boost::tuple<uint8_t *, MemoryLayout::const_iterator>
+init(uint8_t *buffer, MemoryLayout::const_iterator it,
+     MemoryLayout::const_iterator end);
+boost::tuple<uint8_t *, MemoryLayout::const_iterator>
+zero(uint8_t *buffer, MemoryLayout::const_iterator it,
+     MemoryLayout::const_iterator end);
+boost::tuple<size_t, MemoryLayout::const_iterator>
+getDumpSize(uint8_t *buffer, MemoryLayout::const_iterator it,
+            MemoryLayout::const_iterator end);
+}
 }
 
 #endif
-


### PR DESCRIPTION
The C++ code is horrible to read. Too many different coding styles and broken indentations.

I'm pretty sure this will not be merged ;-) However, somehow start a discussion on how to improve things.

Does still compile, does still pass all test suites (after installing).

Makefile to reproduce is included. go forth and play!

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
