### PR TITLE
ruby: initialize Typelib::Type.metadata to an empty metadata set

### DIFF
--- a/bindings/ruby/lib/typelib.rb
+++ b/bindings/ruby/lib/typelib.rb
@@ -178,6 +178,16 @@ require 'typelib/cxx_registry'
 require 'typelib/specializations'
 require 'typelib_ruby'
 
+Typelib::Type.instance_variable_set :@metadata, Typelib::MetaData.new
+Typelib::IndirectType.instance_variable_set :@metadata, Typelib::MetaData.new
+Typelib::OpaqueType.instance_variable_set :@metadata, Typelib::MetaData.new
+Typelib::PointerType.instance_variable_set :@metadata, Typelib::MetaData.new
+Typelib::NumericType.instance_variable_set :@metadata, Typelib::MetaData.new
+Typelib::ArrayType.instance_variable_set :@metadata, Typelib::MetaData.new
+Typelib::CompoundType.instance_variable_set :@metadata, Typelib::MetaData.new
+Typelib::EnumType.instance_variable_set :@metadata, Typelib::MetaData.new
+Typelib::ContainerType.instance_variable_set :@metadata, Typelib::MetaData.new
+
 require 'typelib/standard_convertions'
 
 require 'typelib/path'

--- a/test/ruby/test_specialized_types.rb
+++ b/test/ruby/test_specialized_types.rb
@@ -35,6 +35,18 @@ class TC_SpecializedTypes < Minitest::Test
     attr_reader :array_t
     attr_reader :root_t
 
+    def test_base_classes_have_metadata
+        assert_kind_of Typelib::MetaData, Typelib::IndirectType.metadata
+        assert_kind_of Typelib::MetaData, Typelib::OpaqueType.metadata
+        assert_kind_of Typelib::MetaData, Typelib::PointerType.metadata
+        assert_kind_of Typelib::MetaData, Typelib::NumericType.metadata
+        assert_kind_of Typelib::MetaData, Typelib::ArrayType.metadata
+        assert_kind_of Typelib::MetaData, Typelib::CompoundType.metadata
+        assert_kind_of Typelib::MetaData, Typelib::EnumType.metadata
+        assert_kind_of Typelib::MetaData, Typelib::ContainerType.metadata
+        assert_kind_of Typelib::MetaData, Typelib::CompoundType.metadata
+    end
+
     # Not in setup() since we want to make sure
     # that the registry is not destroyed by the GC
     def make_registry

--- a/test/ruby/test_type.rb
+++ b/test/ruby/test_type.rb
@@ -17,6 +17,10 @@ class TC_Type < Minitest::Test
         registry
     end
 
+    def test_type_class_has_metadata
+        assert_kind_of Typelib::MetaData, Type.metadata
+    end
+
     def test_type_should_be_equal_when_they_are_the_same_object
         type = CXXRegistry.new.get("/int32_t")
         assert_equal type, type


### PR DESCRIPTION
This is for consistency, mostly, as Typelib::Type is never used directly