### PR TITLE
Extends type-display.

### DIFF
--- a/typelib/typedisplay.cc
+++ b/typelib/typedisplay.cc
@@ -49,7 +49,7 @@ bool TypeDisplayVisitor::visit_(Compound const& type, Field const& field)
 { 
     m_stream << m_indent << "(+" << field.getOffset() << ") ";
     TypeVisitor::visit_(type, field);
-    m_stream << "\n";
+    m_stream << " " << field.getName() << std::endl;
     return true;
 }
 
@@ -72,7 +72,7 @@ bool TypeDisplayVisitor::visit_(Numeric const& type)
     };
 
     m_stream
-        << name << "(" << type.getSize() << ")";
+        << name << "(" << type.getSize() << ") (" << type.getName() << ")";
     return true;
 }
 
@@ -103,4 +103,8 @@ bool TypeDisplayVisitor::visit_(Array const& type)
     return true;
 }
 
-
+bool TypeDisplayVisitor::visit_(Container const& type)
+{
+    m_stream << "container " << type.kind() << "<" << type.getIndirection().getName() << ">";
+    return true;
+}

--- a/typelib/typedisplay.hh
+++ b/typelib/typedisplay.hh
@@ -29,6 +29,7 @@ namespace Typelib
        
         bool visit_(Pointer const& type);
         bool visit_(Array const& type);
+        bool visit_(Container const& type);
 
     public:
         TypeDisplayVisitor(std::ostream& stream, std::string const& base_indent);


### PR DESCRIPTION
Adds the missing visit method for containers and adds some more output-informations to compound and numeric.

Example for new output:

compound /base/samples/Pointcloud_m [56] {
    (+0) compound /base/Time [8] {
      (+0) sint(8) (/int64_t) microseconds
    }; time
    (+8) container /std/vector</wrappers/Matrix</double,3,1>> points
    (+32) container /std/vector</wrappers/Matrix</double,4,1>> colors
  };