### PR TITLE
ruby: fix access to soon-to-be invalidated elements when logger level is debug (closes #36)

### DIFF
--- a/bindings/ruby/lib/typelib/container_type.rb
+++ b/bindings/ruby/lib/typelib/container_type.rb
@@ -243,10 +243,10 @@ module Typelib
             if invalidated? 
                 # All children have been invalidated already by #invalidate
             elsif memory_id && (memory_id != self.contained_memory_id)
-                Typelib.debug { "invalidating all elements in #{self}" }
+                Typelib.debug { "invalidating all elements in #{raw_to_s}" }
                 invalidate_children
             elsif @elements.size > self.size
-                Typelib.debug { "invalidating #{@elements.size - self.size} trailing elements in #{self}" }
+                Typelib.debug { "invalidating #{@elements.size - self.size} trailing elements in #{raw_to_s}" }
                 while @elements.size > self.size
                     if el = @elements.pop
                         el.invalidate

--- a/bindings/ruby/lib/typelib/type.rb
+++ b/bindings/ruby/lib/typelib/type.rb
@@ -695,9 +695,13 @@ module Typelib
 	    elsif ! (ruby_value = to_ruby).eql?(self)
 		ruby_value.to_s
 	    else
-		"#<#{self.class.name}: 0x#{address.to_s(16)} ptr=0x#{@ptr.zone_address.to_s(16)}>"
+                raw_to_s
 	    end
 	end
+
+        def raw_to_s
+            "#<#{self.class.name}: 0x#{address.to_s(16)} ptr=0x#{@ptr.zone_address.to_s(16)}>"
+        end
 
 	def pretty_print(pp) # :nodoc:
 	    pp.text to_s


### PR DESCRIPTION
The elements have already been deleted on the C++ side, and will be
invalidated on the ruby side. However, calling #to_s at that point
would cause a conversion to ruby to occur, which would lead to a crash