### PR TITLE
fix null type equality to only compare on name

### DIFF
--- a/test/ruby/test_specialized_types.rb
+++ b/test/ruby/test_specialized_types.rb
@@ -485,6 +485,18 @@ class TC_SpecializedTypes < Minitest::Test
         assert(null.null?)
     end
 
+    def test_null_type_equality
+        registry = Typelib::Registry.new
+        void_t = registry.create_null('/void')
+        nil_t  = registry.create_null('/nil')
+        other_registry = Typelib::Registry.new
+        other_void_t = other_registry.create_null('/void')
+
+        assert_equal void_t, other_void_t
+        refute_equal void_t, nil_t
+        refute_equal other_void_t, nil_t
+    end
+
     def test_containers
         std = make_registry.get("StdCollections")
         assert(std[:dbl_vector] < Typelib::ContainerType)

--- a/typelib/typemodel.hh
+++ b/typelib/typemodel.hh
@@ -256,6 +256,8 @@ namespace Typelib
     public:
         NullType(std::string const& name) : Type(name, 0, Type::NullType ) {}
 	virtual std::set<Type const*> dependsOn() const { return std::set<Type const*>(); }
+	virtual bool do_compare(Type const& other, bool equality, std::map<Type const*, Type const*>& stack) const
+        { return other.getName() == getName(); }
 
     private:
 	virtual Type* do_merge(Registry& registry, RecursionStack& stack) const { return new NullType(*this); }


### PR DESCRIPTION
The default equality would lead to having all null types be equal.
