### PR TITLE
First version of clang parser

### DIFF
--- a/lang/csupport/containers.cc
+++ b/lang/csupport/containers.cc
@@ -457,6 +457,8 @@ Container::MarshalOps::const_iterator String::load(
     std::string* string_ptr =
         reinterpret_cast< std::string* >(container_ptr);
 
+    string_ptr->clear();
+        
     std::vector<uint8_t> buffer;
     buffer.resize(element_count);
     stream.read(&buffer[0], element_count);


### PR DESCRIPTION
Hi, 
the clang paser is now in a semi usable state. Together with the clang_integration branch from
https://github.com/jmachowinski/orogen it is possible to generate correct tlbs for base types.

Note that there are still some hard coded paths in 
bindings/ruby/lib/typelib/clang.rb.

Please test and review these changed.
Greetings
   Janosch
