### PR TITLE
Fix boost/test/floating_point_comparison.hpp include in test_display.cc for Boost 1.59 and older

### DIFF
--- a/test/test_display.cc
+++ b/test/test_display.cc
@@ -1,5 +1,9 @@
 #include <boost/test/unit_test.hpp>
+#if BOOST_VERSION < 105900
+#include <boost/test/floating_point_comparison.hpp>
+#else
 #include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 #include <lang/csupport/standard_types.hh>
 


### PR DESCRIPTION
_Fixes https://github.com/orocos-toolchain/typelib/pull/128#issuecomment-768656215 ([failed Travis CI job](https://github.com/orocos-toolchain/orocos_toolchain/pull/41/checks?check_run_id=1778156440))._

This patch is required for building on Ubuntu Xenial 16.04 with Boost 1.56. Everything else seems to work fine.
At least all unit tests pass if I set `TYPELIB_CXX_LOADER=castxml` manually:

```sh
(xenial)johannes@im-laptop-007:/tmp/orocos/build/typelib$ export TYPELIB_CXX_LOADER=castxml
(xenial)johannes@im-laptop-007:/tmp/orocos/build/typelib$ ctest
Test project /tmp/orocos/build/typelib
    Start 1: RubyInstalledPlugins
1/4 Test #1: RubyInstalledPlugins .............   Passed   12.48 sec
    Start 2: RubyLocalPlugins
2/4 Test #2: RubyLocalPlugins .................   Passed   12.85 sec
    Start 3: CxxSuiteInstalledPlugins
3/4 Test #3: CxxSuiteInstalledPlugins .........   Passed    0.33 sec
    Start 4: CxxSuiteLocalPlugins
4/4 Test #4: CxxSuiteLocalPlugins .............   Passed    0.34 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  26.00 sec
```