### PR TITLE
ruby: strip spaces from metadata value

### DIFF
--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -907,7 +907,7 @@ module Typelib
             meta = doc.split("\n").grep(/^\s*@meta/)
             meta.each do |line|
                 if line =~ /^\s*@meta (\w+)\s+(.*)$/
-                    metadata.add($1, $2)
+                    metadata.add($1, $2.strip)
                 end
             end
         end

--- a/test/ruby/cxx_common_tests.rb
+++ b/test/ruby/cxx_common_tests.rb
@@ -179,6 +179,11 @@ module CXXCommonTests
         assert_equal ["field_metadata"], reg.get('/DocumentedType').field_metadata['field'].get('test')
     end
 
+    def test_trailing_spaces_are_removed_from_metadata_tag_values
+        reg = Typelib::Registry.import File.join(cxx_test_dir, 'documentation_metadata_tags.h'), 'c', cxx_importer: loader
+        assert_equal ["without_trailing_space"], reg.get('/DocumentedType').metadata.get('strip')
+    end
+
     def test_import_supports_utf8
         reg = Typelib::Registry.import File.join(cxx_test_dir, 'documentation_utf8.h'), 'c', cxx_importer: loader
         assert_equal ["this is a \u9999 multiline with \u1290 unicode characters"], reg.get('/DocumentedType').metadata.get('doc')

--- a/test/ruby/cxx_import_tests/documentation_metadata_tags.h
+++ b/test/ruby/cxx_import_tests/documentation_metadata_tags.h
@@ -1,7 +1,7 @@
 /* Struct documentation
  *
  * @meta test struct_metadata
- */
+ * @meta strip without_trailing_space */
 struct DocumentedType
 {
     /** Field documentation

--- a/test/ruby/test_cxx.rb
+++ b/test/ruby/test_cxx.rb
@@ -27,6 +27,5 @@ class TC_CXX < Minitest::Test
             Typelib::CXX.parse_template('std::vector<int, std::allocator<int> >')
         assert_equal ['std::vector', ['std::vector<int,std::allocator<int>>', 'std::allocator<std::vector<int,std::allocator<int>>>']],
             Typelib::CXX.parse_template('std::vector <std::vector <int ,std::allocator<int>>, std::allocator< std::vector<int , std::allocator <int>>      > >')
-
     end
 end


### PR DESCRIPTION
Even beyond trailing spaces (which one should remove, but we
all know how it goes), a C++ comment can be

~~~ cpp
/* @meta key value */
~~~

Which causes the value to have a trailing space.