### PR TITLE
ruby: allow to reset an existing export with reset_registry_export

### DIFF
--- a/bindings/ruby/lib/typelib/registry.rb
+++ b/bindings/ruby/lib/typelib/registry.rb
@@ -109,7 +109,7 @@ module Typelib
         # which it should be done is given in +base_module+
         def export_to_ruby(base_module, options = Hash.new, &block)
             base_module.extend RegistryExport
-            base_module.reset_registry_export(self, block)
+            base_module.reset_registry_export(self, block, '/')
         end
 
 	# Returns the file type as expected by Typelib from 

--- a/bindings/ruby/lib/typelib/registry_export.rb
+++ b/bindings/ruby/lib/typelib/registry_export.rb
@@ -7,7 +7,7 @@ module Typelib
 
             include RegistryExport
 
-            def reset_registry_export(registry, filter_block, typename_prefix = '/')
+            def reset_registry_export(registry = self.registry, *)
                 @registry = registry
                 super
             end
@@ -37,9 +37,11 @@ module Typelib
         attr_reader :__typelib_registry_export_typename_prefix
         attr_reader :__typelib_registry_export_filter_block
 
-        def reset_registry_export(registry, filter_block, typename_prefix = '/')
+        def reset_registry_export(registry = self.registry,
+                                  filter_block = @__typelib_registry_export_filter_block,
+                                  typename_prefix = @__typelib_registry_export_typename_prefix)
             if registry && (self.registry != registry)
-                raise RuntimeError, "setting up #{self} to be an export type from #{registry}, but it is a type from #{self.registry}"
+                raise RuntimeError, "setting up #{self} to be an export type from #{registry}, but it is already exporting types from #{self.registry}"
             end
 
             @__typelib_registry_export_filter_block = filter_block
@@ -48,7 +50,9 @@ module Typelib
         end
 
         def initialize_registry_export(mod, name)
-            reset_registry_export(mod.registry, mod.__typelib_registry_export_filter_block, "#{mod.__typelib_registry_export_typename_prefix}#{name}/")
+            reset_registry_export(mod.registry,
+                                  mod.__typelib_registry_export_filter_block,
+                                  "#{mod.__typelib_registry_export_typename_prefix}#{name}/")
         end
 
         def disable_registry_export
@@ -131,7 +135,7 @@ module Typelib
 
                 attr_reader :registry
 
-                def reset_registry_export(registry, filter_block, typename_prefix = '/')
+                def reset_registry_export(registry = self.registry, *args)
                     @registry = registry
                     super
                 end


### PR DESCRIPTION
The call was so far used to reset-and-setup. One can now, by
calling it without arguments, just reset the export when e.g.
the registry itself is reset.