### PR TITLE
PluginManager: Replace broken singleton by working one

### DIFF
--- a/test/test_containers.cc
+++ b/test/test_containers.cc
@@ -66,8 +66,8 @@ static void import_test_types(Registry& registry)
     static const char* test_file = TEST_DATA_PATH("test_cimport.tlb");
 
     utilmm::config_set config;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     BOOST_REQUIRE_NO_THROW( importer->load(test_file, config, registry) );
 }
 

--- a/test/test_display.cc
+++ b/test/test_display.cc
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(test_csv)
     {
 	// Get the test file into repository
 	utilmm::config_set config;
-	auto_ptr<Registry> registry(PluginManager::self()->load("tlb", TEST_DATA_PATH("test_cimport.tlb"), config));
+	auto_ptr<Registry> registry(PluginManager::getInstance().load("tlb", TEST_DATA_PATH("test_cimport.tlb"), config));
 
 	{
 	    ostringstream stream;

--- a/test/test_lang_tlb.cc
+++ b/test/test_lang_tlb.cc
@@ -19,34 +19,34 @@ using namespace std;
 #ifdef HAS_INTERNAL_CPARSER
 BOOST_AUTO_TEST_CASE( test_tlb_rejects_recursive_types )
 {
-    PluginManager::self manager;
+    PluginManager &manager(PluginManager::getInstance());
     Registry registry;
 
     static const char* test_file = TEST_DATA_PATH("test_cimport.1");
     utilmm::config_set config;
-    manager->load("c", test_file, config, registry);
+    manager.load("c", test_file, config, registry);
 
-    BOOST_REQUIRE_THROW(manager->save("tlb", registry), ExportError);
+    BOOST_REQUIRE_THROW(manager.save("tlb", registry), ExportError);
 }
 #endif
 
 BOOST_AUTO_TEST_CASE( test_tlb_idempotent )
 {
-    PluginManager::self manager;
+    PluginManager &manager(PluginManager::getInstance());
     Registry registry;
 
     static const char* test_file = TEST_DATA_PATH("test_cimport.tlb");
     {
         utilmm::config_set config;
-        manager->load("tlb", test_file, config, registry);
+        manager.load("tlb", test_file, config, registry);
     }
 
     string result;
-    result = manager->save("tlb", registry);
+    result = manager.save("tlb", registry);
     istringstream io(result);
     utilmm::config_set config;
     Registry* reloaded = NULL;
-    reloaded = manager->load("tlb", io, config);
+    reloaded = manager.load("tlb", io, config);
 
     if (!registry.isSame(*reloaded))
     {
@@ -68,8 +68,8 @@ BOOST_AUTO_TEST_CASE( test_tlb_idempotent )
 
 BOOST_AUTO_TEST_CASE( test_tlb_import )
 {
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
 
     {

--- a/test/test_marshalling.cc
+++ b/test/test_marshalling.cc
@@ -19,8 +19,9 @@ BOOST_AUTO_TEST_CASE( test_marshalling_simple )
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 
@@ -148,8 +149,9 @@ BOOST_AUTO_TEST_CASE(test_marshalapply_containers)
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 

--- a/test/test_memory_layout.cc
+++ b/test/test_memory_layout.cc
@@ -48,8 +48,8 @@ static Registry& getRegistry()
 {
     static Registry registry;
 
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
     return registry;
@@ -119,8 +119,9 @@ BOOST_AUTO_TEST_CASE(test_layout_arrays)
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 
@@ -188,8 +189,9 @@ BOOST_AUTO_TEST_CASE(test_layout_array_of_containers)
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 
@@ -225,8 +227,9 @@ BOOST_AUTO_TEST_CASE(test_layout_containers)
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 

--- a/test/test_plugin.cc
+++ b/test/test_plugin.cc
@@ -7,7 +7,7 @@ using namespace Typelib;
 
 BOOST_AUTO_TEST_CASE( test_manager )
 {
-    PluginManager::self manager;
-    BOOST_REQUIRE_THROW(manager->importer("BLAH"), PluginNotFound);
+    PluginManager &manager(PluginManager::getInstance());
+    BOOST_REQUIRE_THROW(manager.importer("BLAH"), PluginNotFound);
 }
 

--- a/test/test_registry.cc
+++ b/test/test_registry.cc
@@ -208,9 +208,9 @@ BOOST_AUTO_TEST_CASE( test_repositories_merge )
     static const char* test_file = TEST_DATA_PATH("test_cimport.tlb");
 
     utilmm::config_set config;
-    PluginManager::self manager;
+    PluginManager &manager(PluginManager::getInstance());
 
-    std::auto_ptr<Registry> ref( manager->load("tlb", test_file, config));
+    std::auto_ptr<Registry> ref( manager.load("tlb", test_file, config));
     Registry target;
     target.merge(*ref);
     assert_registries_equal(target, *ref);

--- a/test/test_value.cc
+++ b/test/test_value.cc
@@ -37,8 +37,8 @@ BOOST_AUTO_TEST_CASE( test_value_struct )
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 
@@ -107,8 +107,8 @@ BOOST_AUTO_TEST_CASE( test_value_endian_swap )
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 
@@ -142,8 +142,8 @@ BOOST_AUTO_TEST_CASE( test_compile_endian_swap )
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 
@@ -238,8 +238,8 @@ BOOST_AUTO_TEST_CASE( test_apply_endian_swap )
 {
     // Get the test file into repository
     Registry registry;
-    PluginManager::self manager;
-    auto_ptr<Importer> importer(manager->importer("tlb"));
+    PluginManager &manager(PluginManager::getInstance());
+    auto_ptr<Importer> importer(manager.importer("tlb"));
     utilmm::config_set config;
     BOOST_REQUIRE_NO_THROW( importer->load(TEST_DATA_PATH("test_cimport.tlb"), config, registry) );
 

--- a/typelib/pluginmanager.cc
+++ b/typelib/pluginmanager.cc
@@ -6,10 +6,13 @@
 #include <boost/filesystem.hpp>
 #include <boost/version.hpp>
 #include <dlfcn.h>
+#include <iostream>
 
 using namespace std;
 using namespace Typelib;
 using namespace boost::filesystem;
+
+PluginManager *PluginManager::instance = NULL;
 
 namespace
 {
@@ -173,7 +176,7 @@ void PluginManager::save(std::string const& kind, Registry const& registry, std:
 }
 void PluginManager::save(std::string const& kind, utilmm::config_set const& config, Registry const& registry, std::ostream& into)
 {
-    auto_ptr<Exporter> exporter(PluginManager::self()->exporter(kind));
+    auto_ptr<Exporter> exporter(PluginManager::getInstance().exporter(kind));
     exporter->save(into, config, registry);
 }
 
@@ -207,7 +210,7 @@ Registry* PluginManager::load(std::string const& kind, std::istream& stream, uti
 void PluginManager::load(std::string const& kind, std::istream& stream, utilmm::config_set const& config
         , Registry& into )
 {
-    std::auto_ptr<Importer> importer(PluginManager::self()->importer(kind));
+    std::auto_ptr<Importer> importer(PluginManager::getInstance().importer(kind));
     importer->load(stream, config, into);
 }
 Registry* PluginManager::load(std::string const& kind, std::string const& file, utilmm::config_set const& config)
@@ -219,7 +222,14 @@ Registry* PluginManager::load(std::string const& kind, std::string const& file, 
 void PluginManager::load(std::string const& kind, std::string const& file, utilmm::config_set const& config
         , Registry& into)
 {
-    auto_ptr<Importer> importer(PluginManager::self()->importer(kind));
+    auto_ptr<Importer> importer(PluginManager::getInstance().importer(kind));
     importer->load(file, config, into);
 }
 
+PluginManager& PluginManager::getInstance()
+{
+    if(instance == NULL)
+        instance = new PluginManager();
+    
+    return *instance;
+}

--- a/typelib/pluginmanager.hh
+++ b/typelib/pluginmanager.hh
@@ -4,7 +4,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <typelib/utilmm/singleton/use.hh>
 #include <typelib/utilmm/configset.hh>
 #include <stdexcept>
 
@@ -182,13 +181,10 @@ namespace Typelib
             , utilmm::config_set const& config
             , Registry& into );
 
-	/** The one PluginManager object. See main PluginManager documentation
-	 * for its use.
-	 */
-        typedef utilmm::singleton::use<PluginManager> self;
-
+        static PluginManager& getInstance();
+            
     private:
-        friend class utilmm::singleton::wrapper<PluginManager>;
+        static PluginManager *instance;
     };
 }
 

--- a/typelib/registry.cc
+++ b/typelib/registry.cc
@@ -53,8 +53,8 @@ namespace Typelib
     Registry::Registry()
         : m_global(nameSort)
     { 
-        PluginManager::self manager;
-        manager->registerPluginTypes(*this);
+        PluginManager &manager(PluginManager::getInstance());
+        manager.registerPluginTypes(*this);
         setDefaultNamespace("/");
     }
     Registry::~Registry() { clear(); }


### PR DESCRIPTION
The singleton of the pluginmanager was not working, this 
lead to multiple loads of the plugins.