### PR TITLE
opaques: don't set/import/export the size of "Opaques", it is always zero

### DIFF
--- a/bindings/ruby/ext/registry.cc
+++ b/bindings/ruby/ext/registry.cc
@@ -632,14 +632,14 @@ static VALUE registry_create_enum(VALUE registry, VALUE name, VALUE symbol_defs,
 
 /*
  * call-seq:
- *   registry.create_opaque(name, size)
+ *   registry.create_opaque(name)
  *
- * Creates a new opaque type with the given name and size
+ * Creates a new opaque type with the given name
  */
-static VALUE registry_create_opaque(VALUE registry, VALUE _name, VALUE _size)
+static VALUE registry_create_opaque(VALUE registry, VALUE _name)
 {
     Registry& reg = rb2cxx::object<Registry>(registry);
-    Typelib::Type* type = new Typelib::OpaqueType(StringValuePtr(_name), NUM2INT(_size));
+    Typelib::Type* type = new Typelib::OpaqueType(StringValuePtr(_name));
     try { reg.add(type, true, ""); }
     catch(std::runtime_error e) { rb_raise(rb_eArgError, "%s", e.what()); }
     return cxx2rb::type_wrap(*type, registry);
@@ -687,7 +687,7 @@ void typelib_ruby::Typelib_init_registry()
     rb_define_method(cRegistry, "source_id_of", RUBY_METHOD_FUNC(registry_source_id_of), 1);
     rb_define_method(cRegistry, "do_create_compound", RUBY_METHOD_FUNC(registry_create_compound), 3);
     rb_define_method(cRegistry, "do_create_enum", RUBY_METHOD_FUNC(registry_create_enum), 3);
-    rb_define_method(cRegistry, "create_opaque", RUBY_METHOD_FUNC(registry_create_opaque), 2);
+    rb_define_method(cRegistry, "create_opaque", RUBY_METHOD_FUNC(registry_create_opaque), 1);
     rb_define_method(cRegistry, "create_null", RUBY_METHOD_FUNC(registry_create_null), 1);
 
     rb_define_singleton_method(cRegistry, "add_standard_cxx_types", RUBY_METHOD_FUNC(registry_add_standard_cxx_types), 1);

--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -763,7 +763,7 @@ module Typelib
                 # resolve_opaques as resolve_opaques will add the resolved
                 # opaque names to +opaques+
                 opaques.each do |type_name|
-                    registry.create_opaque type_name, 0
+                    registry.create_opaque type_name
                 end
                 resolve_opaques
             end

--- a/lang/tlb/export.cc
+++ b/lang/tlb/export.cc
@@ -91,7 +91,7 @@ namespace
 
     bool TlbExportVisitor::visit_(OpaqueType const& type)
     {
-        m_stream << "<opaque name=\"" << xmlEscape(type.getName()) << "\" size=\"" << type.getSize() << "\" " << emitSourceID() << ">\n";
+        m_stream << "<opaque name=\"" << xmlEscape(type.getName()) << "\" " << emitSourceID() << ">\n";
         m_stream << m_indent << emitMetaData(type) << "\n";
         m_stream << m_indent << "</opaque>";
         return true;

--- a/lang/tlb/import.cc
+++ b/lang/tlb/import.cc
@@ -193,8 +193,7 @@ namespace
     }
     Type const* load_opaque(TypeNode const& node, Factory& factory)
     {
-        size_t size = getAttribute<size_t>(node.xml, "size");
-        Type* type = new OpaqueType(node.name, size);
+        Type* type = new OpaqueType(node.name);
         factory.insert(node, type);
         return type;
     }

--- a/test/ruby/test_registry.rb
+++ b/test/ruby/test_registry.rb
@@ -288,8 +288,8 @@ class TC_Registry < Minitest::Test
 
     def test_create_opaque_raises_ArgumentError_if_the_name_is_already_used
         reg = Typelib::Registry.new
-        reg.create_opaque '/Test', 10
-        assert_raises(ArgumentError) { reg.create_opaque '/Test', 10 }
+        reg.create_opaque '/Test'
+        assert_raises(ArgumentError) { reg.create_opaque '/Test' }
     end
 
     def test_create_null_raises_ArgumentError_if_the_name_is_already_used

--- a/test/test_memory_layout.cc
+++ b/test/test_memory_layout.cc
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE( test_layout_simple )
  
     // Check an opaque type
     {
-        OpaqueType type("test_opaque", 10);
+        OpaqueType type("test_opaque");
         BOOST_CHECK_THROW(Typelib::layout_of(type), Typelib::NoLayout);
     }
 }

--- a/test/test_value.cc
+++ b/test/test_value.cc
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE( test_compile_endian_swap )
 
     // Check an opaque type (must throw)
     {
-        OpaqueType type("test_opaque", 10);
+        OpaqueType type("test_opaque");
 	CompileEndianSwapVisitor compiled;
         BOOST_CHECK_THROW(compiled.apply(type), Typelib::UnsupportedEndianSwap);
     }

--- a/typelib/typemodel.hh
+++ b/typelib/typemodel.hh
@@ -260,7 +260,7 @@ namespace Typelib
     class OpaqueType : public Type
     {
     public:
-        OpaqueType(std::string const& name, size_t size) : Type(name, size, Type::Opaque) {}
+        OpaqueType(std::string const& name) : Type(name, 0, Type::Opaque) {}
 	virtual std::set<Type const*> dependsOn() const { return std::set<Type const*>(); }
 	virtual bool do_compare(Type const& other, bool equality, std::map<Type const*, Type const*>& stack) const;
 	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const { return new OpaqueType(*this); }


### PR DESCRIPTION
opaques entries in a tlb have no size. not sure here, if this would
break stuff elsewhere... how to check that this property is not
read/modified anywhere? at least an "amake" inside "base/orogen/types"
with this commit included still works. no runtime-testing.

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
