### PR TITLE
allow to load C++ files in parallel

### DIFF
--- a/bindings/ruby/lib/typelib/cxx.rb
+++ b/bindings/ruby/lib/typelib/cxx.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'typelib/gccxml'
 require 'typelib/clang'
 

--- a/bindings/ruby/lib/typelib/cxx.rb
+++ b/bindings/ruby/lib/typelib/cxx.rb
@@ -119,8 +119,8 @@ module Typelib
             cxx_importer.load(registry, file, kind, **options)
         end
 
-        def self.preprocess(files, kind, options)
-            loader.preprocess(files, kind, options)
+        def self.preprocess(files, kind, **options)
+            loader.preprocess(files, kind, **options)
         end
 
         Registry::TYPE_HANDLERS['c'] = method(:load)

--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -3,6 +3,7 @@
 require 'set'
 require 'tempfile'
 require 'shellwords'
+require 'strscan'
 
 module Typelib
     # Intermediate representation of a parsed GCCXML output, containing only
@@ -102,14 +103,14 @@ module Typelib
         end
 
         def parse(xml)
-            lines = xml.split("\n")
-            lines.shift
-            root_tag = lines.shift
+            scanner = StringScanner.new(xml)
+            scanner.skip_until(/\n/)
+            root_tag = scanner.scan_until(/\n/)
             if root_tag !~ /<GCC_XML/
                 raise RuntimeError, "the provided XML input does not look like a GCCXML output (expected a root GCC_XML tag but got #{root_tag.chomp})"
             end
 
-            lines.each do |l|
+            while (l = scanner.scan_until(/\n/))
                 if match = /<(\w+)/.match(l)
                     name = match[1]
                     parsing_needed = %w{File Field Base EnumValue}.include?(name) ||

--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -984,13 +984,15 @@ module Typelib
             end
 
             required_files.map do |file|
-                Tempfile.open('typelib_gccxml') do |io|
-                    if !system(*cmdline, '-o', io.path, file)
-                        raise ArgumentError, "gccxml returned an error while parsing #{file} with call #{cmdline.join(' ')} "
-                    end
-                    io.open
-                    io.read
+                result = IO.popen([*cmdline, '-o', '-', file]) do |out|
+                    out.read
                 end
+
+                unless $?.success?
+                    raise ArgumentError, "castxml failed to parse #{file}"
+                end
+
+                result
             end
         end
         # Runs gccxml on the provided file and with the given options, and

--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'tempfile'
 require 'shellwords'
@@ -275,7 +277,7 @@ module Typelib
 
         def self.split_first_namespace(typename)
             basename  = typename[1..-1]
-            namespace = "/"
+            namespace = "/".dup
             level = 0
             while true
                 next_marker = (basename =~ /[\/<>]/)
@@ -302,7 +304,7 @@ module Typelib
         end
 
         def self.split_last_namespace(name)
-            basename = ""
+            basename = "".dup
             typename = name.reverse
             level = 0
             while true
@@ -803,10 +805,10 @@ module Typelib
             block = block.map do |l|
                 l.strip.gsub(/^\s*(\*+\/?|\/+\**)/, '')
             end
-            while block.first && block.first.strip == ""
+            while block.first && block.first.strip.empty?
                 block.shift
             end
-            while block.last && block.last.strip == ""
+            while block.last && block.last.strip.empty?
                 block.pop
             end
             # Now remove the same amount of spaces in front of each lines

--- a/bindings/ruby/lib/typelib/gccxml.rb
+++ b/bindings/ruby/lib/typelib/gccxml.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require 'set'
-require 'tempfile'
-require 'shellwords'
-require 'strscan'
+require "set"
+require "tempfile"
+require "shellwords"
+require "strscan"
+require "English"
 
 module Typelib
     # Intermediate representation of a parsed GCCXML output, containing only
@@ -858,7 +859,7 @@ module Typelib
                 # We MUST emit the opaque definitions before calling
                 # resolve_opaques as resolve_opaques will add the resolved
                 # opaque names to +opaques+
-                opaques.each do |type_name|
+                opaques.sort.uniq.each do |type_name|
                     registry.create_opaque type_name, 0
                 end
                 resolve_opaques
@@ -959,130 +960,211 @@ module Typelib
         end
 
         def self.castxml_binary_name
-            return "castxml"
+            "castxml"
         end
+
         # Runs castxml on the provided file and with the given options, and
         # return the Nokogiri::XML object representing the result
         #
         # Raises RuntimeError if casrxml failed to run
-        def self.castxml(file, options)
-            cmdline = [castxml_binary_name, *castxml_default_options, "--castxml-gccxml", '-x', 'c++']
-            required_files = (options[:required_files] || [file])
-            if raw = options[:rawflags]
-                cmdline.concat(raw)
-            end
-
-            if defs = options[:define]
-                defs.each do |str|
-                    cmdline << "-D#{str}"
-                end
-            end
-
-            if inc = (options[:include] || options[:include_paths])
-                inc.each do |str|
-                    cmdline << "-I#{str}"
-                end
-            end
+        def self.castxml(
+            composite_file,
+            required_files: [composite_file], rawflags: [], define: [],
+            include: [], include_paths: [], **
+        )
+            cmdline = [castxml_binary_name, *castxml_default_options,
+                       "--castxml-gccxml", "-x", "c++"]
+            cmdline.concat(rawflags)
+            cmdline.concat(define.map { |str| "-D#{str}" })
+            cmdline.concat(include.map { |str| "-I#{str}" })
+            cmdline.concat(include_paths.map { |str| "-I#{str}" })
 
             required_files.map do |file|
-                result = IO.popen([*cmdline, '-o', '-', file]) do |out|
+                result = IO.popen([*cmdline, "-o", "-", file]) do |out|
                     out.read
                 end
 
-                unless $?.success?
+                unless $CHILD_STATUS.success?
                     raise ArgumentError, "castxml failed to parse #{file}"
                 end
 
                 result
             end
         end
+
         # Runs gccxml on the provided file and with the given options, and
         # return the Nokogiri::XML object representing the result
         #
         # Raises RuntimeError if gccxml failed to run
-        def self.gccxml(file, options)
+        def self.gccxml(
+            composite_file, required_files: [], rawflags: [], define: [],
+            include: [], include_paths: [], **
+        )
             cmdline = [gcc_binary_name, *gccxml_default_options]
-            if raw = options[:rawflags]
-                cmdline.concat(raw)
-            end
+            cmdline.concat(rawflags)
+            cmdline.concat(define.map { |str| "-D#{str}" })
+            cmdline.concat(include.map { |str| "-I#{str}" })
+            cmdline.concat(include_paths.map { |str| "-I#{str}" })
+
+            # Fix for wrong arch size detection on some systems, particulary OSX
             if 1.size == 4
                 cmdline << "-m32"
             else
                 cmdline << "-m64"
             end
 
-            if defs = options[:define]
-                defs.each do |str|
-                    cmdline << "-D#{str}"
-                end
-            end
-
-            if inc = (options[:include] || options[:include_paths])
-                inc.each do |str|
-                    cmdline << "-I#{str}"
-                end
-            end
-
-            cmdline << file
-
-            Tempfile.open('typelib_gccxml') do |io|
+            cmdline << composite_file
+            Tempfile.open("typelib_gccxml") do |io|
                 cmdline << "-fxml=#{io.path}"
-                if !system(*cmdline)
+                unless system(*cmdline)
                     raise ArgumentError, "gccxml returned an error while parsing #{file}"
                 end
                 [io.read]
             end
         end
 
-        def self.load(registry, file, kind, options)
-            required_files = (options[:required_files] || [file]).
-                map { |f| File.expand_path(f) }
-
-            registry_opaques = Set.new
-            registry.each do |type|
-                if type.opaque?
-                    registry_opaques << type.name
-                end
+        # @api private
+        #
+        # A do-nothing job server
+        #
+        # It works as default argument as {.load} spawns exactly parallel_level
+        # threads.
+        class NullJobServer
+            def get
+                yield if block_given?
             end
 
-            raw_xml = if options[:castxml] then castxml(file, options)
-                      else gccxml(file, options)
-                      end
-
-            raw_xml.each do |xml|
-                converter = GCCXMLLoader.new
-                converter.opaques = registry_opaques.dup
-                if options_opaques = options[:opaques]
-                    converter.opaques |= options_opaques.to_set
-                end
-                gccxml_registry = converter.load(required_files, xml)
-                registry.merge(gccxml_registry)
-            end
+            def put; end
         end
 
-        def self.preprocess(files, kind, options)
-            includes = options.fetch(:include, Array.new).map { |v| "-I#{v}" }
-            defines  = options.fetch(:define, Array.new).map { |v| "-D#{v}" }
-            rawflags = options.fetch(:rawflags, Array.new)
+        def self.load(
+            registry, file, _kind,
+            required_files: [file], opaques: Set.new,
+            parallel_level: 1, job_server: NullJobServer.new,
+            merge: true, **parsing_options
+        )
+            required_files = required_files.map { |f| File.expand_path(f) }
 
-            Tempfile.open(['orogen_gccxml_input','.hpp']) do |io|
+            opaques = opaques.dup
+            registry.each do |type|
+                opaques << type.name if type.opaque?
+            end
+
+            file_queue = Queue.new
+            required_files.each { |f| file_queue.push(f) }
+            xml_queue = Queue.new
+            registry_queue = Queue.new
+
+            if parallel_level <= 1
+                parsing_thread(NullJobServer.new, file_queue, xml_queue, **parsing_options)
+                xml_queue.push(nil)
+                registry_thread(
+                    NullJobServer.new, xml_queue, registry_queue, required_files, opaques
+                )
+            else
+                parsing_threads = (0...(parallel_level - 1)).map do
+                    Thread.new do
+                        parsing_thread(job_server, file_queue, xml_queue,
+                                       **parsing_options)
+                    end
+                end
+                registry_thread = Thread.new do
+                    registry_thread(
+                        job_server, xml_queue, registry_queue, required_files, opaques
+                    )
+                end
+
+                # Per the make job server protocol, orogen already has a token.
+                # "Give" a token back since we're doing nothing in this thread.
+                begin
+                    job_server.put
+                    # Handle errors, we don't care about return values
+                    begin
+                        parsing_threads.map(&:value)
+                    ensure
+                        xml_queue.push(nil)
+                    end
+                    registry_thread.value
+                ensure
+                    job_server.get
+                end
+            end
+
+            registry.merge(registry_queue.pop) until registry_queue.empty?
+        end
+
+        def self.parsing_thread(
+            job_server, in_queue, out_queue, castxml: true, **parsing_options
+        )
+            loop do
+                file = in_queue.pop(true)
+                xml = job_server.get do
+                    if castxml
+                        castxml(file, required_files: [file], **parsing_options)
+                    else
+                        gccxml(file, required_files: [file], **parsing_options)
+                    end
+                end
+                out_queue.push(xml.first)
+            end
+        rescue ThreadError # rubocop:disable Lint/SuppressedException
+        rescue Exception # rubocop:disable Lint/RescueException
+            # Speedup error propagation
+            in_queue.clear
+            out_queue.clear
+            raise
+        end
+
+        def self.registry_thread(job_server, in_queue, out_queue, required_files, opaques)
+            loop do
+                return unless (xml = in_queue.pop)
+
+                registry = job_server.get do
+                    registry_from_gccxml_output(required_files, xml, opaques)
+                end
+                out_queue.push(registry)
+            end
+        rescue Exception # rubocop:disable Lint/RescueException
+            # Speedup error propagation
+            in_queue.clear
+            out_queue.clear
+            raise
+        end
+
+        def self.registry_from_gccxml_output(required_files, xml, opaques)
+            converter = GCCXMLLoader.new
+            converter.opaques = opaques.dup
+            converter.load(required_files, xml)
+        end
+
+        def self.preprocess(
+            files, _kind,
+            castxml: true, include: [], include_paths: [], define: [], rawflags: [], **
+        )
+            includes = (include + include_paths).map { |v| "-I#{v}" }
+            defines  = define.map { |v| "-D#{v}" }
+
+            Tempfile.open(["orogen_gccxml_input", ".hpp"]) do |io|
                 files.each do |path|
                     io.puts "#include <#{path}>"
                 end
                 io.flush
 
-                if options[:castxml]
-                    call = [castxml_binary_name, "--castxml-gccxml", "-E", *includes, *defines, *rawflags, *castxml_default_options, io.path]
-                else
-                    call = [gcc_binary_name, "--preprocess", *includes, *defines, *rawflags, *gccxml_default_options, io.path]
-                end
+                call =
+                    if castxml
+                        [castxml_binary_name, "--castxml-gccxml", "-E",
+                         *includes, *defines, *rawflags,
+                         *castxml_default_options, io.path]
+                    else
+                        [gcc_binary_name, "--preprocess", *includes, *defines,
+                         *rawflags, *gccxml_default_options, io.path]
+                    end
 
-                result = IO.popen(call) do |gccxml_io|
-                    gccxml_io.read
-                end
-
-                if !$?.success?
-                    raise ArgumentError, "failed to preprocess #{files.join(" ")} \"#{call[0..-1].join(" ")} /tmp/gcc-debug\""
+                result = IO.popen(call, &:read)
+                unless $CHILD_STATUS.success?
+                    raise ArgumentError,
+                          "failed to preprocess #{files.join(' ')} "\
+                          "\"#{call[0..-1].join(' ')} /tmp/gcc-debug\""
                 end
 
                 result
@@ -1094,6 +1176,7 @@ module Typelib
         def self.load(registry, file, kind, **options)
             super(registry, file, kind, castxml: true, **options)
         end
+
         def self.preprocess(files, kind, **options)
             super(files, kind, castxml: true, **options)
         end
@@ -1107,7 +1190,7 @@ module Typelib
 
         # Returns true if Registry#import will use GCCXML to load the given
         # file
-        def self.uses_gccxml?(path, kind = 'auto')
+        def self.uses_gccxml?(path, kind = "auto")
             (handler_for(path, kind) == method(:load_from_gccxml))
         end
     end


### PR DESCRIPTION
Unlike for gccxml, with castxml we have to parse file-by-file. While
this reduces performance in principle (headers have to be re-parsed
over and over again), it also allows for parallelization between the
castxml instances and the Ruby parsing method.

Implement this parallelization scheme. For base/orogen/types, which
is infamously slow, we get (on a quad-core i7 with 16 GB RAM, so no
issue with disk caching)

~~~
time TYPELIB_CASTXML_PARALLEL=1 make regen
110,85s user 3,55s system 100% cpu 1:54,01 total

time TYPELIB_CASTXML_PARALLEL=2 make regen
121,59s user 4,20s system 143% cpu 1:27,88 total

time TYPELIB_CASTXML_PARALLEL=3 make regen
137,41s user 4,76s system 195% cpu 1:12,66 total

time TYPELIB_CASTXML_PARALLEL=4 make regen
144,81s user 4,88s system 216% cpu 1:09,25 total
~~~