### PR TITLE
normalize the File name attributes by expanding them

### DIFF
--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -68,6 +68,9 @@ module Typelib
 
         def tag_start(name, attributes)
             if name == "File"
+                if File.exist?(attributes["name"])
+                    attributes["name"] = File.expand_path(attributes["name"])
+                end
                 id_to_node[attributes['id']] = Node.new(name, attributes)
                 return file(attributes)
             elsif name == "Field" || name == "FundamentalType"

--- a/test/ruby/cxx_import_tests/relative_includes.hh
+++ b/test/ruby/cxx_import_tests/relative_includes.hh
@@ -1,0 +1,10 @@
+#ifndef TYPELIB_RELATIVE_INCLUDES_HH
+#define TYPELIB_RELATIVE_INCLUDES_HH
+
+#include <classes.hh>
+
+struct MakeItSo {
+    classes::BaseClass field;
+};
+
+#endif

--- a/test/ruby/test_cxx_castxml.rb
+++ b/test/ruby/test_cxx_castxml.rb
@@ -12,6 +12,55 @@ module Typelib
             setup_loader 'castxml'
         end
 
+        describe "file resolution" do
+            it "normalizes the path of a file whose path was given relative" do
+                registry = Registry.new
+                relative_path = File.join(__dir__, "cxx_import_tests",
+                                          "unsupported", "..", "classes.hh")
+                normalized_path = File.join(__dir__, "cxx_import_tests", "classes.hh")
+                GCCXMLLoader.load(registry, relative_path, "c", castxml: true)
+
+                type = registry.get("/classes/BaseClass")
+                assert_equal ["#{normalized_path}:15"],
+                             type.metadata.get("source_file_line")
+            end
+
+            it "normalizes the path of includes that are resolved relatively" do
+                registry = Registry.new
+                path = File.join(__dir__, "cxx_import_tests", "relative_includes.hh")
+                include_path = File.join(__dir__, "cxx_import_tests", "unsupported", "..")
+                normalized_path = File.join(__dir__, "cxx_import_tests", "classes.hh")
+                GCCXMLLoader.load(registry, path, "c",
+                                  include_paths: [include_path],
+                                  castxml: true)
+
+                type = registry.get("/classes/BaseClass")
+                assert_equal ["#{normalized_path}:15"],
+                             type.metadata.get("source_file_line")
+            end
+
+            it "does the full path normalization during parsing" do
+                registry = Registry.new
+                main_relative_path =
+                    File.join(__dir__, "cxx_import_tests",
+                              "unsupported", "..", "relative_includes.hh")
+                main_normalized_path =
+                    File.join(__dir__, "cxx_import_tests", "relative_includes.hh")
+                normalized_path = File.join(__dir__, "cxx_import_tests", "classes.hh")
+
+                include_path = File.join(__dir__, "cxx_import_tests", "unsupported", "..")
+                xml = GCCXMLLoader.castxml(
+                    main_relative_path, include_paths: [include_path]
+                ).first
+                info = GCCXMLInfo.new([main_normalized_path, normalized_path])
+                info.parse(xml)
+                id = info.required_files[normalized_path]
+                assert_equal normalized_path, info.id_to_node[id].attributes["name"]
+                id = info.required_files[main_normalized_path]
+                assert_equal main_normalized_path, info.id_to_node[id].attributes["name"]
+            end
+        end
+
         describe "#find_node_by_name" do
             attr_reader :parser, :info
             before do


### PR DESCRIPTION
castxml will report a relative path if given explicitely on
the command line, or if it is resolves through the include path
and the include path has .. in it.

That is, -I/some/path/../bla will lead to a file path that
includes ..

Expand all of them. There was already some normalization done
at the end of the chain, but this was failing if the relative
path is given on the command line (thus completely making the
load fail).