### PR TITLE
Activation of C++11 features in castxml

### DIFF
--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -933,7 +933,7 @@ module Typelib
         #
         # Raises RuntimeError if casrxml failed to run
         def self.castxml(file, options)
-            cmdline = [castxml_binary_name, *castxml_default_options, "--castxml-gccxml", '-x', 'c++']
+            cmdline = [castxml_binary_name, *castxml_default_options, "--castxml-gccxml", '-x', 'c++','-std=c++11']
             required_files = (options[:required_files] || [file])
             if raw = options[:rawflags]
                 cmdline.concat(raw)


### PR DESCRIPTION
Got a very simple type such as this one using C++11 features:

`MyHeader.hpp`:
```
#ifndef MYHEADER_HPP_
#define MYHEADER_HPP_

enum class MyCPP11Enum{
    VALUE = 1
};

bool my_func(MyCPP11Enum en){
    switch(en){
    case MyCPP11Enum::VALUE:
        return true;
    default:
        return false;
    }
}
#endif
```

When running `typelib` on this using `castxml` gives a warning that C++11 extensions are used for the defined Enum and also an error in the function that uses the Enum:
```
wirkus@mwirkus-lap-u:test$ typegen $PWD/bla /$PWD/MyHeader.hpp
/media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/gccxml.rb:1039: warning: Insecure world writable dir /media/wirkus/Data/development/d-rock/base/admin_scripts/bin in PATH, mode 040777
/media/wirkus/Data/development/test/bla/types/media/wirkus/Data/development/test/bla/test/MyHeader.hpp:4:6: warning: 
      scoped enumerations are a C++11 extension [-Wc++11-extensions]
enum class MyCPP11Enum{
     ^
/media/wirkus/Data/development/test/bla/types/media/wirkus/Data/development/test/bla/test/MyHeader.hpp:10:10: warning: 
      use of enumeration in a nested name specifier is a C++11 extension [-Wc++11-extensions]
    case MyCPP11Enum::VALUE:
         ^
/media/wirkus/Data/development/test/bla/types/media/wirkus/Data/development/test/bla/test/MyHeader.hpp:10:10: error: 
      expression is not an integral constant expression
    case MyCPP11Enum::VALUE:
         ^~~~~~~~~~~~~~~~~~
2 warnings and 1 error generated.
/media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/gccxml.rb:957:in `block (2 levels) in castxml': cannot load one of the header files /media/wirkus/Data/development/test/bla/types/media/wirkus/Data/development/test/bla/test/MyHeader.hpp: gccxml returned an error while parsing /media/wirkus/Data/development/test/bla/types/media/wirkus/Data/development/test/bla/test/MyHeader.hpp with call castxml --castxml-gccxml -x c++ -DOROCOS_TARGET=gnulinux -D__orogen2 -I/media/wirkus/Data/development/test/bla/types -I/media/wirkus/Data/development -I/media/wirkus/Data/development/test/bla/types  (ArgumentError)
	from /usr/lib/ruby/2.3.0/tempfile.rb:295:in `open'
	from /media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/gccxml.rb:955:in `block in castxml'
	from /media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/gccxml.rb:954:in `map'
	from /media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/gccxml.rb:954:in `castxml'
	from /media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/gccxml.rb:1008:in `load'
	from /media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/gccxml.rb:1054:in `load'
	from /media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/cxx.rb:117:in `load'
	from /media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/registry.rb:225:in `call'
	from /media/wirkus/Data/development/d-rock/install/lib/ruby/2.3.0/typelib/registry.rb:225:in `import'
	from /media/wirkus/Data/development/d-rock/tools/orogen/lib/orogen/gen/typekit.rb:1523:in `block in perform_pending_loads'
	from /usr/lib/ruby/2.3.0/tempfile.rb:295:in `open'
	from /media/wirkus/Data/development/d-rock/tools/orogen/lib/orogen/gen/typekit.rb:1518:in `perform_pending_loads'
	from /media/wirkus/Data/development/d-rock/tools/orogen/lib/orogen/gen/typekit.rb:1952:in `generate'
	from /media/wirkus/Data/development/d-rock/tools/orogen/bin/typegen:116:in `<main>'
wirkus@mwirkus-lap-u:test$ 
```

Passing the command line argument `-std=c++11` to `castxml` as done in this PR seems to help. But
* I don't know about possible implications of this
* There might be objections with enabling c++11 per default

Please review and give comments how to go on with this.