### PR TITLE
Make CastXML the default instead of GccXML

### DIFF
--- a/bindings/ruby/lib/typelib/cxx.rb
+++ b/bindings/ruby/lib/typelib/cxx.rb
@@ -90,7 +90,7 @@ module Typelib
         # with {loader=} or by setting the TYPELIB_CXX_LOADER to the name of a
         # loader registered in {CXX_LOADERS}.
         #
-        # The default is currently GCCXMLLoader
+        # The default is currently CastXMLLoader
         #
         # @return [#load,#preprocess] a loader object suitable for operating
         #   on C++ files
@@ -104,7 +104,7 @@ module Typelib
                 end
                 cxx_loader
             else
-                GCCXMLLoader
+                CastXMLLoader
             end
         end
 

--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,7 @@
     <depend>castxml</depend>
     <depend>gccxml</depend>
   -->
-  <depend>gccxml</depend>
+  <depend>castxml</depend>
 
   <depend>boost</depend>
   <depend>facets</depend>


### PR DESCRIPTION
As discussed in #132 

I don't know if this also should be merged into master.