### PR TITLE
fix compilation error with gcc9

### DIFF
--- a/test/test_display.cc
+++ b/test/test_display.cc
@@ -36,7 +36,8 @@ BOOST_AUTO_TEST_CASE(test_csv)
     {
         // Get the test file into repository
         utilmm::config_set config;
-        auto_ptr<Registry> registry(PluginManager::self()->load("tlb", TEST_DATA_PATH("test_cimport.tlb"), config));
+        auto myself = PluginManager::self();
+        auto_ptr<Registry> registry(myself->load("tlb", TEST_DATA_PATH("test_cimport.tlb"), config));
 
         {
             ostringstream stream;

--- a/typelib/pluginmanager.cc
+++ b/typelib/pluginmanager.cc
@@ -173,7 +173,8 @@ void PluginManager::save(std::string const& kind, Registry const& registry, std:
 }
 void PluginManager::save(std::string const& kind, utilmm::config_set const& config, Registry const& registry, std::ostream& into)
 {
-    unique_ptr<Exporter> exporter(PluginManager::self()->exporter(kind));
+    auto myself = PluginManager::self();
+    unique_ptr<Exporter> exporter(myself->exporter(kind));
     exporter->save(into, config, registry);
 }
 
@@ -207,7 +208,8 @@ Registry* PluginManager::load(std::string const& kind, std::istream& stream, uti
 void PluginManager::load(std::string const& kind, std::istream& stream, utilmm::config_set const& config
         , Registry& into )
 {
-    std::unique_ptr<Importer> importer(PluginManager::self()->importer(kind));
+    auto myself = PluginManager::self();
+    std::unique_ptr<Importer> importer(myself->importer(kind));
     importer->load(stream, config, into);
 }
 Registry* PluginManager::load(std::string const& kind, std::string const& file, utilmm::config_set const& config)
@@ -219,7 +221,8 @@ Registry* PluginManager::load(std::string const& kind, std::string const& file, 
 void PluginManager::load(std::string const& kind, std::string const& file, utilmm::config_set const& config
         , Registry& into)
 {
-    unique_ptr<Importer> importer(PluginManager::self()->importer(kind));
+    auto myself = PluginManager::self();
+    unique_ptr<Importer> importer(myself->importer(kind));
     importer->load(file, config, into);
 }
 


### PR DESCRIPTION
Typelib curretnly fails to build on debian testing with gcc9 with following error:

```
/opt/rock/tools/typelib/typelib/pluginmanager.cc: In static member function 'static void Typelib::PluginManager::save(const string&, const utilmm::config_set&, const Typelib::Registry&, std::ostream&)':
/opt/rock/tools/typelib/typelib/pluginmanager.cc:176:35: error: 'parameter' function with trailing return type not declared with 'auto' type specifier
  176 |     unique_ptr<Exporter> exporter(PluginManager::self()->exporter(kind));
      |                                   ^~~~~~~~~~~~~
```

This PR fixes the error by declaring the PluginManager::self() call with an auto object and use the object afterwards to call ->exporter(kind) on it.
