### PR TITLE
ruby: fix a bunch of nasty corner cases in the registry export code

### DIFF
--- a/test/ruby/test_registry_export.rb
+++ b/test/ruby/test_registry_export.rb
@@ -68,7 +68,7 @@ describe Typelib::RegistryExport do
         it "returns the type as converted to ruby" do
             type = reg.create_compound '/CustomType'
             type.convert_to_ruby(Array) { Array.new }
-            assert_same Array, root.CustomType
+            assert_equal Array.new, root.CustomType.new
         end
     end
 
@@ -87,13 +87,13 @@ describe Typelib::RegistryExport do
         end
         it "returns the type as returned by the block" do
             root.reset_registry_export(reg, ->(type, ruby_type) { Hash })
-            assert_same Hash, root.CustomType
+            assert_kind_of Hash, root.CustomType.new
         end
         it "performs the conversion-to-ruby for the returned type" do
             target_t = reg.create_compound '/WrapperType'
             target_t.convert_to_ruby(Hash) { Hash.new }
-            root.reset_registry_export(reg, ->(type, ruby_type) { target_t })
-            assert_same Hash, root.CustomType
+            root.reset_registry_export(reg, ->(type, ruby_type) { ruby_type })
+            assert_kind_of Hash, root.WrapperType.new
         end
         it "will consider that types for which the block returned nil do not exist" do
             root.reset_registry_export(reg, ->(type, ruby_type) { })


### PR DESCRIPTION
This one's a far-reaching patch for a bunch of problems in the registry export code. Given its significance, it will probably need some testing before being merged. However, #60 should really be merged ASAP as there is currently some cases where we get into use-after-free (and crash)

1) the filter block could return types that were *not* from the
   registry being exported. This broke a few things, and is just
   inconsistent, so validate that the return type *is* from the
   expected registry
2) when a type has a conversion to ruby, the ruby class is returned.
   It is also setup as a subnamespace in the type export hierarchy,
   so some methods were defined, and attributes set. Which obviously
   breaks if the same type (namely, Array) is used on multiple places
   (the last one would win), and is just plain wrong from a general
   perspective since we globally change classes. Use DelegateClass to
   create a private class for the purpose of the export
3) be narrower in the extensions we define (mainly #to_s and
   #method_missing), for the same reasons: the type export influences
   Type objects as well as Ruby classes, so avoid changing their
   behaviours unnecessarily. Common methods are now left unchanged
   on all exported types except the Namespace (which are created for
   the only purpose of type export, so that's OK)