### PR TITLE
castxml: fix corner case in opaque resolution

### DIFF
--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -718,7 +718,7 @@ module Typelib
 
         def find_node_by_name(typename, node_type: nil)
             if node = info.name_to_nodes[typename].first
-                return node
+                return node if !node_type || (node.name == node_type)
             else
                 basename, context = resolve_namespace_of(typename)
                 return if !context
@@ -809,6 +809,8 @@ module Typelib
         end
 
         IGNORED_NODES = %w{Method OperatorMethod Destructor Constructor Function OperatorFunction}.to_set
+
+        attr_writer :info
 
         def load(required_files, xml)
             @registry = Typelib::Registry.new

--- a/test/ruby/cxx_common_tests.rb
+++ b/test/ruby/cxx_common_tests.rb
@@ -171,4 +171,9 @@ module CXXCommonTests
         reg = Typelib::Registry.import File.join(cxx_test_dir, 'documentation_utf8.h'), 'c', cxx_importer: loader
         assert_equal ["this is a \u9999 multiline with \u1290 unicode characters"], reg.get('/DocumentedType').metadata.get('doc')
     end
+
+    def test_resolves_opaques_to_their_true_name
+        registry = Typelib::Registry.new
+        registry.import(File.join(cxx_test_dir, 'bug_opaque_import.hh'), 'c', cxx_importer: loader, opaques: ['/OpaquePoint'])
+    end
 end

--- a/test/ruby/cxx_import_tests/bug_opaque_import.hh
+++ b/test/ruby/cxx_import_tests/bug_opaque_import.hh
@@ -1,0 +1,27 @@
+#ifndef OPAQUES_HH
+#define OPAQUES_HH
+
+class OpaquePoint
+{
+    int padding; // to make sure that OpaquePoint and Point do not look the same
+    int _x, _y;
+public:
+    OpaquePoint(int x = 0, int y = 0)
+        : _x(x), _y(y) {}
+
+    int x() const { return _x; }
+    int y() const { return _y; }
+};
+
+struct OpaqueContainingType
+{
+    OpaquePoint field;
+};
+
+struct NonExportedType
+{
+    OpaquePoint field;
+};
+
+#endif
+

--- a/test/ruby/test_cxx_castxml.rb
+++ b/test/ruby/test_cxx_castxml.rb
@@ -1,16 +1,39 @@
 require 'typelib/test'
 require_relative './cxx_common_tests'
 require_relative './cxx_gccxml_common'
+require 'typelib/gccxml'
 
-class TC_CXX_CastXML < Minitest::Test
-    include Typelib
-    include CXXCommonTests
+module Typelib
+    describe CastXMLLoader do
+        include Typelib
+        include CXXCommonTests
 
-    def setup
-        super
-        setup_loader 'castxml'
+        before do
+            setup_loader 'castxml'
+        end
+
+        describe "#find_node_by_name" do
+            attr_reader :parser, :info
+            before do
+                @parser = loader.new
+                @info = GCCXMLInfo.new(Array.new)
+                parser.info = info
+            end
+
+            it "resolves from cache" do
+                expected = flexmock
+                info.name_to_nodes['test'] = [expected]
+                assert_equal expected, parser.find_node_by_name('test')
+            end
+            it "filters on node_type when resolving from cache" do
+                expected = flexmock
+                expected.should_receive(name: 'Test')
+                expected.name
+                info.name_to_nodes['test'] = [expected]
+                assert_equal expected, parser.find_node_by_name('test', node_type: 'Test')
+                refute parser.find_node_by_name('test', node_type: 'Another')
+            end
+        end
     end
-
-    include CXX_GCCXML_Common
 end
 


### PR DESCRIPTION
find_node_by_name would fail to filter on node_type when the node could
be resolved directly. This would lead to the opaque resolution assuming
that it is a typedef, and then usage of a nil value