### PR TITLE
ruby: make sure we apply any ruby type used within #initialize in .new

### DIFF
--- a/bindings/ruby/lib/typelib/type.rb
+++ b/bindings/ruby/lib/typelib/type.rb
@@ -115,6 +115,12 @@ module Typelib
         end
         @convertions_from_ruby = Hash.new
 
+        def self.new(*args)
+            super(*args)
+            apply_changes_from_converted_types
+            invalidate_changes_from_converted_types
+        end
+
         # True if this type refers to subtype of the given type, or if it a
         # subtype of +type+ itself
         def self.contains?(type)

--- a/test/ruby/test_numeric_type.rb
+++ b/test/ruby/test_numeric_type.rb
@@ -92,15 +92,15 @@ describe Typelib::NumericType do
         describe "convertion to nil" do
             it "converts a NaN into nil" do
                 float = Typelib.from_ruby(Float::NAN, float_t)
-                assert_equal nil, float.to_json_value(:special_float_values => :nil)
+                assert_nil float.to_json_value(:special_float_values => :nil)
             end
             it "converts a positive infinity into nil" do
                 float = Typelib.from_ruby(Float::INFINITY, float_t)
-                assert_equal nil, float.to_json_value(:special_float_values => :nil)
+                assert_nil float.to_json_value(:special_float_values => :nil)
             end
             it "converts a negative infinity into nil" do
                 float = Typelib.from_ruby(-Float::INFINITY, float_t)
-                assert_equal nil, float.to_json_value(:special_float_values => :nil)
+                assert_nil float.to_json_value(:special_float_values => :nil)
             end
         end
 


### PR DESCRIPTION
It wouldn't be wrong per se, but having converted types after .new
is quite unexpected in the current usage of the API. Since the API
does not support "switching" between using raw access and Ruby access
at the same time, it can lead to hard-to-debug issues.