### PR TITLE
Enable compatibility with newer clang versions

### DIFF
--- a/bindings/ruby/lib/typelib/clang.rb
+++ b/bindings/ruby/lib/typelib/clang.rb
@@ -88,12 +88,12 @@ module Typelib
             elsif system("which clang > /dev/null 2>&1")
                 IO.popen(['clang', '--version']) do |clang_io|
                     clang_version = clang_io.read
-                    if clang_version.include?('clang version 3.4')
+                    if clang_version.include?('clang version 3.')
                         return "clang"
                     end
                 end
             end
-            raise RuntimeError, "Couldn't find clang 3.4 compiler binary!"
+            raise RuntimeError, "Couldn't find clang 3.x compiler binary!"
         end
 
         # NOTE: preprocessing of a group of header-files by the actual compiler


### PR DESCRIPTION
Ubuntu 16.04 only provide clang versions 3.5, 3.6, 3.7 and 3.8.

This patch lets typelib accept any 3.x version (if need be, this should be replaced by a regex for 3.4 or newer