### PR TITLE
Fixed call for gccxml

### DIFF
--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -763,12 +763,20 @@ module Typelib
         end
         @gccxml_default_options = Shellwords.split(ENV['TYPELIB_GCCXML_DEFAULT_OPTIONS'] || '-DEIGEN_DONT_VECTORIZE')
 
+        #figure out the correct gccxml binary name, debian has changed this name 
+        #to gccxml.real
+        def self.gcc_binary_name
+            if !`which gccxml.real`.empty?
+                return "gccxml.real"
+            end
+            return "gccxml"
+        end
         # Runs gccxml on the provided file and with the given options, and
         # return the Nokogiri::XML object representing the result
         #
         # Raises RuntimeError if gccxml failed to run
         def self.gccxml(file, options)
-            cmdline = ["gccxml", *gccxml_default_options]
+            cmdline = [gcc_binary_name, *gccxml_default_options]
             if raw = options[:rawflags]
                 cmdline.concat(raw)
             end
@@ -831,7 +839,7 @@ module Typelib
                 end
                 io.flush
                 Tempfile.open('gccxml_err') do |err|
-                    command = ["gccxml", "--preprocess", *includes, *defines, *gccxml_default_options, io.path]
+                    command = [gcc_binary_name,, "--preprocess", *includes, *defines, *gccxml_default_options, io.path]
                     result = IO.popen(command, err: err.path) do |gccxml_io|
                         gccxml_io.read
                     end


### PR DESCRIPTION
Debian (Testing) has changed the name from gccxml to gccxml.real
This needs this hack. If gccxml.real is present in path use this
instead of gccxml.