### PR TITLE
toolchain-2.9: fix rosdep compatibility of manifest.xml and merge recent changes to package.xml

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -27,11 +27,7 @@
   <rosdep name="facets" />
   <rosdep name="libxml2" />
   <rosdep name="pkg-config" />
-
-  <!-- rosdep key `ruby-dev` is not known to ROS.
-       Depend on `ruby` instead, which includes development files. -->
-  <!-- <rosdep name="ruby-dev" /> -->
-  <rosdep name="ruby" />
+  <rosdep name="ruby-dev" />
 
   <tags>stable</tags>
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -27,7 +27,11 @@
   <rosdep name="facets" />
   <rosdep name="libxml2" />
   <rosdep name="pkg-config" />
-  <rosdep name="ruby-dev" />
+
+  <!-- rosdep key `ruby-dev` is not known to ROS.
+       Depend on `ruby` instead, which includes development files. -->
+  <!-- <rosdep name="ruby-dev" /> -->
+  <rosdep name="ruby" />
 
   <tags>stable</tags>
 

--- a/package.xml
+++ b/package.xml
@@ -34,7 +34,7 @@
   <build_depend>boost</build_depend>
   <build_depend>facets</build_depend>
   <build_depend>libxml2</build_depend>
-  <build_depend>ruby</build_depend>
+  <build_depend>ruby-dev</build_depend>
 
   <run_depend>utilrb</run_depend>
   <run_depend>boost</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -18,17 +18,29 @@
   <buildtool_depend>pkg-config</buildtool_depend>
   <run_depend>catkin</run_depend>
 
-  <build_depend>utilrb</build_depend>
+  <!-- typelib depends on onle one of these optional libraries
+       the user has to choose which one to use and install it manually
+    <build_depend>clang-3.4</build_depend>
+    <run_depend>clang-3.4</run_depend>
+    <build_depend>castxml</build_depend>
+    <run_depend>castxml</run_depend>
+    <build_depend>gccxml</build_depend>
+    <run_depend>gccxml</run_depend>
+  -->
   <build_depend>gccxml</build_depend>
+  <run_depend>gccxml</run_depend>
+
+  <build_depend>utilrb</build_depend>
   <build_depend>boost</build_depend>
-  <build_depend>libxml2</build_depend>
   <build_depend>facets</build_depend>
+  <build_depend>libxml2</build_depend>
+  <build_depend>ruby</build_depend>
 
   <run_depend>utilrb</run_depend>
-  <run_depend>gccxml</run_depend>
   <run_depend>boost</run_depend>
-  <run_depend>libxml2</run_depend>
   <run_depend>facets</run_depend>
+  <run_depend>libxml2</run_depend>
+  <run_depend>ruby</run_depend>
 
   <export>
     <build_type>


### PR DESCRIPTION
I updated the `package.xml`, which - as far as I know - is only used by ROS tools, and merged the recent dependency changes from master. Like this, it can be compiled using ROS and catkin.

I am not sure about the changes in `manifest.xml`. Most likely they would break the autoproj bootstrap procedure, right? If yes, the alternative would be to submit a PR to https://github.com/ros/rosdistro/tree/master/rosdep/rosdep.yaml and add the key `ruby-dev` there.

The [differences](https://github.com/orocos-toolchain/typelib/compare/master...toolchain-2.9) between [toolchain-2.9](https://github.com/orocos-toolchain/typelib/tree/toolchain-2.9) and [master](https://github.com/orocos-toolchain/typelib/tree/master) are actually quite small. Is it desirable to submit individual PRs targeting `master` and only keep the ROS/catkin-specific changes in `toolchain-2.x`? Most non-catkin patches have been contributed by @smits.

Ideally the patches related to catkin and ROS-builds are not breaking non-ROS builds and `catkin` as a dependency is optional. See also related discussion in https://github.com/orocos-toolchain/typelib/issues/23.
