### PR TITLE
ruby: use 'backports' to avoid an explicit check on the availability of #dup

### DIFF
--- a/bindings/ruby/lib/typelib.rb
+++ b/bindings/ruby/lib/typelib.rb
@@ -9,6 +9,11 @@ require 'pp'
 require 'facets/string/camelcase'
 require 'set'
 require 'base64'
+require 'backports/2.4.0/true_class/dup'
+require 'backports/2.4.0/false_class/dup'
+require 'backports/2.4.0/fixnum/dup'
+require 'backports/2.4.0/float/dup'
+require 'backports/2.4.0/nil_class/dup'
 
 if !defined?(Infinity)
     Infinity = Float::INFINITY
@@ -136,8 +141,6 @@ module Typelib
         end
     end
 
-    # Set of classes that have a #dup method but on which dup is forbidden
-    DUP_FORBIDDEN = [TrueClass, FalseClass, Fixnum, Float, Symbol]
     @@loaded_typelib_plugins = false
 
     def self.load_typelib_plugins(force: false)

--- a/bindings/ruby/lib/typelib/compound_type.rb
+++ b/bindings/ruby/lib/typelib/compound_type.rb
@@ -105,13 +105,10 @@ module Typelib
                 new_value = super()
                 for field_name in self.class.converted_fields
                     converted_value = instance_variable_get("@#{FIELD_NANE_PREFIX}#{field_name}")
-                    if !converted_value.nil?
-                        # false, nil,  numbers can't be dup'ed
-                        if !DUP_FORBIDDEN.include?(converted_value.class)
-                            converted_value = converted_value.dup
-                        end
-                        instance_variable_set("@#{FIELD_NANE_PREFIX}#{field_name}", converted_value)
+                    if !converted_value.kind_of?(Symbol)
+                        converted_value = converted_value.dup
                     end
+                    instance_variable_set("@#{FIELD_NANE_PREFIX}#{field_name}", converted_value.dup)
                 end
                 new_value
             end

--- a/manifest.xml
+++ b/manifest.xml
@@ -28,6 +28,7 @@
   <depend package="libxml2" />
   <depend package="pkg-config" />
   <depend package="ruby-dev" />
+  <depend package="ruby-backports" />
 
   <tags>stable</tags>
 


### PR DESCRIPTION
'dup' has been defined on immediate values in Ruby 2.4, use backports
to get it for older Ruby versions