### PR TITLE
ruby: allow setting metadata from a type or field documentation

### DIFF
--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -860,6 +860,7 @@ module Typelib
                     line = Integer(line)
                     if doc = GCCXMLLoader.parse_cxx_documentation_before(source_file_content(file), line)
                         type.metadata.set('doc', doc)
+                        extract_doc_metadata(type.metadata, doc)
                     end
                 end
                 if type.respond_to?(:field_metadata)
@@ -869,6 +870,7 @@ module Typelib
                             line = Integer(line)
                             if doc = GCCXMLLoader.parse_cxx_documentation_before(source_file_content(file), line)
                                 md.set('doc', doc)
+                                extract_doc_metadata(md, doc)
                             end
                         end
                     end
@@ -890,6 +892,15 @@ module Typelib
                 end
             end
             filtered_registry
+        end
+
+        def extract_doc_metadata(metadata, doc)
+            meta = doc.split("\n").grep(/^\s*@meta/)
+            meta.each do |line|
+                if line =~ /^\s*@meta (\w+)\s+(.*)$/
+                    metadata.add($1, $2)
+                end
+            end
         end
 
         def permanent_alias?(name)

--- a/test/ruby/cxx_common_tests.rb
+++ b/test/ruby/cxx_common_tests.rb
@@ -173,6 +173,12 @@ module CXXCommonTests
         assert_equal ["this is a multiline\ndocumentation block"], reg.get('/DocumentedType').metadata.get('doc')
     end
 
+    def test_import_documentation_extracts_metadata_tags
+        reg = Typelib::Registry.import File.join(cxx_test_dir, 'documentation_metadata_tags.h'), 'c', cxx_importer: loader
+        assert_equal ["struct_metadata"], reg.get('/DocumentedType').metadata.get('test')
+        assert_equal ["field_metadata"], reg.get('/DocumentedType').field_metadata['field'].get('test')
+    end
+
     def test_import_supports_utf8
         reg = Typelib::Registry.import File.join(cxx_test_dir, 'documentation_utf8.h'), 'c', cxx_importer: loader
         assert_equal ["this is a \u9999 multiline with \u1290 unicode characters"], reg.get('/DocumentedType').metadata.get('doc')

--- a/test/ruby/cxx_import_tests/documentation_metadata_tags.h
+++ b/test/ruby/cxx_import_tests/documentation_metadata_tags.h
@@ -1,0 +1,12 @@
+/* Struct documentation
+ *
+ * @meta test struct_metadata
+ */
+struct DocumentedType
+{
+    /** Field documentation
+     *
+     * @meta test field_metadata
+     */
+    int field;
+};


### PR DESCRIPTION
This allows to set arbitrary metadata from a type documentation.

See test file documentation_metadata_tags.h for an example