### PR TITLE
Fix for #47

### DIFF
--- a/typelib/value_ops.cc
+++ b/typelib/value_ops.cc
@@ -5,10 +5,9 @@
 #include <iostream>
 #include "value_ops_details.hh"
 #include <cstdio>
+#include <cstring>
 
 using namespace Typelib;
-using std::memcmp;
-using std::memcpy;
 
 void Typelib::display(std::ostream& io, MemoryLayout::const_iterator const begin, MemoryLayout::const_iterator const end)
 {


### PR DESCRIPTION
Including header cstring is required on some systems. (see #47, #48)

There was a misunderstanding on #48 fixed #47 or not. It did not, but this PR does.