### PR TITLE
allow types without fields and virtual methods as base classes for any accessor

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,8 +16,12 @@ if (ENABLE_INTERNAL_CPARSER)
 endif()
 
 if (ROCK_TEST_LOG_DIR)
+    if (NOT ROCK_TEST_BOOST_FORMAT)
+        set(ROCK_TEST_BOOST_FORMAT XML)
+    endif()
+
     list(APPEND __boost_test_parameters
-        --log_format=xml
+        --log_format=${ROCK_TEST_BOOST_FORMAT}
         --log_level=all
         --log_sink=${ROCK_TEST_LOG_DIR}/typelib_testsuite.boost.xml)
     file(MAKE_DIRECTORY "${ROCK_TEST_LOG_DIR}")

--- a/test/ruby/cxx_import_tests/empty_base_class.hh
+++ b/test/ruby/cxx_import_tests/empty_base_class.hh
@@ -1,0 +1,26 @@
+#ifndef TEST_HEADER_EMPTY_BASE_CLASS_HH
+#define TEST_HEADER_EMPTY_BASE_CLASS_HH
+
+struct Base {};
+
+struct PublicDerived : public Base {
+    int field;
+};
+
+struct PrivateDerived : private Base {
+    int field;
+};
+
+struct VirtualDerived : public virtual Base {
+    int field;
+};
+
+struct BaseWithVirtual {
+    virtual void something() { };
+};
+
+struct DerivedWithVirtual : public BaseWithVirtual {
+    int field;
+};
+
+#endif

--- a/test/ruby/cxx_import_tests/empty_base_class.tlb
+++ b/test/ruby/cxx_import_tests/empty_base_class.tlb
@@ -1,0 +1,44 @@
+<?xml version='1.0'?>
+<typelib>
+    <numeric name='/int32_t' category='sint' size='4'>
+    </numeric>
+    <compound name='/PrivateDerived' size='4'>
+        <field name='field' type='/int32_t' offset='0'>
+            <metadata key='source_file_line'>
+                <![CDATA[empty_base_class.hh:11]]>
+            </metadata>
+        </field>
+        <metadata key='cxxname'>
+            <![CDATA[::PrivateDerived]]>
+        </metadata>
+        <metadata key='source_file_line'>
+            <![CDATA[empty_base_class.hh:10]]>
+        </metadata>
+    </compound>
+    <compound name='/PublicDerived' size='4'>
+        <field name='field' type='/int32_t' offset='0'>
+            <metadata key='source_file_line'>
+                <![CDATA[empty_base_class.hh:7]]>
+            </metadata>
+        </field>
+        <metadata key='cxxname'>
+            <![CDATA[::PublicDerived]]>
+        </metadata>
+        <metadata key='source_file_line'>
+            <![CDATA[empty_base_class.hh:6]]>
+        </metadata>
+    </compound>
+    <compound name='/VirtualDerived' size='16'>
+        <field name='field' type='/int32_t' offset='8'>
+            <metadata key='source_file_line'>
+                <![CDATA[empty_base_class.hh:15]]>
+            </metadata>
+        </field>
+        <metadata key='cxxname'>
+            <![CDATA[::VirtualDerived]]>
+        </metadata>
+        <metadata key='source_file_line'>
+            <![CDATA[empty_base_class.hh:14]]>
+        </metadata>
+    </compound>
+</typelib>

--- a/test/ruby/cxx_tlbgen.in
+++ b/test/ruby/cxx_tlbgen.in
@@ -45,7 +45,7 @@ registry = Typelib::Registry.new
 if File.file?(opaques_file)
     registry.merge_xml(File.read(opaques_file))
 end
-registry.import(cxx_file, 'c', cxx_importer: 'gccxml', defines: defines, include_paths: [cxx_test_dir])
+registry.import(cxx_file, 'c', cxx_importer: 'castxml', defines: defines, include_paths: [cxx_test_dir])
 
 # Format the source_file_line metadata since it can really not be ported across
 # compilers and filesystems


### PR DESCRIPTION
These "empty types" do not affect the binary representation of
the struct, and are therefore safe to manipulate from Typelib's
perspective.

Note that this fixes the test failure regarding std::pair, which on
recent GCCs (C++11) derives from a private empty type