### PR TITLE
feat: standardize strings on /int8_t

### DIFF
--- a/bindings/ruby/ext/registry.cc
+++ b/bindings/ruby/ext/registry.cc
@@ -472,6 +472,22 @@ static VALUE registry_aliases_of(VALUE self, VALUE type_)
 
 /*
  * call-seq:
+ *  registry.remove_alias
+ *
+ * Removes all aliases defined on this registry
+ */
+static VALUE registry_remove_alias(VALUE self, VALUE name)
+{
+    Registry& registry = rb2cxx::object<Registry>(self);
+    try { registry.removeAlias(StringValuePtr(name)); }
+    catch(std::runtime_error const& e) {
+        rb_raise(rb_eArgError, "%s", e.what());
+    }
+    return Qnil;
+}
+
+/*
+ * call-seq:
  *  registry.clear_aliases
  *
  * Removes all aliases defined on this registry
@@ -704,6 +720,7 @@ void typelib_ruby::Typelib_init_registry()
     rb_define_method(cRegistry, "do_export", RUBY_METHOD_FUNC(registry_export), 2);
     rb_define_method(cRegistry, "merge_xml", RUBY_METHOD_FUNC(registry_merge_xml), 1);
     rb_define_method(cRegistry, "alias", RUBY_METHOD_FUNC(registry_alias), 2);
+    rb_define_method(cRegistry, "remove_alias", RUBY_METHOD_FUNC(registry_remove_alias), 1);
     rb_define_method(cRegistry, "clear_aliases", RUBY_METHOD_FUNC(registry_clear_aliases), 0);
     rb_define_method(cRegistry, "aliases_of", RUBY_METHOD_FUNC(registry_aliases_of), 1);
     rb_define_method(cRegistry, "merge", RUBY_METHOD_FUNC(registry_merge), 1);

--- a/bindings/ruby/ext/registry.cc
+++ b/bindings/ruby/ext/registry.cc
@@ -192,7 +192,7 @@ VALUE registry_alias(VALUE self, VALUE name, VALUE aliased)
     } catch(BadName const&) {
         rb_raise(rb_eArgError, "invalid type name %s", StringValuePtr(name));
     } catch(Undefined const&) {
-        rb_raise(eNotFound, "there is not type in this registry with the name '%s'", StringValuePtr(aliased));
+        rb_raise(eNotFound, "there is no type in this registry with the name '%s'", StringValuePtr(aliased));
     }
 }
 

--- a/lang/csupport/containers.cc
+++ b/lang/csupport/containers.cc
@@ -388,22 +388,9 @@ Container const& Vector::factory(Registry& registry, std::list<Type const*> cons
 Container::ContainerFactory Vector::getFactory() const { return factory; }
 
 
-Type const& String::getElementType(Typelib::Registry const& registry)
-{
-    std::string element_type_name;
-    if (std::numeric_limits<char>::is_signed)
-        element_type_name = "/int8_t";
-    else
-        element_type_name = "/uint8_t";
-
-    Type const* element_type = registry.get(element_type_name);
-    if (!element_type)
-        throw std::runtime_error("cannot find string element " + element_type_name + " in registry");
-    return *element_type;
+String::String(Type const& on)
+    : Container("/std/string", "/std/string", getNaturalSize(), on) {
 }
-String::String(Typelib::Registry const& registry)
-    : Container("/std/string", "/std/string", getNaturalSize(), String::getElementType(registry)) {}
-
 size_t String::getElementCount(void const* ptr) const
 {
     size_t byte_count = reinterpret_cast< std::string const* >(ptr)->length();
@@ -509,12 +496,17 @@ Container const& String::factory(Registry& registry, std::list<Type const*> cons
     if (on.size() != 1)
         throw std::runtime_error("expected only one template argument for std::string");
 
-    Type const& contained_type = *on.front();
-    Type const& expected_type  = String::getElementType(registry);
-    if (contained_type != expected_type)
-        throw std::runtime_error("std::string can only be built on top of '" + expected_type.getName() + "' -- found " + contained_type.getName());
+    Type const* element_type;
+    if (!registry.has("/int8_t")) {
+        Type* new_type = new Typelib::Numeric("/int8_t", 1, Numeric::SInt);
+        registry.add(new_type);
+        element_type = new_type;
+    }
+    else {
+        element_type = registry.get("/int8_t");
+    }
 
-    String* new_type = new String(registry);
+    String* new_type = new String(*element_type);
     registry.add(new_type);
     return *new_type;
 }

--- a/lang/csupport/containers.hh
+++ b/lang/csupport/containers.hh
@@ -54,7 +54,7 @@ public:
 class String : public Typelib::Container
 {
 public:
-    String(Typelib::Registry const& registry);
+    String(Type const& on);
 
     size_t getElementCount(void const* ptr) const;
     void init(void* ptr) const;
@@ -86,8 +86,6 @@ public:
 
     static Container const& factory(Typelib::Registry& registry, std::list<Type const*> const& on);
     ContainerFactory getFactory() const;
-
-    static Type const& getElementType(Typelib::Registry const& registry);
 
     // This method is never called since we redefine modifiedDependencyAliases
     std::string getIndirectTypeName(std::string const& element_name) const { return ""; }

--- a/lang/csupport/standard_types.cc
+++ b/lang/csupport/standard_types.cc
@@ -126,6 +126,6 @@ void Typelib::CXX::addStandardTypes(Typelib::Registry& registry)
     if (!registry.has("/bool"))
         ::addStandardTypes(registry);
     if (!registry.has("/std/string"))
-        registry.add(new String(registry));
+        registry.add(new String(*registry.get("/int8_t")));
 }
 

--- a/typelib/registry.cc
+++ b/typelib/registry.cc
@@ -196,7 +196,7 @@ namespace Typelib
         unique_ptr<Registry> result(new Registry);
         Type const* type = get(name);
         if (!type)
-            throw std::runtime_error("there is not type '" + name + "' in this registry");
+            throw std::runtime_error("there is no type '" + name + "' in this registry");
 
         type->merge(*result);
 

--- a/typelib/registry.cc
+++ b/typelib/registry.cc
@@ -432,6 +432,22 @@ namespace Typelib
         }
     }
 
+    void Registry::removeAlias(std::string const& name)
+    {
+        TypeMap::iterator global_it = m_global.find(name);
+        if (global_it == m_global.end()) {
+            throw std::runtime_error("no alias named " + name);
+        }
+        else if (global_it->second.type->getName() == name) {
+            throw std::runtime_error(
+                name + " is the primary name of the type, not an alias"
+            );
+        }
+
+        m_global.erase(global_it);
+        updateCurrentNameMap();
+    }
+
     void Registry::clearAliases()
     {
         // We remove the aliases from +m_global+ and recompute m_current from

--- a/typelib/registry.hh
+++ b/typelib/registry.hh
@@ -308,6 +308,10 @@ namespace Typelib
          * +this+ which have no source ID yet */
         void copySourceIDs(Registry const& registry);
 
+        /** Remove a single alias
+         */
+        void removeAlias(std::string const& name);
+
         /** Removes all defined aliases
          */
         void clearAliases();


### PR DESCRIPTION
A well known "feature" of C (and therefore C++) is that the signed-ness
of char is architecture-dependent. This is (very unfortunately)
represented as-is into the Typelib representation of C++ base types,
which leads to typelib thinking that strings generated e.g. ARM are
different than strings generated on a x86.

The "right" fix I've been thinking about for years now would be to stop
using an int8 type for strings, but add a completely separate character
type. However, this is an amount of work I'm not willing to do right
now.

So, in the meantime, standardize on int8 on all platforms.