### PR TITLE
fix memory leak in container resizing

### DIFF
--- a/lang/csupport/containers.cc
+++ b/lang/csupport/containers.cc
@@ -128,6 +128,7 @@ void Vector::resize(std::vector<uint8_t>* ptr, size_t new_size) const
         {
             Typelib::init(&new_buffer[i], element_layout);
             Typelib::copy(&new_buffer[i], &(*ptr)[i], element_layout);
+            Typelib::destroy(&(*ptr)[i], element_layout);
         }
         ptr->swap(new_buffer);
     }

--- a/test/ruby/container_memory_leak_on_resize.rb
+++ b/test/ruby/container_memory_leak_on_resize.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+require 'typelib'
+
+Process.setrlimit(:AS, 300*1024**2)
+
+registry = Typelib::CXXRegistry.new
+
+double_vector_t = registry.create_container '/std/vector', '/double'
+particle_t = registry.create_compound '/C' do |c|
+  c.add 'f', double_vector_t
+end
+particle_vector_t = registry.create_container '/std/vector', particle_t
+
+internal = particle_t.new(f: [0]*100_000)
+10.times do |i|
+  vector = particle_vector_t.new
+  10.times do
+      vector.push internal
+  end
+end

--- a/test/ruby/test_container_type.rb
+++ b/test/ruby/test_container_type.rb
@@ -92,5 +92,12 @@ describe Typelib::ContainerType do
             assert container_t.of_size(0).empty?
         end
     end
+
+    it "does not leak on resize" do
+        pid = Process.spawn(File.join(__dir__, 'container_memory_leak_on_resize.rb'))
+        _, status = Process.waitpid2(pid)
+        assert status.success?, "the test script crashed, probably due "\
+            "to exceeding the 500MB memory limit. Are we leaking again ?"
+    end
 end
 


### PR DESCRIPTION
In case of resize, the elements of the old container would not
be deleted, which leaks if the container's elements have
containers themselves