### PR TITLE
Ruby: Use base64 encoding for  :pack_simple_arrays option (to_simple_value)

### DIFF
--- a/bindings/ruby/lib/typelib/array_type.rb
+++ b/bindings/ruby/lib/typelib/array_type.rb
@@ -210,7 +210,7 @@ module Typelib
         def to_simple_value(options = Hash.new)
             if options[:pack_simple_arrays] && element_t.respond_to?(:pack_code)
                 Hash[:pack_code => element_t.pack_code,
-                     :data => to_byte_array]
+                     :data => Base64.strict_encode64(to_byte_array)]       
             else
                 raw_each.map { |v| v.to_simple_value(options) }
             end

--- a/bindings/ruby/lib/typelib/container_type.rb
+++ b/bindings/ruby/lib/typelib/container_type.rb
@@ -368,9 +368,8 @@ module Typelib
         # in the container to allow for validation on the receiving end.
         def to_simple_value(options = Hash.new)
             if options[:pack_simple_arrays] && element_t.respond_to?(:pack_code)
-                Hash[pack_code: element_t.pack_code,
-                     size: size,
-                     data: to_byte_array[8..-1]]
+                Hash[:pack_code => element_t.pack_code,
+                     :data => Base64.strict_encode64(to_byte_array[8..-1])]             
             else
                 raw_each.map { |v| v.to_simple_value(options) }
             end


### PR DESCRIPTION
Uses base64 encoded strings as return value for to_simple_value, in case :pack_simple_arrays option is used.

Base64.strict_encode64 is available from ruby 1.9.2, it is needed, bacause Base64.encode64 fills the String with additional newlines at teh end or after 40 chars (default in http headers, but not wanted here).
