### PR TITLE
tlb: support empty metadata keys

### DIFF
--- a/lang/tlb/export.cc
+++ b/lang/tlb/export.cc
@@ -76,8 +76,15 @@ namespace
         {
             std::string key = it->first;
             MetaData::Values values = it->second;
-            for (MetaData::Values::const_iterator it_value = values.begin(); it_value != values.end(); ++it_value)
-                stream << "<metadata key=\"" << key << "\"><![CDATA[" << *it_value << "]]></metadata>\n";
+            if (values.empty())
+            {
+                stream << "<metadata key=\"" << key << "\" />";
+            }
+            else
+            {
+                for (MetaData::Values::const_iterator it_value = values.begin(); it_value != values.end(); ++it_value)
+                    stream << "<metadata key=\"" << key << "\"><![CDATA[" << *it_value << "]]></metadata>\n";
+            }
         }
         return stream.str();
     }

--- a/lang/tlb/import.cc
+++ b/lang/tlb/import.cc
@@ -67,19 +67,20 @@ namespace
             if (xmlStrcmp(xml->name, reinterpret_cast<const xmlChar*>("metadata")))
                 continue;
             string key = getAttribute<string>(xml, "key");
-            string value;
+            metadata.add(key, MetaData::Values());
+
             // Look at a child CDATA block
             xmlNodePtr cdata = xml->children;
             for(; cdata; cdata=cdata->next)
             {
                 if (cdata->type == XML_CDATA_SECTION_NODE)
                 {
-                    value = reinterpret_cast<char const*>(cdata->content);
+                    std::string value = reinterpret_cast<char const*>(cdata->content);
+                    metadata.add(key, value);
                     break;
                 }
             }
 
-            metadata.add(key, value);
         }
     }
 


### PR DESCRIPTION
The metadata system makes a difference between a key that is set to
an empty set of values, and a non-existent key. The TLB import/export
was losing this distinction.