### PR TITLE
define Type.zero which creates a value that's pre-zeroed out then initialized

### DIFF
--- a/bindings/ruby/ext/value.cc
+++ b/bindings/ruby/ext/value.cc
@@ -445,13 +445,16 @@ VALUE value_from_memory_zone(VALUE klass, VALUE ptr)
  * Allocates a new Typelib object that has a freshly initialized buffer inside
  */
 static
-VALUE value_new(VALUE klass)
+VALUE value_new(VALUE klass, VALUE zero)
 {
     Type const& type(rb2cxx::object<Type>(klass));
 #   ifdef VERBOSE
     fprintf(stderr, "allocating new value of type %s\n", type.getName().c_str());
 #   endif
     VALUE buffer = memory_allocate(type.getSize());
+    if (RTEST(zero)) {
+        memset(memory_cptr(buffer), 0, type.getSize());
+    }
     memory_init(buffer, klass);
 
     return value_from_memory_zone(klass, buffer);
@@ -701,7 +704,7 @@ void typelib_ruby::Typelib_init_values()
     rb_define_singleton_method(cType, "do_memory_layout", RUBY_METHOD_FUNC(&type_memory_layout), 4);
     rb_define_singleton_method(cType, "do_dependencies",  RUBY_METHOD_FUNC(&type_dependencies), 0);
     rb_define_singleton_method(cType, "casts_to?",     RUBY_METHOD_FUNC(&type_can_cast_to), 1);
-    rb_define_singleton_method(cType, "value_new", RUBY_METHOD_FUNC(&value_new), 0);
+    rb_define_singleton_method(cType, "value_new", RUBY_METHOD_FUNC(&value_new), 1);
     rb_define_singleton_method(cType, "from_memory_zone", RUBY_METHOD_FUNC(&value_from_memory_zone), 1);
     rb_define_singleton_method(cType, "from_address", RUBY_METHOD_FUNC(&value_from_address), 1);
 

--- a/bindings/ruby/lib/typelib/type.rb
+++ b/bindings/ruby/lib/typelib/type.rb
@@ -1,4 +1,19 @@
 module Typelib
+    class << self
+        # Globally sets whether all values created with .new are to be
+        # zeroed-out first
+        #
+        # @see zero_all_values?
+        attr_writer :zero_all_values
+
+        # Whether all values created with .new are to be zeroed-out first
+        #
+        # @see zero_all_values=
+        def zero_all_values?
+            @zero_all_values
+        end
+    end
+
     # Base class for all types
     # Registry types are wrapped into subclasses of Type
     # or other Type-derived classes (Array, Pointer, ...)
@@ -595,7 +610,7 @@ module Typelib
                 create(init: init)
             end
 
-            def create(init: nil, zero: false)
+            def create(init: nil, zero: Typelib.zero_all_values?)
                 if init
                     new_value = Typelib.from_ruby(init, self)
                 else

--- a/bindings/ruby/lib/typelib/type.rb
+++ b/bindings/ruby/lib/typelib/type.rb
@@ -115,12 +115,6 @@ module Typelib
         end
         @convertions_from_ruby = Hash.new
 
-        def self.new(*args)
-            super(*args)
-            apply_changes_from_converted_types
-            invalidate_changes_from_converted_types
-        end
-
         # True if this type refers to subtype of the given type, or if it a
         # subtype of +type+ itself
         def self.contains?(type)
@@ -589,14 +583,29 @@ module Typelib
             #
             # Note that the value is *not* initialized. To initialize a value to
             # zero, one can call Type#zero!
+            def zero
+                create(zero: true)
+            end
+
+            # Creates a new value of the given type.
+            #
+            # Note that the value is *not* initialized. To initialize a value to
+            # zero, one can call Type#zero!
             def new(init = nil)
+                create(init: init)
+            end
+
+            def create(init: nil, zero: false)
                 if init
-                    Typelib.from_ruby(init, self)
+                    new_value = Typelib.from_ruby(init, self)
                 else
-                    new_value = value_new
+                    new_value = value_new(zero)
                     new_value.send(:initialize)
-                    new_value
                 end
+
+                new_value.apply_changes_from_converted_types
+                new_value.invalidate_changes_from_converted_types
+                new_value
             end
 
             # Check if this type is a +typename+. If +typename+

--- a/test/ruby/test_value.rb
+++ b/test/ruby/test_value.rb
@@ -50,6 +50,26 @@ class TC_Value < Minitest::Test
         int_t.from_buffer(v.to_byte_array)
     end
 
+    def test_zero_creates_a_pre_zeroed_out_then_initialized_value
+        registry = Typelib::CXXRegistry.new
+        registry.create_enum "/E" do |e|
+            e.add "First", 1
+            e.add "Second", 2
+        end
+        type = registry.create_compound "/ZeroTest" do |c|
+            c.add "e", "/E"
+            c.add "uninit", "/int"
+            c.add "init", "/int"
+        end
+
+        type.define_method(:initialize) { self.init = 42 }
+
+        value = type.zero
+        assert_equal :First, value.e
+        assert_equal 0, value.uninit
+        assert_equal 42, value.init
+    end
+
     def test_wrapping_a_memory_zone_should_call_typelib_initialize
         int_t = CXXRegistry.new.build("/int")
         v = Typelib.from_ruby(2, int_t)

--- a/test/ruby/test_value.rb
+++ b/test/ruby/test_value.rb
@@ -50,6 +50,29 @@ class TC_Value < Minitest::Test
         int_t.from_buffer(v.to_byte_array)
     end
 
+    def test_it_creates_a_pre_zeroed_out_then_initialized_value_if_the_global_zero_all_values_attribute_is_set_to_true
+        registry = Typelib::CXXRegistry.new
+        registry.create_enum "/E" do |e|
+            e.add "First", 1
+            e.add "Second", 2
+        end
+        type = registry.create_compound "/ZeroTest" do |c|
+            c.add "e", "/E"
+            c.add "uninit", "/int"
+            c.add "init", "/int"
+        end
+
+        type.define_method(:initialize) { self.init = 42 }
+
+        Typelib.zero_all_values = true
+        value = type.new
+        assert_equal :First, value.e
+        assert_equal 0, value.uninit
+        assert_equal 42, value.init
+    ensure
+        Typelib.zero_all_values = false
+    end
+
     def test_zero_creates_a_pre_zeroed_out_then_initialized_value
         registry = Typelib::CXXRegistry.new
         registry.create_enum "/E" do |e|


### PR DESCRIPTION
Type.new returns a value that is not zeroed out, but whose enums
and containers are properly initialized. Type.zero now offers the
same, but allowing to zero the structure first.