### PR TITLE
exporter: add checks on export-filename, throw if bad

### DIFF
--- a/typelib/exporter.cc
+++ b/typelib/exporter.cc
@@ -10,9 +10,23 @@
 using namespace Typelib;
 using namespace std;
 
-void Exporter::save(std::string const& file_name, utilmm::config_set const& config, Registry const& registry)
-{
+void Exporter::save(std::string const &file_name,
+                    utilmm::config_set const &config,
+                    Registry const &registry) {
+    // create a new 'ofstream' where we can write our data to. truncate
+    // (delete) a existing file.
     std::ofstream file(file_name.c_str(), std::ofstream::trunc);
+    // do some preleminary checking on our own, so we are able to report a
+    // proper error message, which contains the intended filename
+    if (!file.good())
+        throw std::runtime_error(
+            "typelib::Exporter::save() cannot export into filename '" +
+            file_name + "'");
+    // afterwards we activate excaptions, so that we still abort if something
+    // bad happens (instead of silently continuing)
+    file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    // and then call the internal "save()" function giving it the prepared
+    // 'ofstream' object
     save(file, config, registry);
 }
 

--- a/typelib/exporter.hh
+++ b/typelib/exporter.hh
@@ -44,11 +44,11 @@ namespace Typelib
     public:
         virtual ~Exporter() {}
 
-	/** Serialize a whole registry in a file */
-	virtual void save
-	    ( std::string const& file_name
-	    , utilmm::config_set const& config
-	    , Registry const& registry );
+        /** Serialize a whole registry into a file, overwriting an existing
+         * file. will throw on any errors. */
+        virtual void save(std::string const &file_name,
+                          utilmm::config_set const &config,
+                          Registry const &registry);
 
         /** Serialize a whole registry using this exporter
          * 


### PR DESCRIPTION
The string given as filename was not checked for validity after opening
before. This lead to silently _not_ writing to the given filename (if it
is an existing directory for example).

Now the function will throw() if the file could not be opened.
Additionally exceptions are activated for the ofstream-object so that
later failures (like a full disc or unmounted partition) will abort
the execution as well.

Signed-off-by: Martin Zenzes <martin.zenzes@dfki.de>