### PR TITLE
Initialize enum values

### DIFF
--- a/bindings/ruby/ext/specialized_types.cc
+++ b/bindings/ruby/ext/specialized_types.cc
@@ -625,7 +625,7 @@ static VALUE vector_raw_memcpy(VALUE self,VALUE _source,VALUE _size)
     try
     {
         MemoryLayout ops = Typelib::layout_of(container_t.getIndirection());
-        is_memcpy = (ops.size() == 2 && ops[0] == MemLayout::FLAG_MEMCPY);
+        is_memcpy = ops.isMemcpy();
     }
     catch(std::runtime_error) { no_layout = true; }
     if(no_layout)

--- a/bindings/ruby/ext/specialized_types.cc
+++ b/bindings/ruby/ext/specialized_types.cc
@@ -574,7 +574,7 @@ static VALUE container_erase(VALUE self, VALUE obj)
 
 bool container_delete_if_i(Value v, VALUE registry, VALUE container)
 {
-    VALUE rb_v = typelib_to_ruby(v, registry, container);
+    VALUE rb_v = cxx2rb::value_wrap(v, registry, container);
     return RTEST(rb_yield(rb_v));
 }
 

--- a/bindings/ruby/ext/value.cc
+++ b/bindings/ruby/ext/value.cc
@@ -262,6 +262,48 @@ static VALUE type_can_cast_to(VALUE self, VALUE to)
     return from_type.canCastTo(to_type) ? Qtrue : Qfalse;
 }
 
+static VALUE layout_to_ruby(VALUE registry, MemoryLayout::const_iterator begin, MemoryLayout::const_iterator end)
+{
+    VALUE result = rb_ary_new();
+
+    VALUE rb_memcpy = ID2SYM(rb_intern("FLAG_MEMCPY"));
+    VALUE rb_skip = ID2SYM(rb_intern("FLAG_SKIP"));
+    VALUE rb_array = ID2SYM(rb_intern("FLAG_ARRAY"));
+    VALUE rb_end = ID2SYM(rb_intern("FLAG_END"));
+    VALUE rb_container = ID2SYM(rb_intern("FLAG_CONTAINER"));
+
+    // Now, convert into something representable in Ruby
+    for (MemoryLayout::const_iterator it = begin; it != end; ++it)
+    {
+        switch(*it)
+        {
+            case MemLayout::FLAG_MEMCPY:
+                rb_ary_push(result, rb_memcpy);
+                rb_ary_push(result, LONG2NUM(*(++it)));
+                break;
+            case MemLayout::FLAG_SKIP:
+                rb_ary_push(result, rb_skip);
+                rb_ary_push(result, LONG2NUM(*(++it)));
+                break;
+            case MemLayout::FLAG_ARRAY:
+                rb_ary_push(result, rb_array);
+                rb_ary_push(result, LONG2NUM(*(++it)));
+                break;
+            case MemLayout::FLAG_END:
+                rb_ary_push(result, rb_end);
+                break;
+            case MemLayout::FLAG_CONTAINER:
+                rb_ary_push(result, rb_container);
+                rb_ary_push(result, cxx2rb::type_wrap(*reinterpret_cast<Container*>(*(++it)), registry));
+                break;
+            default:
+                rb_raise(rb_eArgError, "error encountered while parsing memory layout");
+        }
+    }
+
+    return result;
+}
+
 /*
  *  type.do_memory_layout(VALUE accept_pointers, VALUE accept_opaques, VALUE merge_skip_copy, VALUE remove_trailing_skips) => [operations]
  *
@@ -274,50 +316,19 @@ static VALUE type_memory_layout(VALUE self, VALUE pointers, VALUE opaques, VALUE
     Type const& type(rb2cxx::object<Type>(self));
     VALUE registry = type_get_registry(self);
 
-    VALUE result = rb_ary_new();
-
-    VALUE rb_memcpy = ID2SYM(rb_intern("FLAG_MEMCPY"));
-    VALUE rb_skip = ID2SYM(rb_intern("FLAG_SKIP"));
-    VALUE rb_array = ID2SYM(rb_intern("FLAG_ARRAY"));
-    VALUE rb_end = ID2SYM(rb_intern("FLAG_END"));
-    VALUE rb_container = ID2SYM(rb_intern("FLAG_CONTAINER"));
-
+    MemoryLayout layout;
     try {
-        MemoryLayout layout = Typelib::layout_of(type, RTEST(pointers), RTEST(opaques), RTEST(merge), RTEST(remove_trailing_skips));
-
-        // Now, convert into something representable in Ruby
-        for (MemoryLayout::const_iterator it = layout.begin(); it != layout.end(); ++it)
-        {
-            switch(*it)
-            {
-                case MemLayout::FLAG_MEMCPY:
-                    rb_ary_push(result, rb_memcpy);
-                    rb_ary_push(result, LONG2NUM(*(++it)));
-                    break;
-                case MemLayout::FLAG_SKIP:
-                    rb_ary_push(result, rb_skip);
-                    rb_ary_push(result, LONG2NUM(*(++it)));
-                    break;
-                case MemLayout::FLAG_ARRAY:
-                    rb_ary_push(result, rb_array);
-                    rb_ary_push(result, LONG2NUM(*(++it)));
-                    break;
-                case MemLayout::FLAG_END:
-                    rb_ary_push(result, rb_end);
-                    break;
-                case MemLayout::FLAG_CONTAINER:
-                    rb_ary_push(result, rb_container);
-                    rb_ary_push(result, cxx2rb::type_wrap(*reinterpret_cast<Container*>(*(++it)), registry));
-                    break;
-                default:
-                    rb_raise(rb_eArgError, "error encountered while parsing memory layout");
-            }
-        }
-
+        layout = Typelib::layout_of(type, RTEST(pointers), RTEST(opaques), RTEST(merge), RTEST(remove_trailing_skips));
     } catch(std::exception const& e) {
         rb_raise(rb_eArgError, "%s", e.what());
     }
 
+    VALUE mem_layout = layout_to_ruby(registry, layout.begin(), layout.end());
+    VALUE init_layout = layout_to_ruby(registry, layout.init_begin(), layout.init_end());
+
+    VALUE result = rb_ary_new();
+    rb_ary_push(result, mem_layout);
+    rb_ary_push(result, init_layout);
     return result;
 }
 

--- a/bindings/ruby/lib/typelib.rb
+++ b/bindings/ruby/lib/typelib.rb
@@ -1,4 +1,5 @@
 require 'enumerator'
+require 'utilrb/object/address'
 require 'utilrb/logger'
 require 'utilrb/kernel/options'
 require 'utilrb/module/attr_predicate'

--- a/bindings/ruby/lib/typelib/cxx.rb
+++ b/bindings/ruby/lib/typelib/cxx.rb
@@ -94,7 +94,7 @@ module Typelib
         # @return [#load,#preprocess] a loader object suitable for operating
         #   on C++ files
         def self.loader
-            if @loader
+            if instance_variable_defined?(:@loader)
                 @loader
             elsif cxx_loader_name = ENV['TYPELIB_CXX_LOADER']
                 cxx_loader = CXX_LOADERS[cxx_loader_name]

--- a/bindings/ruby/lib/typelib/test.rb
+++ b/bindings/ruby/lib/typelib/test.rb
@@ -28,7 +28,7 @@ Typelib.load_type_plugins = false
 require 'test_config'
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'flexmock/test_unit'
+require 'flexmock/minitest'
 
 if ENV['TEST_ENABLE_PRY'] != '0'
     begin
@@ -40,11 +40,6 @@ end
 
 module Typelib
     module SelfTest
-        if defined? FlexMock
-            include FlexMock::ArgumentTypes
-            include FlexMock::MockContainer
-        end
-
         def setup
             @__warn_about_helper_method_clashes = Typelib.warn_about_helper_method_clashes?
             Typelib.warn_about_helper_method_clashes = false
@@ -52,22 +47,10 @@ module Typelib
         end
 
         def teardown
-            if defined? FlexMock
-                flexmock_teardown
-            end
             super
             Typelib.warn_about_helper_method_clashes = @__warn_about_helper_method_clashes
         end
     end
-end
-
-# Workaround a problem with flexmock and minitest not being compatible with each
-# other (currently). See github.com/jimweirich/flexmock/issues/15.
-if defined?(FlexMock) && !FlexMock::TestUnitFrameworkAdapter.method_defined?(:assertions)
-    class FlexMock::TestUnitFrameworkAdapter
-        attr_accessor :assertions
-    end
-    FlexMock.framework_adapter.assertions = 0
 end
 
 module Minitest

--- a/lang/csupport/containers.cc
+++ b/lang/csupport/containers.cc
@@ -23,7 +23,7 @@ Vector::Vector(Type const& on)
 {
     try {
         MemoryLayout ops = Typelib::layout_of(on);
-        is_memcpy = (ops.size() == 2 && ops[0] == MemLayout::FLAG_MEMCPY);
+        is_memcpy = ops.isMemcpy();
     }
     catch(std::runtime_error)
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ set_source_files_properties(test_containers.cc PROPERTIES
 
 CONFIGURE_FILE(testsuite.hh.in ${CMAKE_BINARY_DIR}/test/testsuite.hh @ONLY)
 ADD_EXECUTABLE(typelib_testsuite testsuite.cc
-    test_registry.cc
+    test_registry.cc test_value_ops_init.cc
     test_display.cc test_lang_tlb.cc test_model.cc
     test_plugin.cc test_value.cc test_containers.cc
     test_memory_layout.cc test_marshalling.cc ${TEST_LANG_C})

--- a/test/ruby/CMakeLists.txt
+++ b/test/ruby/CMakeLists.txt
@@ -24,10 +24,6 @@ ADD_TEST(NAME RubyLocalPlugins
 # the folders set in the env-var are hardcoded...
 set_property(TEST RubyLocalPlugins APPEND PROPERTY ENVIRONMENT
     "TYPELIB_PLUGIN_PATH=${CMAKE_BINARY_DIR}/lang/csupport:${CMAKE_BINARY_DIR}/lang/tlb:${CMAKE_BINARY_DIR}/lang/idl")
-# prepend another RUBYLIB to the already existing list, so that all the other
-# rock-depenencies are found.
-set_property(TEST RubyLocalPlugins APPEND PROPERTY ENVIRONMENT
-    "RUBYLIB=${CMAKE_BINARY_DIR}/bindings/ruby:$ENV{RUBYLIB}")
 # there are no typelib-plugins inside _this_ single project which we might
 # wanna test
 set_property(TEST RubyLocalPlugins APPEND PROPERTY ENVIRONMENT

--- a/test/ruby/test_registry.rb
+++ b/test/ruby/test_registry.rb
@@ -157,9 +157,6 @@ class TC_Registry < Minitest::Test
         assert_raises(ArgumentError) do
             reg.create_compound('NewCompound') { |t| t.field0 = 'int' }
         end
-        assert_raises(ArgumentError) do
-            reg.create_compound('/NewCompound') { |t| }
-        end
         assert_raises(Typelib::NotFound) do
             reg.create_compound('/NewCompound') { |t| t.field0 = 'this_is_an_unknown_type' }
         end

--- a/test/ruby/test_type.rb
+++ b/test/ruby/test_type.rb
@@ -98,7 +98,7 @@ class TC_Type < Minitest::Test
         off_v8 = std.offset_of("v8")
         off_v_of_v = std.offset_of("v_of_v")
 
-        layout = std.memory_layout
+        layout, init_layout = std.memory_layout
         expected = [:FLAG_MEMCPY, off_dlb_vector,
             :FLAG_CONTAINER, reg.get("/std/vector</double>"),
                 :FLAG_MEMCPY, 8,

--- a/test/ruby/test_value.rb
+++ b/test/ruby/test_value.rb
@@ -312,7 +312,7 @@ class TC_Value < Minitest::Test
         arrays.zero!
         array_a_struct = arrays.raw_a_struct
         array_a_struct[0] = ns1_test_t.new(a: 10)
-        assert_equal [10, 0, 0, 0, 0, 0, 0, 0, 0, 0], array_a_struct.to_a
+        assert_equal [10, 0, 0, 0, 0, 0, 0, 0, 0, 0], array_a_struct.map(&:a)
     end
 
     def test_convertion_to_from_ruby
@@ -357,6 +357,9 @@ class TC_Value < Minitest::Test
         assert_equal [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], arrays.raw_a_struct.to_ruby
         arrays.apply_changes_from_converted_types
         assert_equal [10, 0, 0, 0, 0, 0, 0, 0, 0, 0], arrays.raw_a_struct.to_ruby
+    ensure
+        Typelib.convertions_from_ruby.from_typename.delete('/NS1/Test')
+        Typelib.convertions_to_ruby.from_typename.delete('/NS1/Test')
     end
 end
 

--- a/test/test_marshalling.cc
+++ b/test/test_marshalling.cc
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE( test_marshalling_simple )
         };
 
         MemoryLayout ops;
-        ops.insert(ops.end(), raw_ops, raw_ops + 14);
+        ops.ops.insert(ops.ops.end(), raw_ops, raw_ops + 14);
 
         Type const& type = *registry.get("/A");
         memset(&a, 1, sizeof(A));
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE( test_marshalling_simple )
         };
 
         MemoryLayout ops;
-        ops.insert(ops.end(), raw_ops, raw_ops + 9);
+        ops.ops.insert(ops.ops.end(), raw_ops, raw_ops + 9);
 
         Type const& type = *registry.get("/B");
         vector<uint8_t> buffer;

--- a/test/test_memory_layout.cc
+++ b/test/test_memory_layout.cc
@@ -8,6 +8,7 @@
 #include <typelib/registry.hh>
 #include <typelib/value.hh>
 #include <typelib/memory_layout.hh>
+#include <lang/csupport/standard_types.hh>
 
 
 #include <typelib/value_ops.hh>
@@ -23,6 +24,18 @@ void REQUIRE_LAYOUT_EQUALS(size_t* begin, size_t* end, MemoryLayout const& layou
     BOOST_REQUIRE_EQUAL(end - begin, layout.ops.size());
     for (size_t* it = begin; it != end; ++it)
         BOOST_REQUIRE_EQUAL(*it, layout.ops[it - begin]);
+}
+
+void REQUIRE_INIT_EQUALS(size_t* begin, size_t* end, MemoryLayout const& layout)
+{
+    BOOST_REQUIRE_EQUAL(end - begin, layout.init_ops.size());
+    for (size_t* it = begin; it != end; ++it)
+        BOOST_REQUIRE_EQUAL(*it, layout.init_ops[it - begin]);
+}
+
+void REQUIRE_INIT_EMPTY(MemoryLayout const& layout)
+{
+    BOOST_REQUIRE( layout.init_ops.empty() );
 }
 
 static Registry& getRegistry()
@@ -43,14 +56,16 @@ BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_a_simple_structure )
     A data;
     size_t expected[] = { FLAG_MEMCPY, offsetof(A, d) + sizeof(data.d) };
     REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+    REQUIRE_INIT_EMPTY(ops);
 }
 
 BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_simple_arrays )
 {
-    Type const& type = *getRegistry().build("/char[100]");
+    Type const& type = *getRegistry().build("/uint16_t[100]");
     MemoryLayout ops = Typelib::layout_of(type);
-    size_t expected[] = { FLAG_MEMCPY, 100 };
+    size_t expected[] = { FLAG_MEMCPY, 200 };
     REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+    REQUIRE_INIT_EMPTY(ops);
 }
 
 BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_arrays_of_structures )
@@ -59,6 +74,7 @@ BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_arrays_of_structures )
     MemoryLayout ops = Typelib::layout_of(type);
     size_t expected[] = { FLAG_MEMCPY, sizeof(B) * 100 };
     REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+    REQUIRE_INIT_EMPTY(ops);
 }
 
 BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_simple_multidimensional_arrays )
@@ -68,6 +84,7 @@ BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_simple_multidimensional_ar
 
     size_t expected[] = { FLAG_MEMCPY, type.getSize() };
     REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+    REQUIRE_INIT_EMPTY(ops);
 }
 
 BOOST_AUTO_TEST_CASE( test_it_rejects_creating_layouts_for_structures_with_pointers_by_default )
@@ -83,6 +100,7 @@ BOOST_AUTO_TEST_CASE( test_it_generates_layout_for_structures_with_pointers_if_a
     C data;
     size_t expected[] = { FLAG_MEMCPY, offsetof(C, z) + sizeof(data.z) };
     REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+    REQUIRE_INIT_EMPTY(ops);
 }
 
 BOOST_AUTO_TEST_CASE( test_it_rejects_creating_layouts_for_opaques )
@@ -137,8 +155,63 @@ BOOST_AUTO_TEST_CASE(test_layout_arrays)
             sizeof(char)
         };
 
+        size_t init_expected[] = {
+            MemLayout::FLAG_INIT_SKIP,
+               static_cast<size_t>(reinterpret_cast<uint8_t*>(&arrays_v.a_v_numeric) - reinterpret_cast<uint8_t*>(&arrays_v)),
+            MemLayout::FLAG_INIT_REPEAT, 10,
+                MemLayout::FLAG_INIT_CONTAINER,
+                    reinterpret_cast<size_t>(&v_double),
+            MemLayout::FLAG_INIT_END,
+            MemLayout::FLAG_INIT_SKIP,
+               static_cast<size_t>(reinterpret_cast<uint8_t*>(&arrays_v.a_v_struct[0]) - reinterpret_cast<uint8_t*>(&arrays_v.padding3)),
+            MemLayout::FLAG_INIT_REPEAT, 10,
+                MemLayout::FLAG_INIT_CONTAINER,
+                    reinterpret_cast<size_t>(&v_str),
+            MemLayout::FLAG_INIT_END
+        };
+
+        MemoryLayout raw_ops = Typelib::raw_layout_of(type);
         size_t expected_size = sizeof(expected) / sizeof(size_t);
         REQUIRE_LAYOUT_EQUALS(expected, expected + expected_size, ops);
+        size_t init_expected_size = sizeof(init_expected) / sizeof(size_t);
+        REQUIRE_INIT_EQUALS(init_expected, init_expected + init_expected_size, ops);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_layout_array_of_containers)
+{
+    // Get the test file into repository
+    Registry registry;
+    PluginManager::self manager;
+    auto_ptr<Importer> importer(manager->importer("tlb"));
+    utilmm::config_set config;
+    BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+
+    {
+        Type const& type  = *registry.get("/std/vector</double>[10]");
+        Type const& v_double = static_cast<Indirect const&>(type).getIndirection();
+        MemoryLayout ops = Typelib::layout_of(type);
+
+        size_t expected[] = {
+            MemLayout::FLAG_ARRAY, 10,
+                MemLayout::FLAG_CONTAINER,
+                    reinterpret_cast<size_t>(&v_double),
+                    MemLayout::FLAG_MEMCPY,
+                    sizeof(double),
+                MemLayout::FLAG_END,
+            MemLayout::FLAG_END
+        };
+
+        size_t init_expected[] = {
+            MemLayout::FLAG_ARRAY, 10,
+                MemLayout::FLAG_CONTAINER, reinterpret_cast<size_t>(&v_double),
+            MemLayout::FLAG_END
+        };
+
+        size_t expected_size = sizeof(expected) / sizeof(size_t);
+        REQUIRE_LAYOUT_EQUALS(expected, expected + expected_size, ops);
+        size_t init_expected_size = sizeof(init_expected) / sizeof(size_t);
+        REQUIRE_INIT_EQUALS(init_expected, init_expected + init_expected_size, ops);
     }
 }
 
@@ -206,6 +279,24 @@ BOOST_AUTO_TEST_CASE(test_layout_containers)
     }
 }
 
+BOOST_AUTO_TEST_CASE( test_require_init_enums )
+{
+    Enum enum_t("/Test", 0);
+    enum_t.add("TEST", 10);
+    Compound compound_t("/CTest");
+    compound_t.addField("test", enum_t, 5);
+
+    MemoryLayout ops = Typelib::layout_of(compound_t);
+
+    size_t expected[] = {
+        MemLayout::FLAG_INIT_SKIP, 5,
+        MemLayout::FLAG_INIT, sizeof(Enum::integral_type), 0, 0, 0, 0, 0, 0, 0, 0 };
+    size_t expected_size = 4 + sizeof(Enum::integral_type);
+    *reinterpret_cast<Enum::integral_type*>(expected + 4) = 10;
+    REQUIRE_INIT_EQUALS(expected, expected + expected_size, ops);
+}
+
+
 BOOST_AUTO_TEST_CASE( test_simplifies_merges_consecutive_memcpy )
 {
     MemoryLayout layout;
@@ -216,18 +307,59 @@ BOOST_AUTO_TEST_CASE( test_simplifies_merges_consecutive_memcpy )
     REQUIRE_LAYOUT_EQUALS(expected, expected + 2, result);
 }
 
+BOOST_AUTO_TEST_CASE( test_it_does_not_mistake_something_looking_like_a_typecode_when_simplifying )
+{
+    MemoryLayout first_element;
+    std::vector<uint8_t> init_data;
+    init_data.resize(1, 0);
+    first_element.pushMemcpy(1, init_data);
+    first_element.pushMemcpy(MemLayout::FLAG_ARRAY);
+
+    MemoryLayout second_element;
+    second_element.pushMemcpy(10);
+
+    MemoryLayout layout;
+    layout.pushArray(10, first_element);
+    layout.pushArray(10, second_element);
+    layout.pushMemcpy(20);
+
+    MemoryLayout result = layout.simplify(true);
+    size_t expected[] = { FLAG_MEMCPY, 10 * (MemLayout::FLAG_ARRAY + 1) + 10 * 10 + 20 };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, result);
+    size_t init_expected[] = {
+        FLAG_INIT_REPEAT, 10,
+            FLAG_INIT, 1, 0,
+            FLAG_SKIP, 1,
+        FLAG_END
+    };
+    REQUIRE_INIT_EQUALS(init_expected, init_expected + 8, result);
+}
+
 BOOST_AUTO_TEST_CASE( test_simplifies_converts_simple_arrays_to_memcpy )
 {
     MemoryLayout layout;
     layout.pushMemcpy(10);
     layout.pushGenericOp(MemLayout::FLAG_ARRAY, 10);
-    layout.pushMemcpy(20);
-    layout.pushMemcpy(21);
+        layout.pushMemcpy(20);
+        layout.pushMemcpy(21);
     layout.pushEnd();
     layout.pushMemcpy(22);
     MemoryLayout result = layout.simplify(false);
     size_t expected[] = { FLAG_MEMCPY, 442 };
     REQUIRE_LAYOUT_EQUALS(expected, expected + 2, result);
+}
+
+BOOST_AUTO_TEST_CASE( test_simplifies_removes_empty_arrays )
+{
+    MemoryLayout layout;
+    layout.pushMemcpy(10);
+    MemoryLayout array_ops;
+    layout.pushArray(10, array_ops);
+    layout.pushMemcpy(22);
+    MemoryLayout result = layout.simplify(false);
+    size_t expected[] = { FLAG_MEMCPY, 32 };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, result);
+    REQUIRE_INIT_EMPTY(result);
 }
 
 BOOST_AUTO_TEST_CASE( test_simplifies_converts_recursive_arrays_to_memcpy )
@@ -247,5 +379,4 @@ BOOST_AUTO_TEST_CASE( test_simplifies_converts_recursive_arrays_to_memcpy )
     size_t expected[] = { FLAG_MEMCPY, 1692 };
     REQUIRE_LAYOUT_EQUALS(expected, expected + 2, result);
 }
-
 

--- a/test/test_memory_layout.cc
+++ b/test/test_memory_layout.cc
@@ -15,77 +15,80 @@
 #include <string.h>
 
 using namespace Typelib;
+using namespace Typelib::MemLayout;
 using namespace std;
 
-BOOST_AUTO_TEST_CASE( test_layout_simple )
+void REQUIRE_LAYOUT_EQUALS(size_t* begin, size_t* end, MemoryLayout const& layout)
 {
-    // Get the test file into repository
-    Registry registry;
+    BOOST_REQUIRE_EQUAL(end - begin, layout.ops.size());
+    for (size_t* it = begin; it != end; ++it)
+        BOOST_REQUIRE_EQUAL(*it, layout.ops[it - begin]);
+}
+
+static Registry& getRegistry()
+{
+    static Registry registry;
+
     PluginManager::self manager;
     auto_ptr<Importer> importer(manager->importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
+    return registry;
+}
 
-    /* Check a simple structure with alignment issues */
-    {
-        Type const& type = *registry.get("/A");
-        MemoryLayout ops = Typelib::layout_of(type);
+BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_a_simple_structure )
+{
+    Type const& type = *getRegistry().get("/A");
+    MemoryLayout ops = Typelib::layout_of(type);
+    A data;
+    size_t expected[] = { FLAG_MEMCPY, offsetof(A, d) + sizeof(data.d) };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+}
 
-        BOOST_REQUIRE_EQUAL(2U, ops.size());
-        BOOST_REQUIRE_EQUAL(MemLayout::FLAG_MEMCPY, ops[0]);
-        A data;
-        BOOST_REQUIRE_EQUAL(offsetof(A, d) + sizeof(data.d), ops[1]);
-    }
+BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_simple_arrays )
+{
+    Type const& type = *getRegistry().build("/char[100]");
+    MemoryLayout ops = Typelib::layout_of(type);
+    size_t expected[] = { FLAG_MEMCPY, 100 };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+}
 
-    /* Check handling of simple arrays */
-    {
-        Type const& type = *registry.build("/char[100]");
-        MemoryLayout ops = Typelib::layout_of(type);
+BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_arrays_of_structures )
+{
+    Type const& type = *getRegistry().build("/B[100]");
+    MemoryLayout ops = Typelib::layout_of(type);
+    size_t expected[] = { FLAG_MEMCPY, sizeof(B) * 100 };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+}
 
-        BOOST_REQUIRE_EQUAL(2U, ops.size());
-        BOOST_REQUIRE_EQUAL(MemLayout::FLAG_MEMCPY, ops[0]);
-        BOOST_REQUIRE_EQUAL(100U, ops[1]);
-    }
+BOOST_AUTO_TEST_CASE( test_it_generates_the_layout_of_simple_multidimensional_arrays )
+{
+    Type const& type = *getRegistry().get("TestMultiDimArray");
+    MemoryLayout ops = Typelib::layout_of(type);
 
-    /* Check a structure with arrays */
-    {
-        Type const& type = *registry.get("/B");
-        MemoryLayout ops = Typelib::layout_of(type);
+    size_t expected[] = { FLAG_MEMCPY, type.getSize() };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+}
 
-        BOOST_REQUIRE_EQUAL(2U, ops.size());
-        BOOST_REQUIRE_EQUAL(MemLayout::FLAG_MEMCPY, ops[0]);
-        B data;
-        BOOST_REQUIRE_EQUAL(offsetof(B, z) + sizeof(data.z), ops[1]);
-    }
+BOOST_AUTO_TEST_CASE( test_it_rejects_creating_layouts_for_structures_with_pointers_by_default )
+{
+    Type const& type = *getRegistry().get("/C");
+    BOOST_CHECK_THROW(Typelib::layout_of(type), Typelib::NoLayout);
+}
 
-    /* Check a multidimensional array */
-    {
-        Type const& type = *registry.get("TestMultiDimArray");
-        MemoryLayout ops = Typelib::layout_of(type);
+BOOST_AUTO_TEST_CASE( test_it_generates_layout_for_structures_with_pointers_if_asked_for_it )
+{
+    Type const& type = *getRegistry().get("/C");
+    MemoryLayout ops = Typelib::layout_of(type, true);
+    C data;
+    size_t expected[] = { FLAG_MEMCPY, offsetof(C, z) + sizeof(data.z) };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, ops);
+}
 
-        BOOST_REQUIRE_EQUAL(2U, ops.size());
-        BOOST_REQUIRE_EQUAL(MemLayout::FLAG_MEMCPY, ops[0]);
-        BOOST_REQUIRE_EQUAL(type.getSize(), ops[1]);
-    }
-
-    // Check a structure with pointer. Must throw by default, but accept if the
-    // accept_pointers flag is set, in which case FLAG_MEMCPY is used for it.
-    {
-        Type const& type = *registry.get("/C");
-        BOOST_CHECK_THROW(Typelib::layout_of(type), Typelib::NoLayout);
-
-        MemoryLayout ops = Typelib::layout_of(type, true);
-        BOOST_REQUIRE_EQUAL(2, ops.size());
-        BOOST_REQUIRE_EQUAL(MemLayout::FLAG_MEMCPY, ops[0]);
-        C data;
-        BOOST_REQUIRE_EQUAL(offsetof(C, z) + sizeof(data.z), ops[1]);
-    }
- 
-    // Check an opaque type
-    {
-        OpaqueType type("test_opaque", 10);
-        BOOST_CHECK_THROW(Typelib::layout_of(type), Typelib::NoLayout);
-    }
+BOOST_AUTO_TEST_CASE( test_it_rejects_creating_layouts_for_opaques )
+{
+    OpaqueType type("test_opaque", 10);
+    BOOST_CHECK_THROW(Typelib::layout_of(type), Typelib::NoLayout);
 }
 
 BOOST_AUTO_TEST_CASE(test_layout_arrays)
@@ -134,17 +137,8 @@ BOOST_AUTO_TEST_CASE(test_layout_arrays)
             sizeof(char)
         };
 
-        for (size_t i = 0; i < ops.size(); ++i)
-            if (expected[i] != ops[i])
-            {
-                Typelib::display(cerr, ops.begin(), ops.end());
-                std::cerr << "error at index " << i << std::endl;
-                BOOST_REQUIRE_EQUAL(expected[i], ops[i]);
-            }
-
-        // Check that we have all the operations that we need
         size_t expected_size = sizeof(expected) / sizeof(size_t);
-        BOOST_REQUIRE_EQUAL(expected_size, ops.size());
+        REQUIRE_LAYOUT_EQUALS(expected, expected + expected_size, ops);
     }
 }
 
@@ -207,17 +201,51 @@ BOOST_AUTO_TEST_CASE(test_layout_containers)
             sizeof(char)
         };
 
-        for (size_t i = 0; i < ops.size(); ++i)
-            if (expected[i] != ops[i])
-            {
-                Typelib::display(cerr, ops.begin(), ops.end());
-                std::cerr << "error at index " << i << std::endl;
-                BOOST_REQUIRE_EQUAL(expected[i], ops[i]);
-            }
-
-        // Check that we have all the operations that we need
         size_t expected_size = sizeof(expected) / sizeof(size_t);
-        BOOST_REQUIRE_EQUAL(expected_size, ops.size());
+        REQUIRE_LAYOUT_EQUALS(expected, expected + expected_size, ops);
     }
 }
+
+BOOST_AUTO_TEST_CASE( test_simplifies_merges_consecutive_memcpy )
+{
+    MemoryLayout layout;
+    layout.pushMemcpy(10);
+    layout.pushMemcpy(20);
+    MemoryLayout result = layout.simplify(false);
+    size_t expected[] = { FLAG_MEMCPY, 30 };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, result);
+}
+
+BOOST_AUTO_TEST_CASE( test_simplifies_converts_simple_arrays_to_memcpy )
+{
+    MemoryLayout layout;
+    layout.pushMemcpy(10);
+    layout.pushGenericOp(MemLayout::FLAG_ARRAY, 10);
+    layout.pushMemcpy(20);
+    layout.pushMemcpy(21);
+    layout.pushEnd();
+    layout.pushMemcpy(22);
+    MemoryLayout result = layout.simplify(false);
+    size_t expected[] = { FLAG_MEMCPY, 442 };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, result);
+}
+
+BOOST_AUTO_TEST_CASE( test_simplifies_converts_recursive_arrays_to_memcpy )
+{
+    MemoryLayout layout;
+    layout.pushMemcpy(10);
+    layout.pushGenericOp(MemLayout::FLAG_ARRAY, 10);
+        layout.pushMemcpy(20);
+        layout.pushMemcpy(21);
+            layout.pushGenericOp(MemLayout::FLAG_ARRAY, 11);
+            layout.pushMemcpy(10);
+            layout.pushEnd();
+        layout.pushMemcpy(15);
+    layout.pushEnd();
+    layout.pushMemcpy(22);
+    MemoryLayout result = layout.simplify(false);
+    size_t expected[] = { FLAG_MEMCPY, 1692 };
+    REQUIRE_LAYOUT_EQUALS(expected, expected + 2, result);
+}
+
 

--- a/test/test_value_ops_init.cc
+++ b/test/test_value_ops_init.cc
@@ -1,0 +1,31 @@
+#include <boost/test/auto_unit_test.hpp>
+
+#include <test/testsuite.hh>
+#include <typelib/utilmm/configset.hh>
+#include <typelib/pluginmanager.hh>
+#include <typelib/importer.hh>
+#include <typelib/typemodel.hh>
+#include <typelib/registry.hh>
+#include <typelib/value.hh>
+#include <typelib/value_ops.hh>
+
+#include <test/test_cimport.1>
+#include <string.h>
+
+using namespace Typelib;
+using namespace std;
+
+enum TestEnum { TEST = 10 };
+BOOST_AUTO_TEST_CASE( test_init_initializes_enums )
+{
+    Enum enum_t("/Test", 0);
+    enum_t.add("TEST", 10);
+    Compound compound_t("/CTest");
+    compound_t.addField("test", enum_t, 5);
+
+    std::vector<uint8_t> buffer;
+    buffer.resize(compound_t.getSize());
+    Typelib::init(Value(&buffer[0], compound_t));
+    BOOST_REQUIRE_EQUAL(10, *reinterpret_cast<TestEnum*>(&buffer[5]));
+}
+

--- a/tools/typelib-tlb-merger/test/test-merge-result.tlb
+++ b/tools/typelib-tlb-merger/test/test-merge-result.tlb
@@ -67,7 +67,7 @@
     <field name="tv_nsec" type="/int64_t" offset="8">
     
     </field>
-  <metadata key="orogen_include"><![CDATA[/usr/include/time.h]]></metadata>
+  <metadata key="cxxname"><![CDATA[struct timespec]]></metadata>
 <metadata key="source_file_line"><![CDATA[/usr/include/time.h:120]]></metadata>
 
   </compound>
@@ -117,8 +117,10 @@
     <field name="m1" type="/int32_t" offset="32">
     
     </field>
-  <metadata key="orogen_include"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/arrays.hh]]></metadata>
-<metadata key="source_file_line"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/arrays.hh:31]]></metadata>
+  <metadata key="cxxname"><![CDATA[class arrays::C1]]></metadata>
+<metadata key="doc"><![CDATA[ more text, formatted to be able to be extracted as a
+ "clang::comments::FullComment". blalba. more text. the same wrapped inside a container -- detected and exported]]></metadata>
+<metadata key="source_file_line"><![CDATA[.../tools/typelib-clang-tlb-importer/test/arrays.hh:39]]></metadata>
 
   </compound>
   <compound name="/arrays/D1" size="2064" >
@@ -134,33 +136,34 @@
     <field name="a" type="/uint64_t" offset="2056">
     
     </field>
-  <metadata key="orogen_include"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/arrays.hh]]></metadata>
-<metadata key="source_file_line"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/arrays.hh:11]]></metadata>
+  <metadata key="cxxname"><![CDATA[struct arrays::D1]]></metadata>
+<metadata key="doc"><![CDATA[ inspired from "laser.h" but, as a courtesy, with a BlockCommandComment]]></metadata>
+<metadata key="source_file_line"><![CDATA[.../tools/typelib-clang-tlb-importer/test/arrays.hh:14]]></metadata>
 
   </compound>
-  <opaque name="/ns/C2&lt;/float&gt;" >
+  <opaque name="/ns/C2&lt;/float&gt;" size="0" >
   
   </opaque>
-  <opaque name="/ns/S2" >
-  <metadata key="orogen_include"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/typedefs.hh]]></metadata>
-<metadata key="source_file_line"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/typedefs.hh:46]]></metadata>
+  <opaque name="/ns/S2" size="0" >
+  <metadata key="cxxname"><![CDATA[struct ns::S2]]></metadata>
+<metadata key="source_file_line"><![CDATA[.../tools/typelib-clang-tlb-importer/test/typedefs.hh:47]]></metadata>
 
   </opaque>
   <compound name="/ns/aClass" size="4" >
     <field name="A" type="/int32_t" offset="0">
     
     </field>
-  <metadata key="orogen_include"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/typedefs.hh]]></metadata>
-<metadata key="source_file_line"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/typedefs.hh:15]]></metadata>
+  <metadata key="cxxname"><![CDATA[class ns::aClass]]></metadata>
+<metadata key="source_file_line"><![CDATA[.../tools/typelib-clang-tlb-importer/test/typedefs.hh:15]]></metadata>
 
   </compound>
   <alias name="/ns/anotherIntTypedef" source="/int32_t"/>
   <alias name="/ns/intTypedef" source="/int32_t"/>
   <alias name="/ns/intTypedefTypedef" source="/int32_t"/>
-  <opaque name="/ns/myTestTypedef" >
-  <metadata key="opaque_is_typedef"><![CDATA[1]]></metadata>
-<metadata key="orogen_include"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/typedefs.hh]]></metadata>
-<metadata key="source_file_line"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/typedefs.hh:42]]></metadata>
+  <opaque name="/ns/myTestTypedef" size="0" >
+  <metadata key="cxxname"><![CDATA[typedef myTestTypedef ns::S1]]></metadata>
+<metadata key="opaque_is_typedef"><![CDATA[1]]></metadata>
+<metadata key="source_file_line"><![CDATA[.../tools/typelib-clang-tlb-importer/test/typedefs.hh:43]]></metadata>
 
   </opaque>
   <alias name="/ns/S1" source="/ns/myTestTypedef"/>
@@ -178,8 +181,8 @@
     <field name="D" type="/int32_t" offset="12">
     
     </field>
-  <metadata key="orogen_include"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/typedefs.hh]]></metadata>
-<metadata key="source_file_line"><![CDATA[/home/mzenzes/TransTerrA/rock/tools/typelib/tools/typelib-clang-tlb-importer/test/typedefs.hh:25]]></metadata>
+  <metadata key="cxxname"><![CDATA[struct ns::test]]></metadata>
+<metadata key="source_file_line"><![CDATA[.../tools/typelib-clang-tlb-importer/test/typedefs.hh:25]]></metadata>
 
   </compound>
   <container  name="/std/string" of="/int8_t" size="8" kind="/std/string" >

--- a/typelib/memory_layout.cc
+++ b/typelib/memory_layout.cc
@@ -1,8 +1,10 @@
 #include "memory_layout.hh"
 #include <iostream>
+#include <boost/lexical_cast.hpp>
 using namespace Typelib;
 using namespace Typelib::MemLayout;
 using namespace std;
+using boost::lexical_cast;
 
 void MemoryLayout::removeTrailingSkips()
 {
@@ -17,14 +19,26 @@ bool MemoryLayout::isMemcpy() const
 {
     return (ops.size() == 2 && ops[0] == MemLayout::FLAG_MEMCPY);
 }
-void MemoryLayout::pushMemcpy(size_t size)
+void MemoryLayout::pushMemcpy(size_t size, vector<uint8_t> const& init_data)
 {
-    pushGenericOp(FLAG_MEMCPY, size);
+    ops.push_back(FLAG_MEMCPY);
+    ops.push_back(size);
+
+    if (init_data.empty())
+        pushInitSkip(size);
+    else
+    {
+        if (size != init_data.size())
+            throw runtime_error("not enough or too many bytes provided as initialization data");
+        pushInit(init_data);
+    }
 }
 
 void MemoryLayout::pushSkip(size_t size)
 {
-    pushGenericOp(FLAG_SKIP, size);
+    ops.push_back(FLAG_SKIP);
+    ops.push_back(size);
+    pushInitSkip(size);
 }
 
 void MemoryLayout::pushEnd()
@@ -32,18 +46,25 @@ void MemoryLayout::pushEnd()
     ops.push_back(FLAG_END);
 }
 
-void MemoryLayout::pushGenericOp(size_t op, size_t size)
+void MemoryLayout::pushGenericOp(size_t op, size_t element)
 {
     ops.push_back(op);
-    ops.push_back(size);
+    ops.push_back(element);
 }
 
 void MemoryLayout::pushArray(Array const& type, MemoryLayout const& array_ops)
 {
+    return pushArray(type.getDimension(), array_ops);
+}
+
+void MemoryLayout::pushArray(size_t dimension, MemoryLayout const& array_ops)
+{
     ops.push_back(FLAG_ARRAY);
-    ops.push_back(type.getDimension());
+    ops.push_back(dimension);
     ops.insert(ops.end(), array_ops.begin(), array_ops.end());
     ops.push_back(FLAG_END);
+    
+    pushInitRepeat(dimension, array_ops);
 }
 
 void MemoryLayout::pushContainer(Container const& type, MemoryLayout const& container_ops)
@@ -52,36 +73,164 @@ void MemoryLayout::pushContainer(Container const& type, MemoryLayout const& cont
     ops.push_back(reinterpret_cast<size_t>(&type));
     ops.insert(ops.end(), container_ops.begin(), container_ops.end());
     ops.push_back(FLAG_END);
+
+    pushInitContainer(type);
 }
 
-bool MemoryLayout::simplifyArray(size_t& memcpy_size, MemoryLayout& merged) const
+void MemoryLayout::pushInit(std::vector<uint8_t> const& data)
 {
-    std::vector<size_t>& merged_ops = merged.ops;
+    pushInitGenericOp(FLAG_INIT, data.size());
+    init_ops.insert(init_ops.end(), data.begin(), data.end());
+}
 
-    if (!merged_ops.empty())
+void MemoryLayout::pushInitSkip(size_t size)
+{
+    pushInitGenericOp(FLAG_INIT_SKIP, size);
+}
+
+void MemoryLayout::pushInitGenericOp(size_t op, size_t size)
+{
+    init_ops.push_back(op);
+    init_ops.push_back(size);
+}
+
+void MemoryLayout::pushInitEnd()
+{
+    init_ops.push_back(FLAG_INIT_END);
+}
+
+void MemoryLayout::pushInitRepeat(size_t dimension, MemoryLayout const& array_ops)
+{
+    pushInitGenericOp(FLAG_INIT_REPEAT, dimension);
+    init_ops.insert(init_ops.end(), array_ops.init_begin(), array_ops.init_end());
+    pushInitEnd();
+}
+
+void MemoryLayout::pushInitContainer(Container const& container)
+{
+    pushInitGenericOp(FLAG_INIT_CONTAINER, reinterpret_cast<Ops::value_type>(&container));
+}
+
+MemoryLayout::Ops MemoryLayout::simplifyInit() const
+{
+    MemoryLayout result;
+    const_iterator end = simplifyInit(init_begin(), init_end(), result, true);
+    if (end != init_end())
+        throw InvalidMemoryLayout("simplifyInit() did not reach the end");
+
+    MemoryLayout::Ops& simplified = result.init_ops;
+    if (simplified.size() == 2 && simplified[0] == FLAG_INIT_SKIP)
+        simplified.clear();
+    return simplified;
+}
+
+MemoryLayout::const_iterator MemoryLayout::simplifyInitBlock(const_iterator it, const_iterator end, MemoryLayout& result) const
+{
+    const_iterator simplify_end = simplifyInit(it, end, result);
+    if (simplify_end == end)
+        throw InvalidMemoryLayout("expected FLAG_INIT_END but reached end of stream");
+    else if (*simplify_end != FLAG_INIT_END)
+        throw InvalidMemoryLayout("expected FLAG_INIT_END got something else");
+    return simplify_end;
+}
+
+MemoryLayout::const_iterator MemoryLayout::simplifyInit(const_iterator it, const_iterator end, MemoryLayout& simplified, bool shave_last_skip) const
+{
+    size_t current_op_count = 0;
+    std::vector<uint8_t> current_init_data;
+    for (; it != end; ++it)
     {
-        size_t last_op = *(merged_ops.rbegin() + 1);
-        if (last_op == FLAG_ARRAY)
+        size_t op   = *it;
+        if (op == FLAG_INIT_END)
         {
-            memcpy_size *= merged_ops.back();
-            merged_ops.pop_back();
-            merged_ops.pop_back();
+            if (current_op_count)
+                simplified.pushInitSkip(current_op_count);
+            else if (!current_init_data.empty())
+                simplified.pushInit(current_init_data);
+            return it;
         }
-        else return false;
+
+        if (op == FLAG_INIT)
+        {
+            if (current_op_count)
+            {
+                simplified.pushInitSkip(current_op_count);
+                current_op_count = 0;
+            }
+            size_t init_size = *(it + 1);
+            current_init_data.insert(current_init_data.end(), it + 2, it + 2 + init_size);
+            it += 1 + init_size;
+            continue;
+        }
+
+        if (!current_init_data.empty())
+        {
+            simplified.pushInit(current_init_data);
+            current_init_data.clear();
+        }
+
+        if (op == FLAG_INIT_REPEAT)
+        {
+            if (current_op_count)
+                simplified.pushInitSkip(current_op_count);
+
+            size_t array_size = *(++it);
+            simplified.pushInitGenericOp(FLAG_INIT_REPEAT, array_size);
+
+            size_t content_i = simplified.init_size();
+            it = simplifyInitBlock(++it, end, simplified);
+            size_t added_ops = simplified.init_size() - content_i;
+            if (added_ops == 2 && simplified.init_ops[content_i] == FLAG_INIT_SKIP)
+            {
+                size_t count = simplified.init_ops[content_i + 1] * array_size;
+                if (current_op_count)
+                {
+                    current_op_count += count;
+                    simplified.init_ops.resize(content_i - 4);
+                }
+                else
+                {
+                    current_op_count = count;
+                    simplified.init_ops.resize(content_i - 2);
+                }
+            }
+            else if (added_ops == 0)
+            {
+                // Void all the modifications we've made so far
+                simplified.init_ops.resize(content_i - 4);
+            }
+            else
+            {
+                simplified.pushInitEnd();
+                current_op_count = 0;
+            }
+        }
+        else if (op == FLAG_INIT_CONTAINER)
+        {
+            if (current_op_count)
+            {
+                simplified.pushInitSkip(current_op_count);
+                current_op_count = 0;
+            }
+            simplified.pushInitGenericOp(FLAG_INIT_CONTAINER, *(++it));
+        }
+        else if (op == FLAG_INIT_SKIP)
+        {
+            current_op_count += *(++it);
+        }
+        else
+            throw InvalidMemoryLayout("found invalid INIT bytecode");
     }
 
-    if (!merged_ops.empty())
+    if (current_op_count && !shave_last_skip)
     {
-        size_t last_op = *(merged_ops.rbegin() + 1);
-        if (last_op == FLAG_MEMCPY)
-        {
-            memcpy_size += merged_ops.back();
-            merged_ops.pop_back();
-            merged_ops.pop_back();
-        }
+        std::cout << "adding " << current_op_count << " " << shave_last_skip << std::endl;
+        simplified.pushInitSkip(current_op_count);
     }
-
-    return true;
+    else if (!current_init_data.empty())
+        simplified.pushInit(current_init_data);
+    
+    return it;
 }
 
 MemoryLayout MemoryLayout::simplify(bool merge_skip_copy) const
@@ -89,66 +238,202 @@ MemoryLayout MemoryLayout::simplify(bool merge_skip_copy) const
     // Merge skips and memcpy: if a skip is preceded by a memcpy (or another
     // skip), simply merge the counts.
     MemoryLayout merged;
+    const_iterator end = simplify(merge_skip_copy, ops.begin(), ops.end(), merged);
+    if (end != ops.end())
+        throw InvalidMemoryLayout("simplify() did not reach the end");
 
-    Ops::const_iterator it = ops.begin();
-    Ops::const_iterator const end = ops.end();
+    merged.init_ops = simplifyInit();
+    return merged;
+}
 
+MemoryLayout::const_iterator MemoryLayout::simplifyBlock(bool merge_skip_copy, const_iterator it, const_iterator end, MemoryLayout& simplified) const
+{
+    const_iterator simplify_end = simplify(merge_skip_copy, it, end, simplified);
+    if (simplify_end == end)
+        throw InvalidMemoryLayout("expected FLAG_END but reached end of stream");
+    else if (*simplify_end != FLAG_END)
+        throw InvalidMemoryLayout("expected FLAG_END got something else");
+    return simplify_end;
+}
+
+MemoryLayout::const_iterator MemoryLayout::simplify(bool merge_skip_copy, const_iterator it, const_iterator end, MemoryLayout& simplified) const
+{
     size_t current_op = FLAG_MEMCPY, current_op_count = 0;
     for (; it != end; ++it)
     {
         size_t op   = *it;
-
-        if (op == FLAG_END && current_op == FLAG_MEMCPY && current_op_count)
+        if (op == FLAG_END)
         {
-            bool simplified = simplifyArray(current_op_count, merged);
-            if (!simplified)
+            if (current_op_count)
+                simplified.pushGenericOp(current_op, current_op_count);
+            return it;
+        }
+
+        if (op == FLAG_ARRAY)
+        {
+            if (current_op_count)
+                simplified.pushGenericOp(current_op, current_op_count);
+
+            size_t array_size = *(++it);
+            simplified.pushGenericOp(FLAG_ARRAY, array_size);
+            size_t content_i = simplified.size();
+            it = simplifyBlock(merge_skip_copy, ++it, end, simplified);
+            size_t added_ops = simplified.size() - content_i;
+
+            // Check whether we should squash the array and its contents.  Note
+            // that the only ops that have one operand are FLAG_SKIP and
+            // FLAG_MEMCPY
+            if (added_ops == 2)
             {
-                merged.pushMemcpy(current_op_count);
-                merged.pushEnd();
+                size_t op    = simplified.ops[content_i];
+                size_t count = simplified.ops[content_i + 1] * array_size;
+
+                // We check whether the operand just before was the same op, in
+                // which case we squash them together as well. Otherwise,
+                // recursive patterns such as
+                //   array
+                //      memcpy
+                //      array
+                //         mempcy
+                //
+                // would not be simplified properly
+                //
+                // Note that we don't squash array with array, as that will be
+                // done when we reach the FLAG_END of the outermost array
+                if (op == current_op && current_op_count)
+                {
+                    current_op_count += count;
+                    simplified.ops.resize(content_i - 4);
+                }
+                else
+                {
+                    current_op = op;
+                    current_op_count = count;
+                    simplified.ops.resize(content_i - 2);
+                }
+            }
+            else if (added_ops == 0)
+            {
+                // Void all the modifications we've made so far
+                simplified.ops.resize(content_i - 4);
+            }
+            else
+            {
+                simplified.pushEnd();
                 current_op_count = 0;
             }
         }
-        else if (op != FLAG_SKIP && op != FLAG_MEMCPY)
+        else if (op == FLAG_CONTAINER)
         {
             if (current_op_count)
             {
-                merged.pushGenericOp(current_op, current_op_count);
+                simplified.pushGenericOp(current_op, current_op_count);
                 current_op_count = 0;
             }
 
-            if (op == FLAG_END)
-                merged.pushEnd();
-            else
-            {
-                ++it;
-                merged.pushGenericOp(op, *it);
-            }
+            simplified.pushGenericOp(FLAG_CONTAINER, *(++it));
+            it = simplifyBlock(merge_skip_copy, ++it, end, simplified);
+            simplified.pushEnd();
         }
+        else if (op == current_op)
+            current_op_count += *(++it);
         else if (merge_skip_copy)
         {
             current_op = FLAG_MEMCPY;
             current_op_count += *(++it);
         }
-        else if (op != current_op)
+        else
         {
             if (current_op_count)
-                merged.pushGenericOp(current_op, current_op_count);
+                simplified.pushGenericOp(current_op, current_op_count);
             current_op = op;
             current_op_count = *(++it);
         }
-        else
-            current_op_count += *(++it);
     }
 
     if (current_op_count)
-        merged.pushGenericOp(current_op, current_op_count);
+        simplified.pushGenericOp(current_op, current_op_count);
 
-    return merged;
+    return it;
 }
 
-void MemoryLayout::display(std::ostream& out) const
+void MemoryLayout::validate() const
 {
-    std::string indent;
+    size_t indent = 0;
+    for (const_iterator it = ops.begin(); it != ops.end(); ++it)
+    {
+        switch(*it)
+        {
+            case FLAG_MEMCPY:
+                ++it;
+                break;
+            case FLAG_SKIP:
+                ++it;
+                break;
+            case FLAG_ARRAY:
+                ++it;
+                ++indent;
+                break;
+            case FLAG_CONTAINER:
+                ++it;
+                ++indent;
+                break;
+            case FLAG_END:
+                if (indent == 0)
+                    throw InvalidMemoryLayout("found FLAG_END without a corresponding start (ARRAY/CONTAINER)");
+                --indent;
+                break;
+            default: 
+                throw InvalidMemoryLayout("found invalid bytecode");
+
+        }
+    }
+
+    if (indent > 0)
+        throw InvalidMemoryLayout("missing FLAG_END: probably an unbalanced ARRAY/CONTAINER");
+
+    for (const_iterator it = init_ops.begin(); it != init_ops.end(); ++it)
+    {
+        switch(*it)
+        {
+            case FLAG_INIT_SKIP:
+                ++it;
+                break;
+            case FLAG_INIT:
+            {
+                size_t size = *(++it);
+                if ((init_ops.end() - it) < static_cast<int>(size))
+                {
+                    throw InvalidMemoryLayout("found a FLAG_INIT block of size " +
+                            lexical_cast<string>(size) + ", but there is only " +
+                            lexical_cast<string>(init_ops.end() - it) + " instructions left in stream");
+                }
+                it += size;
+                break;
+            }
+            case FLAG_INIT_REPEAT:
+                ++it;
+                ++indent;
+                break;
+            case FLAG_INIT_CONTAINER:
+                ++it;
+                break;
+            case FLAG_INIT_END:
+                if (indent == 0)
+                    throw InvalidMemoryLayout("found FLAG_INIT_END without a corresponding FLAG_INIT_REPEAT");
+                --indent;
+                break;
+
+        }
+    }
+
+    if (indent > 0)
+        throw InvalidMemoryLayout("missing FLAG_INIT_END, probably an unbalanced FLAG_INIT_REPEAT");
+}
+
+void MemoryLayout::display(ostream& out) const
+{
+    string indent;
     for (const_iterator it = ops.begin(); it != ops.end(); ++it)
     {
         switch(*it)
@@ -170,6 +455,42 @@ void MemoryLayout::display(std::ostream& out) const
             case FLAG_END:
                 indent = indent.substr(0, indent.size() - 2);
                 out << indent << "FLAG_END" << "\n";
+                break;
+
+        }
+    }
+
+    if (!indent.empty())
+        throw InvalidMemoryLayout("invalid memory layout: probably an unbalanced ARRAY/CONTAINER and END");
+
+    indent = "";
+
+    for (const_iterator it = init_ops.begin(); it != init_ops.end(); ++it)
+    {
+        switch(*it)
+        {
+            case FLAG_INIT_SKIP:
+                out << indent << "FLAG_INIT_SKIP " << *(++it) << "\n";
+                break;
+            case FLAG_INIT:
+            {
+                size_t size = *(++it);
+                out << indent << "FLAG_INIT " << size;
+                for (size_t i = 0; i < size; ++i)
+                    out << " " << hex << "0x" << *(++it);
+                out << dec << "\n";
+                break;
+            }
+            case FLAG_INIT_REPEAT:
+                out << indent << "FLAG_INIT_REPEAT " << *(++it) << "\n";
+                indent += "  ";
+                break;
+            case FLAG_INIT_CONTAINER:
+                out << indent << "FLAG_INIT_CONTAINER " << reinterpret_cast<Type const*>(*(++it))->getName() << "\n";
+                break;
+            case FLAG_INIT_END:
+                indent = indent.substr(0, indent.size() - 2);
+                out << indent << "FLAG_INIT_END" << "\n";
                 break;
 
         }
@@ -215,7 +536,18 @@ bool MemLayout::Visitor::visit_ (Numeric const& type)
 
 bool MemLayout::Visitor::visit_ (Enum    const& type)
 {
-    ops.pushMemcpy(type.getSize());
+    if (type.getSize() > 8)
+        throw runtime_error("cannot handle enum types bigger than 8 bytes");
+
+    vector<uint8_t> init_data;
+    if (!type.values().empty())
+    {
+        uint64_t init_value = type.values().begin()->second;
+        init_data.resize(type.getSize());
+        copy(&init_value, &init_value + 1, init_data.begin());
+    }
+    ops.pushMemcpy(type.getSize(), init_data);
+
     return true;
 }
 bool MemLayout::Visitor::visit_ (Array   const& type)

--- a/typelib/memory_layout.hh
+++ b/typelib/memory_layout.hh
@@ -28,7 +28,40 @@ namespace Typelib
     // pointer on a Container instance
     BOOST_STATIC_ASSERT((sizeof(size_t) == sizeof(void*)));
 
-    typedef std::vector<size_t> MemoryLayout;
+    struct MemoryLayout
+    {
+        typedef std::vector<size_t> Ops;
+
+        std::vector<size_t> ops;
+        typedef std::vector<size_t>::const_iterator const_iterator;
+        typedef std::vector<size_t>::iterator iterator;
+        const_iterator begin() const { return ops.begin(); }
+        const_iterator end() const { return ops.end(); }
+
+        void removeTrailingSkips();
+        void pushMemcpy(size_t size);
+        void pushSkip(size_t size);
+        void pushArray(Array const& type, MemoryLayout const& array_ops);
+        void pushContainer(Container const& type, MemoryLayout const& container_ops);
+        void pushGenericOp(size_t op, size_t size);
+        void pushEnd();
+        bool isMemcpy() const;
+        MemoryLayout simplify(bool merge_skip_copy) const;
+        void display(std::ostream& out) const;
+
+        /** Skips the block starting at \c begin. \c end is the end of the
+         * complete layout (to avoid invalid memory accesses if the layout is
+         * incorrect)
+         *
+         * It returns the position of the block's FLAG_END
+         */
+        static const_iterator skipBlock(
+                const_iterator begin,
+                const_iterator end);
+
+    private:
+        bool simplifyArray(size_t& memcpy_size, MemoryLayout& merged_ops) const;
+    };
 
     /** Namespace used to define basic constants describing the memory layout
      * of a type. The goal is to have a compact representation, in a buffer, of
@@ -65,16 +98,8 @@ namespace Typelib
             MemoryLayout& ops;
             bool   accept_pointers;
             bool   accept_opaques;
-            size_t current_op;
-            size_t current_op_count;
-            bool merge_skip_copy;
 
         protected:
-            void push_current_op();
-            void skip(size_t count);
-            void memcpy(size_t count);
-            void add_generic_op(size_t op, size_t count);
-            bool generic_visit(Type const& value);
             bool visit_ (Numeric const& type);
             bool visit_ (Enum    const& type);
             bool visit_ (Array   const& type);
@@ -83,23 +108,9 @@ namespace Typelib
             bool visit_ (Pointer const& type);
             bool visit_ (OpaqueType const& type);
 
-            void merge_skips_and_copies();
-
         public:
             Visitor(MemoryLayout& ops, bool accept_pointers = false, bool accept_opaques = false);
-
-            void apply(Type const& type, bool merge_skip_copy = true, bool remove_trailing_skips = true);
         };
-
-        /** Skips the block starting at \c begin. \c end is the end of the
-         * complete layout (to avoid invalid memory accesses if the layout is
-         * incorrect)
-         *
-         * It returns the position of the block's FLAG_END
-         */
-        MemoryLayout::const_iterator skip_block(
-                MemoryLayout::const_iterator begin,
-                MemoryLayout::const_iterator end);
     }
 
     /** Returns the memory layout of the given type
@@ -123,8 +134,10 @@ namespace Typelib
     {
         MemoryLayout ret;
         MemLayout::Visitor visitor(ret, accept_pointers, accept_opaques);
-        visitor.apply(t, merge_skip_copy, remove_trailing_skips);
-        return ret;
+        visitor.apply(t);
+        if (remove_trailing_skips)
+            ret.removeTrailingSkips();
+        return ret.simplify(merge_skip_copy);
     }
 }
 

--- a/typelib/memory_layout.hh
+++ b/typelib/memory_layout.hh
@@ -31,23 +31,37 @@ namespace Typelib
     struct MemoryLayout
     {
         typedef std::vector<size_t> Ops;
-
-        std::vector<size_t> ops;
-        typedef std::vector<size_t>::const_iterator const_iterator;
-        typedef std::vector<size_t>::iterator iterator;
+        typedef Ops::const_iterator const_iterator;
+        Ops ops;
         const_iterator begin() const { return ops.begin(); }
-        const_iterator end() const { return ops.end(); }
+        const_iterator end() const   { return ops.end(); }
+        size_t size() const { return ops.size(); }
+
+        Ops init_ops;
+        const_iterator init_begin() const { return init_ops.begin(); }
+        const_iterator init_end() const   { return init_ops.end(); }
+        size_t init_size() const { return init_ops.size(); }
 
         void removeTrailingSkips();
-        void pushMemcpy(size_t size);
+        void pushMemcpy(size_t size,
+                std::vector<uint8_t> const& init_data = std::vector<uint8_t>());
         void pushSkip(size_t size);
+        void pushArray(size_t dimension, MemoryLayout const& array_ops);
         void pushArray(Array const& type, MemoryLayout const& array_ops);
         void pushContainer(Container const& type, MemoryLayout const& container_ops);
         void pushGenericOp(size_t op, size_t size);
         void pushEnd();
         bool isMemcpy() const;
         MemoryLayout simplify(bool merge_skip_copy) const;
+        void validate() const;
         void display(std::ostream& out) const;
+
+        void pushInit(std::vector<uint8_t> const& data);
+        void pushInitSkip(size_t size);
+        void pushInitGenericOp(size_t op, size_t size);
+        void pushInitRepeat(size_t dimension, MemoryLayout const& array_ops);
+        void pushInitContainer(Container const& container);
+        void pushInitEnd();
 
         /** Skips the block starting at \c begin. \c end is the end of the
          * complete layout (to avoid invalid memory accesses if the layout is
@@ -60,7 +74,14 @@ namespace Typelib
                 const_iterator end);
 
     private:
+        const_iterator simplify(bool merge_skip_copy, const_iterator it, const_iterator end, MemoryLayout& simplified) const;
+        const_iterator simplifyBlock(bool merge_skip_copy, const_iterator it, const_iterator end, MemoryLayout& simplified) const;
+        const_iterator simplifyInit(const_iterator it, const_iterator end, MemoryLayout& result, bool shave_last_skip = false) const;
+        const_iterator simplifyInitBlock(const_iterator it, const_iterator end, MemoryLayout& result) const;
+        size_t m_offset;
         bool simplifyArray(size_t& memcpy_size, MemoryLayout& merged_ops) const;
+        bool simplifyInitRepeat(size_t& size, Ops& result) const;
+        MemoryLayout::Ops simplifyInit() const;
     };
 
     /** Namespace used to define basic constants describing the memory layout
@@ -84,6 +105,14 @@ namespace Typelib
             FLAG_CONTAINER,
             FLAG_SKIP,
             FLAG_END
+        };
+
+        enum InitOperations {
+            FLAG_INIT,
+            FLAG_INIT_REPEAT,
+            FLAG_INIT_CONTAINER = FLAG_CONTAINER,
+            FLAG_INIT_SKIP = FLAG_SKIP,
+            FLAG_INIT_END  = FLAG_END
         };
 
         /** This visitor computes the memory layout for a given type. This memory
@@ -113,6 +142,14 @@ namespace Typelib
         };
     }
 
+    inline MemoryLayout raw_layout_of(Type const& t, bool accept_pointers = false, bool accept_opaques = false)
+    {
+        MemoryLayout ret;
+        MemLayout::Visitor visitor(ret, accept_pointers, accept_opaques);
+        visitor.apply(t);
+        return ret;
+    }
+
     /** Returns the memory layout of the given type
      *
      * @param accept_pointers if false (the default), will throw a NoLayout
@@ -132,9 +169,7 @@ namespace Typelib
      */
     inline MemoryLayout layout_of(Type const& t, bool accept_pointers = false, bool accept_opaques = false, bool merge_skip_copy = true, bool remove_trailing_skips = true)
     {
-        MemoryLayout ret;
-        MemLayout::Visitor visitor(ret, accept_pointers, accept_opaques);
-        visitor.apply(t);
+        MemoryLayout ret = raw_layout_of(t, accept_pointers, accept_opaques);
         if (remove_trailing_skips)
             ret.removeTrailingSkips();
         return ret.simplify(merge_skip_copy);

--- a/typelib/memory_layout.hh
+++ b/typelib/memory_layout.hh
@@ -24,6 +24,16 @@ namespace Typelib
         UnknownLayoutBytecode() : std::runtime_error("found an unknown marshalling bytecode operation") { }
     };
 
+    /** Exception thrown when processing a MemoryLayout and it appears that it
+     * is invalid
+     */
+    class InvalidMemoryLayout : public std::runtime_error
+    {
+        public:
+            InvalidMemoryLayout(std::string const& msg)
+                : std::runtime_error(msg) {}
+    };
+
     // This is needed because the FLAG_CONTAINER descriptor is followed by a
     // pointer on a Container instance
     BOOST_STATIC_ASSERT((sizeof(size_t) == sizeof(void*)));

--- a/typelib/value_ops.cc
+++ b/typelib/value_ops.cc
@@ -77,7 +77,7 @@ boost::tuple<size_t, MemoryLayout::const_iterator> ValueOps::dump(
                 size_t element_count = *(++it);
                 MemoryLayout::const_iterator element_it = ++it;
                 if (element_count == 0)
-                    it = MemLayout::skip_block(element_it, end);
+                    it = MemoryLayout::skipBlock(element_it, end);
                 else
                 {
                     for (size_t i = 0; i < element_count; ++i)
@@ -106,7 +106,7 @@ boost::tuple<size_t, MemoryLayout::const_iterator> ValueOps::dump(
                 stream.write(reinterpret_cast< boost::uint8_t* >(&element_count), sizeof(element_count));
 
                 if (element_count == 0)
-                    it = MemLayout::skip_block(++it, end);
+                    it = MemoryLayout::skipBlock(++it, end);
                 else
                     it = type->dump(container_ptr, element_count, stream, ++it, end);
 
@@ -144,7 +144,7 @@ boost::tuple<size_t, MemoryLayout::const_iterator> ValueOps::load(
                 MemoryLayout::const_iterator element_it = ++it;
 
                 if (element_count == 0)
-                    it = MemLayout::skip_block(element_it, end);
+                    it = MemoryLayout::skipBlock(element_it, end);
                 else
                 {
                     for (size_t i = 0; i < element_count; ++i)
@@ -172,7 +172,7 @@ boost::tuple<size_t, MemoryLayout::const_iterator> ValueOps::load(
                 boost::uint64_t element_count;
                 stream.read(reinterpret_cast< boost::uint8_t* >(&element_count), sizeof( boost::uint64_t ));
                 if (element_count == 0)
-                    it = MemLayout::skip_block(++it, end);
+                    it = MemoryLayout::skipBlock(++it, end);
                 else
                 {
                     it = type->load(container_ptr, element_count, stream, ++it, end);
@@ -193,7 +193,7 @@ boost::tuple<size_t, MemoryLayout::const_iterator> ValueOps::load(
 
 void Typelib::init(Value v)
 {
-    MemoryLayout ops = layout_of(v.getType(), true);
+    MemoryLayout ops = layout_of(v.getType());
     init(v, ops);
 }
 
@@ -210,7 +210,7 @@ void Typelib::init(boost::uint8_t* data, MemoryLayout const& ops)
 
 void Typelib::zero(Value v)
 {
-    MemoryLayout ops = layout_of(v.getType(), true);
+    MemoryLayout ops = layout_of(v.getType());
     zero(v, ops);
 }
 
@@ -228,7 +228,7 @@ void Typelib::zero(boost::uint8_t* data, MemoryLayout const& ops)
 void Typelib::destroy(Value v)
 {
     boost::uint8_t* buffer = reinterpret_cast< boost::uint8_t* >(v.getData());
-    MemoryLayout ops = layout_of(v.getType(), true);
+    MemoryLayout ops = layout_of(v.getType());
     destroy(buffer, ops);
 }
 
@@ -277,13 +277,11 @@ bool Typelib::compare(void* dst, void* src, Type const& type)
     boost::uint8_t* out_buffer = reinterpret_cast< boost::uint8_t* >(dst);
     boost::uint8_t* in_buffer  = reinterpret_cast< boost::uint8_t* >(src);
 
-    MemoryLayout ret;
-    MemLayout::Visitor visitor(ret);
-    visitor.apply(type, false);
+    MemoryLayout layout = layout_of(type, true, false, false, true);
 
     bool is_equal;
     boost::tie(is_equal, boost::tuples::ignore, boost::tuples::ignore, boost::tuples::ignore) =
-        ValueOps::compare(out_buffer, in_buffer, ret.begin(), ret.end());
+        ValueOps::compare(out_buffer, in_buffer, layout.begin(), layout.end());
     return is_equal;
 }
 
@@ -323,7 +321,7 @@ boost::tuple< boost::uint8_t*, MemoryLayout::const_iterator>
             {
                 Container const* type = reinterpret_cast<Container const*>(*(++it));
                 type->clear(buffer);
-                it = MemLayout::skip_block(++it, end);
+                it = MemoryLayout::skipBlock(++it, end);
                 buffer += type->getSize();
                 break;
             }
@@ -372,7 +370,7 @@ boost::tuple< boost::uint8_t*, MemoryLayout::const_iterator>
             {
                 Container const* type = reinterpret_cast<Container const*>(*(++it));
                 type->init(buffer);
-                it = MemLayout::skip_block(++it, end);
+                it = MemoryLayout::skipBlock(++it, end);
                 buffer += type->getSize();
                 break;
             }
@@ -420,7 +418,7 @@ boost::tuple< boost::uint8_t*, MemoryLayout::const_iterator>
             {
                 Container const* type = reinterpret_cast<Container const*>(*(++it));
                 type->destroy(buffer);
-                it = MemLayout::skip_block(it, end);
+                it = MemoryLayout::skipBlock(it, end);
                 buffer += type->getSize();
                 break;
             }
@@ -477,7 +475,7 @@ boost::tuple< boost::uint8_t*, boost::uint8_t*, MemoryLayout::const_iterator>
             {
                 Container const* type = reinterpret_cast<Container const*>(*(++it));
                 type->copy(out_buffer, in_buffer);
-                it = MemLayout::skip_block(it, end);
+                it = MemoryLayout::skipBlock(it, end);
                 out_buffer += type->getSize();
                 in_buffer  += type->getSize();
                 break;
@@ -546,7 +544,7 @@ boost::tuple<bool, boost::uint8_t*, boost::uint8_t*, MemoryLayout::const_iterato
                     return boost::make_tuple(false, (boost::uint8_t *)NULL,
                                              (boost::uint8_t *)NULL, end);
 
-                it = MemLayout::skip_block(it, end);
+                it = MemoryLayout::skipBlock(it, end);
                 out_buffer += type->getSize();
                 in_buffer  += type->getSize();
                 break;
@@ -698,9 +696,7 @@ void Typelib::dump(boost::uint8_t const* v, FILE* fd, MemoryLayout const& ops)
  */
 void Typelib::dump(Value v, OutputStream& stream)
 {
-    MemoryLayout ops;
-    MemLayout::Visitor visitor(ops);
-    visitor.apply(v.getType());
+    MemoryLayout ops = layout_of(v.getType());
     return dump(v, stream, ops);
 }
 void Typelib::dump(Value v, OutputStream& stream, MemoryLayout const& ops)
@@ -741,9 +737,7 @@ struct ByteArrayOutputStream : public OutputStream
 };
 int Typelib::dump(Value v, boost::uint8_t* buffer, unsigned int buffer_size)
 {
-    MemoryLayout ops;
-    MemLayout::Visitor visitor(ops);
-    visitor.apply(v.getType());
+    MemoryLayout ops = layout_of(v.getType());
     return dump(v, buffer, buffer_size, ops);
 }
 
@@ -784,9 +778,7 @@ struct ByteCounterStream : public OutputStream
 };
 size_t Typelib::getDumpSize(Value v)
 { 
-    MemoryLayout ops;
-    MemLayout::Visitor visitor(ops);
-    visitor.apply(v.getType());
+    MemoryLayout ops = layout_of(v.getType());
     return getDumpSize(v, ops);
 }
 size_t Typelib::getDumpSize(Value v, MemoryLayout const& ops)


### PR DESCRIPTION
This PR implements a more generic initialization method than what was there before. MemoryLayout now contains data layout information (for memcpy/delete/...) but also init information which directs both the container initialization and the initialization of arbitrary parts of the data in memory.

It's used to initialize enums. Enums are the only data values right now that cannot be initialized randomly as the set of values they can take is restricted.