### PR TITLE
ruby: reduce opportunity for clash on on the @registry ivar

### DIFF
--- a/bindings/ruby/ext/memory.cc
+++ b/bindings/ruby/ext/memory.cc
@@ -240,6 +240,8 @@ typelib_ruby::memory_init(VALUE ptr, VALUE type)
         if (layout_it == memory_layouts.end())
         {
             cxx2rb::RbRegistry& registry = rb2cxx::object<cxx2rb::RbRegistry>(type_get_registry(type));
+            if (registry.registry->get(t.getName()) != &t)
+                throw std::logic_error("memory_init: mismatch between Ruby-registered registry and C++ registry that really holds the type for " + t.getName());
             layout_it = memory_layouts.insert(
                 make_pair( &t, RbMemoryLayout(layout_of(t, true), registry.registry) )
                 ).first;

--- a/bindings/ruby/ext/value.cc
+++ b/bindings/ruby/ext/value.cc
@@ -117,7 +117,7 @@ VALUE cxx2rb::type_wrap(Type const& type, VALUE registry)
     VALUE base  = class_of(type);
     VALUE klass = rb_funcall(rb_cClass, rb_intern("new"), 1, base);
     VALUE rb_type = Data_Wrap_Struct(rb_cObject, 0, 0, const_cast<Type*>(&type));
-    rb_iv_set(klass, "@registry", registry);
+    rb_iv_set(klass, "@__typelib_registry", registry);
     rb_iv_set(klass, "@type", rb_type);
     rb_iv_set(klass, "@name", rb_str_new2(type.getName().c_str()));
     rb_iv_set(klass, "@null", (type.getCategory() == Type::NullType) ? Qtrue : Qfalse);
@@ -323,7 +323,7 @@ static VALUE type_memory_layout(VALUE self, VALUE pointers, VALUE opaques, VALUE
 
 VALUE typelib_ruby::type_get_registry(VALUE self)
 {
-    return rb_iv_get(self, "@registry");
+    return rb_iv_get(self, "@__typelib_registry");
 }
 
 
@@ -489,7 +489,7 @@ VALUE value_do_cast(VALUE self, VALUE target_type)
     if (value.getType() == to_type)
         return self;
 
-    VALUE registry = rb_iv_get(target_type, "@registry");
+    VALUE registry = type_get_registry(target_type);
     Value casted(value.getData(), to_type);
 #   ifdef VERBOSE
     fprintf(stderr, "wrapping casted value\n");
@@ -555,7 +555,7 @@ VALUE value_memory_eql_p(VALUE rbself, VALUE rbwith)
 VALUE typelib_ruby::value_get_registry(VALUE self)
 {
     VALUE type = rb_funcall(self, rb_intern("class"), 0);
-    return rb_iv_get(type, "@registry");
+    return type_get_registry(type);
 }
 
 /** 

--- a/bindings/ruby/lib/typelib/type.rb
+++ b/bindings/ruby/lib/typelib/type.rb
@@ -348,7 +348,9 @@ module Typelib
 
         class << self
 	    # The Typelib::Registry this type belongs to
-            attr_reader :registry
+            def registry
+                @__typelib_registry
+            end
 
 	    # The type's full name (i.e. name and namespace). In typelib,
 	    # namespace components are separated by '/'


### PR DESCRIPTION
Messing up this one can lead to a free-after-use, as it is used
in the destruction process of the Ruby values during GC

The commit also adds a sanity check in memory_init to detect such
problems.