### PR TITLE
ruby: no need to require utilrb/object/singleton_class anymore

### DIFF
--- a/bindings/ruby/lib/typelib.rb
+++ b/bindings/ruby/lib/typelib.rb
@@ -1,6 +1,5 @@
 require 'enumerator'
 require 'utilrb/logger'
-require 'utilrb/object/singleton_class'
 require 'utilrb/kernel/options'
 require 'utilrb/module/attr_predicate'
 require 'utilrb/module/const_defined_here_p'


### PR DESCRIPTION
Object#singleton_class is built-in since ruby 1.9