### PR TITLE
Make CastXML the default instead of GccXML (master)

### DIFF
--- a/bindings/ruby/lib/typelib/cxx.rb
+++ b/bindings/ruby/lib/typelib/cxx.rb
@@ -90,7 +90,7 @@ module Typelib
         # with {loader=} or by setting the TYPELIB_CXX_LOADER to the name of a
         # loader registered in {CXX_LOADERS}.
         #
-        # The default is currently GCCXMLLoader
+        # The default is currently CastXMLLoader
         #
         # @return [#load,#preprocess] a loader object suitable for operating
         #   on C++ files
@@ -104,7 +104,7 @@ module Typelib
                 end
                 cxx_loader
             else
-                GCCXMLLoader
+                CastXMLLoader
             end
         end
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -17,7 +17,7 @@
 
   <depend package="utilrb" />
 
-  <!-- typelib depends on onle one of these optional libraries
+  <!-- typelib depends on only one of these optional libraries
        the user has to choose which one to use and install it manually
        <depend_optional package="clang-3.4" />
        <depend_optional package="castxml" />

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>typelib</name>
   <version>1.1.1</version>
   <description>
@@ -10,23 +10,26 @@
       modification of C/C++ in-memory types from Ruby.
   </description>
   <author>Sylvain Joyeux/sylvain.joyeux@m4x.org</author>
-  <maintainer email="orocos-dev@lists.mech.kuleuven.be">OCL Development Team</maintainer>
+  <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
   <license>CeCILL-B (BSD-like)</license>
 
   <buildtool_depend>cmake</buildtool_depend>
-  <run_depend>catkin</run_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
-  <build_depend>utilrb</build_depend>
-  <build_depend>gccxml</build_depend>
-  <build_depend>boost</build_depend>
-  <build_depend>libxml2</build_depend>
-  <build_depend>facets</build_depend>
+  <!-- typelib depends on only one of these optional libraries
+       the user has to choose which one to use and install it manually
+    <depend>clang-3.4</depend>
+    <depend>castxml</depend>
+    <depend>gccxml</depend>
+  -->
+  <depend>gccxml</depend>
 
-  <run_depend>utilrb</run_depend>
-  <run_depend>gccxml</run_depend>
-  <run_depend>boost</run_depend>
-  <run_depend>libxml2</run_depend>
-  <run_depend>facets</run_depend>
+  <depend>boost</depend>
+  <depend>facets</depend>
+  <depend>libxml2</depend>
+  <depend>ruby-backports</depend>
+  <depend>ruby-dev</depend>
+  <depend>utilrb</depend>
 
   <export>
     <build_type>
@@ -35,4 +38,3 @@
   </export>
 
 </package>
-

--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,7 @@
     <depend>castxml</depend>
     <depend>gccxml</depend>
   -->
-  <depend>gccxml</depend>
+  <depend>castxml</depend>
 
   <depend>boost</depend>
   <depend>facets</depend>


### PR DESCRIPTION
master version of #133.

As discussed in #132.

I would  prefer that these changes would also end up in `toolchain-2.9`.