### PR TITLE
test/ruby: remove not-needed-anymore requieres

### DIFF
--- a/test/ruby/test_metadata.rb
+++ b/test/ruby/test_metadata.rb
@@ -1,5 +1,4 @@
 require 'typelib/test'
-require BUILDDIR + '/ruby/libtest_ruby'
 
 class TC_MetaData < Minitest::Test
     attr_reader :type, :registry

--- a/test/ruby/test_specializations.rb
+++ b/test/ruby/test_specializations.rb
@@ -1,5 +1,4 @@
 require 'typelib/test'
-require BUILDDIR + '/ruby/libtest_ruby'
 require 'utilrb/hash/map_value'
 
 class TC_RubyMappingCustomization < Minitest::Test

--- a/test/ruby/test_specialized_types.rb
+++ b/test/ruby/test_specialized_types.rb
@@ -1,5 +1,4 @@
 require 'typelib/test'
-require BUILDDIR + '/ruby/libtest_ruby'
 
 class TC_SpecializedTypes < Minitest::Test
     include Typelib

--- a/test/ruby/test_type.rb
+++ b/test/ruby/test_type.rb
@@ -1,5 +1,4 @@
 require 'typelib/test'
-require BUILDDIR + '/ruby/libtest_ruby'
 
 class TC_Type < Minitest::Test
     include Typelib

--- a/test/ruby/test_value.rb
+++ b/test/ruby/test_value.rb
@@ -1,5 +1,4 @@
 require 'typelib/test'
-require BUILDDIR + '/ruby/libtest_ruby'
 
 class TC_Value < Minitest::Test
     include Typelib


### PR DESCRIPTION
a remnant from the "remove-dyncall-merge".

before, a "libtest_ruby" shared object using "test_rb_value.cc" was
compiled and loaded into some ruby-unittests. But, as far as I
understand this, it was only used by "test_value.rb".

I did somehow not realize this... Might be because I never completely
deleted the build-folder, and hence the still-present shared object was
always found? anyways...

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
